### PR TITLE
Asset precompile

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -1,0 +1,6 @@
+#!/bin/bash
+/usr/libexec/s2i/assemble
+npm config set proxy $http_proxy
+npm config set registry http://registry.npmjs.org/
+npm install
+bundle exec rake webpack:compile

--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,7 @@ require 'rubocop/rake_task'
 Rails.application.load_tasks
 RuboCop::RakeTask.new
 task default: [:rubocop, 'cucumber:html', 'brakeman:run', 'bundle_audit:run']
+namespace :assets do
+  task precompile: 'webpack:compile' do
+  end
+end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -17,7 +17,7 @@ Rails.application.configure do
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
-
+  config.public_file_server.enabled = true
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  # config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
   config.public_file_server.enabled = true
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
augments the sit assembly step to run npm install and to precompile the webpack assets which isnt supported by the base assembly script