### PR TITLE
Current Version Display for Questions and Response Sets

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -50,4 +50,25 @@ class Question < ApplicationRecord
             .where.not(version: version)
             .order(version: :desc)
   end
+
+  def all_versions
+    Question.where(version_independent_id: version_independent_id)
+            .order(version: :desc)
+  end
+
+  def most_recent
+    if other_versions[0].version > version
+      other_versions[0].version
+    else
+      version
+    end
+  end
+
+  def most_recent?
+    if other_versions[0].version > version
+      false
+    else
+      true
+    end
+  end
 end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -58,6 +58,27 @@ class ResponseSet < ApplicationRecord
                .order(version: :desc)
   end
 
+  def all_versions
+    ResponseSet.where(version_independent_id: version_independent_id)
+               .order(version: :desc)
+  end
+
+  def most_recent
+    if other_versions[0].version > version
+      other_versions[0].version
+    else
+      version
+    end
+  end
+
+  def most_recent?
+    if other_versions[0].version > version
+      false
+    else
+      true
+    end
+  end
+
   def extend_from
     extended_set = ResponseSet.new
     extended_set.name = name

--- a/app/views/questions/_question_details.html.erb
+++ b/app/views/questions/_question_details.html.erb
@@ -35,25 +35,22 @@
 <% if @question.other_versions.present? %>
 <p>
   <strong>Most Recent Version:</strong>
-  <% if @question.other_versions[0].version > @question.version %>
-    <%= @question.other_versions[0].version %>
+  <% if @question.most_recent? %>
+    <%= @question.version %> (Currently Selected)
   <% else %>
-    <%= @question.version %>
+    <%= @question.most_recent %>
   <% end %>
 </p>
 <p>
-  <strong>Other Versions:</strong>
+  <strong>Versions:</strong>
   <ol>
-    <% @question.other_versions.each do |ov| %>
-      <% if @question.version == (ov.version + 1) %>
+    <% @question.all_versions.each do |av| %>
+      <% if @question.version == av.version %>
         <li>Version: <%= @question.version %> - Created <%= time_ago_in_words(@question.created_at) %> ago (Currently Selected)
         </li>
+      <% else %>
+        <li><%= link_to "Version: #{av.version}", av %> - Created <%= time_ago_in_words(av.created_at) %> ago</li>
       <% end %>
-      <li><%= link_to "Version: #{ov.version}", ov %> - Created <%= time_ago_in_words(ov.created_at) %> ago</li>
-    <% end %>
-    <% if @question.version == 1 %>
-      <li>Version: <%= @question.version %> - Created <%= time_ago_in_words(@question.created_at) %> ago (Currently Selected)
-      </li>
     <% end %>
   </ol>
 </p>

--- a/app/views/questions/_question_details.html.erb
+++ b/app/views/questions/_question_details.html.erb
@@ -32,12 +32,28 @@
   <%= question.question_type.try :name %>
 </p>
 
-<% if question.other_versions.present? %>
+<% if @question.other_versions.present? %>
+<p>
+  <strong>Most Recent Version:</strong>
+  <% if @question.other_versions[0].version > @question.version %>
+    <%= @question.other_versions[0].version %>
+  <% else %>
+    <%= @question.version %>
+  <% end %>
+</p>
 <p>
   <strong>Other Versions:</strong>
   <ol>
-    <% question.other_versions.each do |ov| %>
+    <% @question.other_versions.each do |ov| %>
+      <% if @question.version == (ov.version + 1) %>
+        <li>Version: <%= @question.version %> - Created <%= time_ago_in_words(@question.created_at) %> ago (Currently Selected)
+        </li>
+      <% end %>
       <li><%= link_to "Version: #{ov.version}", ov %> - Created <%= time_ago_in_words(ov.created_at) %> ago</li>
+    <% end %>
+    <% if @question.version == 1 %>
+      <li>Version: <%= @question.version %> - Created <%= time_ago_in_words(@question.created_at) %> ago (Currently Selected)
+      </li>
     <% end %>
   </ol>
 </p>

--- a/app/views/questions/show.html.erb
+++ b/app/views/questions/show.html.erb
@@ -1,5 +1,6 @@
 <p id="notice"><%= notice %></p>
 
+
 <%= render partial: 'question_details', locals: {question: @question } %>
 <% if user_signed_in? %>
     <%= link_to 'Revise', revise_question_path(@question) %> |

--- a/app/views/response_sets/show.html.erb
+++ b/app/views/response_sets/show.html.erb
@@ -58,10 +58,26 @@
 
 <% if @response_set.other_versions.present? %>
 <p>
+  <strong>Most Recent Version:</strong>
+  <% if @response_set.other_versions[0].version > @response_set.version %>
+    <%= @response_set.other_versions[0].version %>
+  <% else %>
+    <%= @response_set.version %>
+  <% end %>
+</p>
+<p>
   <strong>Other Versions:</strong>
   <ol>
     <% @response_set.other_versions.each do |ov| %>
+      <% if @response_set.version == (ov.version + 1) %>
+        <li>Version: <%= @response_set.version %> - Created <%= time_ago_in_words(@response_set.created_at) %> ago (Currently Selected)
+        </li>
+      <% end %>
       <li><%= link_to "Version: #{ov.version}", ov %> - Created <%= time_ago_in_words(ov.created_at) %> ago</li>
+    <% end %>
+    <% if @response_set.version == 1 %>
+      <li>Version: <%= @response_set.version %> - Created <%= time_ago_in_words(@response_set.created_at) %> ago (Currently Selected)
+      </li>
     <% end %>
   </ol>
 </p>

--- a/app/views/response_sets/show.html.erb
+++ b/app/views/response_sets/show.html.erb
@@ -59,25 +59,22 @@
 <% if @response_set.other_versions.present? %>
 <p>
   <strong>Most Recent Version:</strong>
-  <% if @response_set.other_versions[0].version > @response_set.version %>
-    <%= @response_set.other_versions[0].version %>
+  <% if @response_set.most_recent? %>
+    <%= @response_set.version %> (Currently Selected)
   <% else %>
-    <%= @response_set.version %>
+    <%= @response_set.most_recent %>
   <% end %>
 </p>
 <p>
-  <strong>Other Versions:</strong>
+  <strong>Versions:</strong>
   <ol>
-    <% @response_set.other_versions.each do |ov| %>
-      <% if @response_set.version == (ov.version + 1) %>
+    <% @response_set.all_versions.each do |av| %>
+      <% if @response_set.version == av.version %>
         <li>Version: <%= @response_set.version %> - Created <%= time_ago_in_words(@response_set.created_at) %> ago (Currently Selected)
         </li>
+      <% else %>
+        <li><%= link_to "Version: #{av.version}", av %> - Created <%= time_ago_in_words(av.created_at) %> ago</li>
       <% end %>
-      <li><%= link_to "Version: #{ov.version}", ov %> - Created <%= time_ago_in_words(ov.created_at) %> ago</li>
-    <% end %>
-    <% if @response_set.version == 1 %>
-      <li>Version: <%= @response_set.version %> - Created <%= time_ago_in_words(@response_set.created_at) %> ago (Currently Selected)
-      </li>
     <% end %>
   </ol>
 </p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,6 +15,15 @@ ActiveRecord::Schema.define(version: 20161107220951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "authentications", force: :cascade do |t|
+    t.string   "provider",   null: false
+    t.string   "uid",        null: false
+    t.integer  "user_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_authentications_on_user_id", using: :btree
+  end
+
   create_table "form_questions", force: :cascade do |t|
     t.integer  "form_id"
     t.integer  "question_id"
@@ -67,9 +76,9 @@ ActiveRecord::Schema.define(version: 20161107220951) do
     t.integer  "created_by_id"
     t.integer  "updated_by_id"
     t.boolean  "coded"
+    t.integer  "parent_id"
     t.string   "version_independent_id"
     t.integer  "version",                default: 1
-    t.integer  "parent_id"
     t.index ["created_by_id"], name: "index_response_sets_on_created_by_id", using: :btree
     t.index ["updated_by_id"], name: "index_response_sets_on_updated_by_id", using: :btree
   end
@@ -120,6 +129,7 @@ ActiveRecord::Schema.define(version: 20161107220951) do
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
   end
 
+  add_foreign_key "authentications", "users"
   add_foreign_key "forms", "users", column: "created_by_id"
   add_foreign_key "questions", "question_types"
   add_foreign_key "questions", "users", column: "created_by_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,15 +15,6 @@ ActiveRecord::Schema.define(version: 20161107220951) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "authentications", force: :cascade do |t|
-    t.string   "provider",   null: false
-    t.string   "uid",        null: false
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_authentications_on_user_id", using: :btree
-  end
-
   create_table "form_questions", force: :cascade do |t|
     t.integer  "form_id"
     t.integer  "question_id"
@@ -76,9 +67,9 @@ ActiveRecord::Schema.define(version: 20161107220951) do
     t.integer  "created_by_id"
     t.integer  "updated_by_id"
     t.boolean  "coded"
-    t.integer  "parent_id"
     t.string   "version_independent_id"
     t.integer  "version",                default: 1
+    t.integer  "parent_id"
     t.index ["created_by_id"], name: "index_response_sets_on_created_by_id", using: :btree
     t.index ["updated_by_id"], name: "index_response_sets_on_updated_by_id", using: :btree
   end
@@ -129,7 +120,6 @@ ActiveRecord::Schema.define(version: 20161107220951) do
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
   end
 
-  add_foreign_key "authentications", "users"
   add_foreign_key "forms", "users", column: "created_by_id"
   add_foreign_key "questions", "question_types"
   add_foreign_key "questions", "users", column: "created_by_id"


### PR DESCRIPTION
This PR adds a display of the current version and version currently selected on the show page for both response sets and questions. Please review how it looks and let me know any stylistic changes that should be made.

Make sure you have checked off the following before you issue your Pull Request:

- [N/A] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [N/A] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [N/A] If any database changes were made, run `rake generate_erd` to update the README.md
