### PR TITLE
eslint [SDP-234]

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,11 @@
             2,
             "always"
         ],
+        "camelcase": 2,
+        "indent": ["error", 2],
+        "brace-style": 2,
+        "no-nested-ternary": 2,
+        "no-trailing-spaces": 2,
         'react/jsx-no-duplicate-props': 2,
         'react/jsx-no-undef': 2,
         'react/jsx-uses-react': 2,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= csrf_meta_tags %>
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 
-
+    <%= javascript_include_tag *webpack_asset_paths('babel-polyfill', extension: 'js') %>
     <%= javascript_include_tag *webpack_asset_paths('bootstrap', extension: 'js') %>
     <%= javascript_include_tag *webpack_asset_paths('application', extension: 'js') %>
   </head>

--- a/app/views/response_sets/_form.html.erb
+++ b/app/views/response_sets/_form.html.erb
@@ -69,6 +69,6 @@
 </div>
 
 <script type="application/json" id="responses-json">
-  <%= raw response_set.responses.to_json %>
+  <%= raw response_set.responses.map{|r| {code: r.value, display: r.display_name, system: r.code_system}}.to_json %>
 </script>
 <%= javascript_include_tag *webpack_asset_paths('response_set', extension: 'js') %>

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -23,7 +23,8 @@ var config = {
     'question_list': './webpack/question_list.js',
     'response_set_list': './webpack/response_set_list.js',
     'search': './webpack/search.js',
-    'bootstrap': 'bootstrap-loader'
+    'bootstrap': 'bootstrap-loader',
+    'babel-polyfill': 'babel-polyfill'
   },
 
   output: {

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -15,15 +15,6 @@ ActiveRecord::Schema.define(version: 20161212180833) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
-  create_table "authentications", force: :cascade do |t|
-    t.string   "provider",   null: false
-    t.string   "uid",        null: false
-    t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_authentications_on_user_id", using: :btree
-  end
-
   create_table "form_questions", force: :cascade do |t|
     t.integer  "form_id"
     t.integer  "question_id"
@@ -139,7 +130,6 @@ ActiveRecord::Schema.define(version: 20161212180833) do
     t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id", using: :btree
   end
 
-  add_foreign_key "authentications", "users"
   add_foreign_key "forms", "users", column: "created_by_id"
   add_foreign_key "questions", "question_types"
   add_foreign_key "questions", "response_types"

--- a/test/frontend/components/question_list_test.js
+++ b/test/frontend/components/question_list_test.js
@@ -6,9 +6,9 @@ describe('QuestionList', () => {
   let component;
 
   beforeEach(() => {
-    const questions = [{id: 1, content: "Is this a question?", question_type: ""},
-                      {id: 2, content: "Whats your name", question_type: ""},
-                      {id: 3, content: "What is a question?", question_type: ""}];
+    const questions = [{id: 1, content: "Is this a question?", questionType: ""},
+                      {id: 2, content: "Whats your name", questionType: ""},
+                      {id: 3, content: "What is a question?", questionType: ""}];
     component = renderComponent(QuestionList, {questions, routes});
   });
 

--- a/test/frontend/components/response_set_table_test.js
+++ b/test/frontend/components/response_set_table_test.js
@@ -11,8 +11,8 @@ describe('ResponseSetTable', () => {
   let component, componentInstance;
 
   beforeEach(() => {
-    const initialResponses = [{value: 'M', code_system: 'Gender', display_name: 'Male'},
-                              {value: 'F', code_system: 'Gender', display_name: 'Female'}];
+    const initialResponses = [{code: 'M', system: 'Gender', display: 'Male'},
+                              {code: 'F', system: 'Gender', display: 'Female'}];
     componentInstance =  TestUtils.renderIntoDocument(<ResponseSetTable initialResponses={initialResponses}/>);
     component = $(ReactDOM.findDOMNode(componentInstance));
   });
@@ -24,7 +24,7 @@ describe('ResponseSetTable', () => {
   it('should update the state when a value is changed', () => {
     const input = component.find("input[value=M]")[0];
     TestUtils.Simulate.change(input, {target: {value: 'different'}});
-    expect(componentInstance.state.responses[0].value).to.equal('different');
+    expect(componentInstance.state.responses[0].code).to.equal('different');
   });
 
   it('should remove a row', () => {

--- a/test/frontend/mock_routes.js
+++ b/test/frontend/mock_routes.js
@@ -1,2 +1,2 @@
-exports.question_path = (q) => `/questions/${q.id}`;
-exports.revise_question_path = (q) => `/questions/${q.id}/revise`;
+exports.questionPath = (q) => `/questions/${q.id}`;
+exports.reviseQuestionPath = (q) => `/questions/${q.id}/revise`;

--- a/webpack/application.js
+++ b/webpack/application.js
@@ -1,4 +1,3 @@
-
 require("styles/scaffolds.scss");
 require("jquery");
 require("jquery-ujs");

--- a/webpack/camelcase.js
+++ b/webpack/camelcase.js
@@ -1,0 +1,55 @@
+// Copied from https://github.com/sindresorhus/camelcase/blob/master/index.js
+// Not installed via npm since we have node_modules excluded from our babel
+// pipeline. Since this uses ES6, it causes the capybara stack to be sad because
+// it runs across the 'let' keyword.
+function preserveCamelCase(str) {
+  let isLastCharLower = false;
+  let isLastCharUpper = false;
+  let isLastLastCharUpper = false;
+
+  for (let i = 0; i < str.length; i++) {
+    const c = str[i];
+
+    if (isLastCharLower && (/[a-zA-Z]/).test(c) && c.toUpperCase() === c) {
+      str = str.substr(0, i) + '-' + str.substr(i);
+      isLastCharLower = false;
+      isLastLastCharUpper = isLastCharUpper;
+      isLastCharUpper = true;
+      i++;
+    } else if (isLastCharUpper && isLastLastCharUpper && (/[a-zA-Z]/).test(c) && c.toLowerCase() === c) {
+      str = str.substr(0, i - 1) + '-' + str.substr(i - 1);
+      isLastLastCharUpper = isLastCharUpper;
+      isLastCharUpper = false;
+      isLastCharLower = true;
+    } else {
+      isLastCharLower = c.toLowerCase() === c;
+      isLastLastCharUpper = isLastCharUpper;
+      isLastCharUpper = c.toUpperCase() === c;
+    }
+  }
+
+  return str;
+}
+
+exports.camelCase = function () {
+  let str = Array
+  .from(arguments)
+  .map(x => x.trim())
+  .filter(x => x.length)
+  .join('-');
+
+  if (str.length === 0) {
+    return '';
+  }
+
+  if (str.length === 1) {
+    return str.toLowerCase();
+  }
+
+  str = preserveCamelCase(str);
+
+  return str
+  .replace(/^[_.\- ]+/, '')
+  .toLowerCase()
+  .replace(/[_.\- ]+(\w|$)/g, (m, p1) => p1.toUpperCase());
+};

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -14,7 +14,7 @@ const QuestionItem = ({question, responseSets, index, removeQuestion}) => {
           <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={question.id}/>
           <select className="col-md-12" aria-label="Response Set IDs" name='response_set_ids[]' id='response_set_ids'>
             {responseSets.map((r, i) => {
-             return (
+              return (
                 <option value={r.id} key={i} >{r.name}</option>
               );
             })}

--- a/webpack/components/QuestionWidget.js
+++ b/webpack/components/QuestionWidget.js
@@ -7,7 +7,7 @@ export default class QuestionWidget extends Component {
         <div className="panel panel-default">
           <div className="question-container">
             <ul className="list-inline">
-              <li><a href={this.props.routes.question_path(this.props.question)}>{this.props.question.content}</a></li>
+              <li><a href={this.props.routes.questionPath(this.props.question)}>{this.props.question.content}</a></li>
               <li className="pull-right">
                 <a>
                   <span className="fa fa-signal"></span>
@@ -28,13 +28,13 @@ export default class QuestionWidget extends Component {
                   </a>
                   <ul className="dropdown-menu">
                     <li>
-                      <a href={this.props.routes.revise_question_path(this.props.question)}>Revise</a>
+                      <a href={this.props.routes.reviseQuestionPath(this.props.question)}>Revise</a>
                     </li>
                     <li>
-                      <a href={this.props.routes.question_path(this.props.question)}>Details</a>
+                      <a href={this.props.routes.questionPath(this.props.question)}>Details</a>
                     </li>
                     <li>
-                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={this.props.routes.question_path(this.props.question)}>Delete</a>
+                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={this.props.routes.questionPath(this.props.question)}>Delete</a>
                     </li>
                   </ul>
                 </div>
@@ -56,11 +56,10 @@ export default class QuestionWidget extends Component {
 QuestionWidget.propTypes = {
   question: PropTypes.shape({
     id: PropTypes.number.isRequired,
-    content: PropTypes.string.isRequired,
-    question_type: PropTypes.string
+    content: PropTypes.string.isRequired
   }),
   routes: PropTypes.shape({
-    question_path: PropTypes.func.isRequired,
-    revise_question_path: PropTypes.func.isRequired
+    questionPath: PropTypes.func.isRequired,
+    reviseQuestionPath: PropTypes.func.isRequired
   })
 };

--- a/webpack/components/ResponseSetList.js
+++ b/webpack/components/ResponseSetList.js
@@ -9,7 +9,7 @@ export default class ResponseSetList extends Component {
           // Each List Item Component needs a key attribute for uniqueness:
           // http://facebook.github.io/react/docs/multiple-components.html#dynamic-children
           // In addition, we pass in our item data
-          return <ResponseSetWidget key={rs.id} response_set={rs} routes={this.props.routes} />;
+          return <ResponseSetWidget key={rs.id} responseSet={rs} routes={this.props.routes} />;
         })}
       </div>
     );
@@ -17,6 +17,6 @@ export default class ResponseSetList extends Component {
 }
 
 ResponseSetList.propTypes = {
-  responseSets: PropTypes.arrayOf(ResponseSetWidget.propTypes.response_set).isRequired,
+  responseSets: PropTypes.arrayOf(ResponseSetWidget.propTypes.responseSet).isRequired,
   routes: ResponseSetWidget.propTypes.routes.isRequired
 };

--- a/webpack/components/ResponseSetTable.js
+++ b/webpack/components/ResponseSetTable.js
@@ -8,7 +8,7 @@ export default class ResponseSetTable extends Component {
 
   addResponseRow() {
     let newResponses = this.state.responses;
-    newResponses.push({display_name: "", code_system: "", value: ""});
+    newResponses.push({display: "", system: "", code: ""});
     this.setState({responses: newResponses});
   }
 
@@ -42,15 +42,15 @@ export default class ResponseSetTable extends Component {
               <tr key={i}>
                 <td>
                   <label className="hidden" htmlFor={`response_set_responses_attributes_${i}_value`}>Value</label>
-                  <input type="text" value={r.value} name={`response_set[responses_attributes][${i}][value]`} id={`response_set_responses_attributes_${i}_value`} onChange={this.handleChange(i, 'value')}/>
+                  <input type="text" value={r.code} name={`response_set[responses_attributes][${i}][value]`} id={`response_set_responses_attributes_${i}_value`} onChange={this.handleChange(i, 'code')}/>
                 </td>
                 <td>
                   <label className="hidden" htmlFor={`response_set_responses_attributes_${i}_code_system`}>Code system</label>
-                  <input type="text" value={r.code_system} name={`response_set[responses_attributes][${i}][code_system]`} id={`response_set_responses_attributes_${i}_code_system`} onChange={this.handleChange(i, 'code_system')}/>
+                  <input type="text" value={r.system} name={`response_set[responses_attributes][${i}][code_system]`} id={`response_set_responses_attributes_${i}_code_system`} onChange={this.handleChange(i, 'system')}/>
                 </td>
                 <td>
                   <label className="hidden" htmlFor={`response_set_responses_attributes_${i}_display_name`}>Display name</label>
-                  <input type="text" value={r.display_name} name={`response_set[responses_attributes][${i}][display_name]`} id={`response_set_responses_attributes_${i}_display_name`} onChange={this.handleChange(i, 'display_name')}/>
+                  <input type="text" value={r.display} name={`response_set[responses_attributes][${i}][display_name]`} id={`response_set_responses_attributes_${i}_display_name`} onChange={this.handleChange(i, 'display')}/>
                 </td>
                 <td>
                   <a href="#" onClick={() => this.removeResponseRow(i)}>Remove</a>
@@ -71,8 +71,8 @@ export default class ResponseSetTable extends Component {
 
 ResponseSetTable.propTypes = {
   initialResponses: PropTypes.arrayOf(PropTypes.shape({
-    value: PropTypes.string,
-    code_system: PropTypes.string,
-    display_name: PropTypes.string
+    code: PropTypes.string,
+    system: PropTypes.string,
+    display: PropTypes.string
   }))
 };

--- a/webpack/components/ResponseSetWidget.js
+++ b/webpack/components/ResponseSetWidget.js
@@ -3,12 +3,12 @@ import React, { Component, PropTypes } from 'react';
 export default class ResponseSetWidget extends Component {
   render() {
     return (
-      <div className="response-set-group" id={"response_set_id_"+this.props.response_set.id}>
+      <div className="response-set-group" id={"response_set_id_"+this.props.responseSet.id}>
         <div className="response-set-name">
           <div className="response-set-container">
             <ul className="list-inline">
               <li>
-                <a href={this.props.routes.response_set_path(this.props.response_set)}>{this.props.response_set.name}</a>
+                <a href={this.props.routes.responseSetPath(this.props.responseSet)}>{this.props.responseSet.name}</a>
               </li>
               <li className="pull-right"><a><span className="fa fa-question-circle-o"></span></a></li>
             </ul>
@@ -16,24 +16,24 @@ export default class ResponseSetWidget extends Component {
 
           <div className="response-set-details">
             <ul className="list-inline response-set-items">
-              <li className="reponse-set-id">{this.props.response_set.description}</li>
+              <li className="reponse-set-id">{this.props.responseSet.description}</li>
               <li className="pull-right response-set-menu">
                 <div className="dropdown">
-                  <a id={"response_set_"+this.props.response_set.id+"_menu"} className="dropdown-toggle" type="" data-toggle="dropdown" role="navigation">
+                  <a id={"response_set_"+this.props.responseSet.id+"_menu"} className="dropdown-toggle" type="" data-toggle="dropdown" role="navigation">
                     <span className="fa fa-ellipsis-h"></span>
                   </a>
                   <ul className="dropdown-menu dropdown-menu-right" >
                     <li>
-                      <a href={this.props.routes.revise_response_set_path(this.props.response_set)}>Revise</a>
+                      <a href={this.props.routes.reviseResponseSetPath(this.props.responseSet)}>Revise</a>
                     </li>
                     <li>
-                      <a href={this.props.routes.extend_response_set_path(this.props.response_set)}>Extend</a>
+                      <a href={this.props.routes.extendResponseSetPath(this.props.responseSet)}>Extend</a>
                     </li>
                     <li>
-                      <a href={this.props.routes.response_set_path(this.props.response_set)}>Details</a>
+                      <a href={this.props.routes.responseSetPath(this.props.responseSet)}>Details</a>
                     </li>
                     <li>
-                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={this.props.routes.response_set_path(this.props.response_set)}>Delete</a>
+                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={this.props.routes.responseSetPath(this.props.responseSet)}>Delete</a>
                     </li>
                   </ul>
                 </div>
@@ -48,14 +48,14 @@ export default class ResponseSetWidget extends Component {
 }
 
 ResponseSetWidget.propTypes = {
-  response_set: PropTypes.shape({
+  responseSet: PropTypes.shape({
     id: PropTypes.number.isRequired,
     name: PropTypes.string.isRequired,
     description: PropTypes.string
   }),
   routes: PropTypes.shape({
-    response_set_path: PropTypes.func.isRequired,
-    extend_response_set_path: PropTypes.func.isRequired,
-    revise_response_set_path: PropTypes.func.isRequired
+    responseSetPath: PropTypes.func.isRequired,
+    extendResponseSetPath: PropTypes.func.isRequired,
+    reviseResponseSetPath: PropTypes.func.isRequired
   })
 };

--- a/webpack/components/SearchBar.js
+++ b/webpack/components/SearchBar.js
@@ -1,27 +1,27 @@
 import React, { Component } from 'react';
 
 class SearchBar extends Component {
-    constructor(props){
-        super(props);
+  constructor(props){
+    super(props);
 
-        this.state = { term: '' };
-    }
+    this.state = { term: '' };
+  }
 
-    render() {
-        return (
+  render() {
+    return (
             <div className="search-bar">
-                <input 
+                <input
                     placeholder="Search Questions"
                     value={this.state.term}
                     onChange={event => this.onInputChange(event.target.value)} />
             </div>
-        );
-    }
+    );
+  }
 
-    onInputChange(term) {
-        this.setState({term});
-        this.props.onSearchTermChange(term);
-    }
+  onInputChange(term) {
+    this.setState({term});
+    this.props.onSearchTermChange(term);
+  }
 }
 
 

--- a/webpack/components/SearchWidget.js
+++ b/webpack/components/SearchWidget.js
@@ -22,50 +22,50 @@ export default class SearchWidget extends Component {
     var rsFiltered = [];
 
     switch (category) {
-      case 'Select Category':
-        if (term == '') {
-          questionsFiltered = this.state.allQuestions;
-          rsFiltered = this.state.allResponseSets;
-        } else {
-          this.state.allQuestions.map((q) => {
-            if (q.content.toLowerCase().includes(term.toLowerCase())){
-              questionsFiltered.push(q);
-            }
-          });
-          this.state.allResponseSets.map((rs) => {
-            if (rs.name.toLowerCase().includes(term.toLowerCase())){
-              rsFiltered.push(rs);
-            }
-          });
-        }
-        break;
+    case 'Select Category':
+      if (term == '') {
+        questionsFiltered = this.state.allQuestions;
+        rsFiltered = this.state.allResponseSets;
+      } else {
+        this.state.allQuestions.map((q) => {
+          if (q.content.toLowerCase().includes(term.toLowerCase())){
+            questionsFiltered.push(q);
+          }
+        });
+        this.state.allResponseSets.map((rs) => {
+          if (rs.name.toLowerCase().includes(term.toLowerCase())){
+            rsFiltered.push(rs);
+          }
+        });
+      }
+      break;
 
-      case 'Questions':
-        if (term == '') {
-          questionsFiltered = this.state.allQuestions;
-        } else {
-          this.state.allQuestions.map((q) => {
-            if (q.content.toLowerCase().includes(term.toLowerCase())){
-              questionsFiltered.push(q);
-            }
-          });
-        }
-        break;
+    case 'Questions':
+      if (term == '') {
+        questionsFiltered = this.state.allQuestions;
+      } else {
+        this.state.allQuestions.map((q) => {
+          if (q.content.toLowerCase().includes(term.toLowerCase())){
+            questionsFiltered.push(q);
+          }
+        });
+      }
+      break;
 
-      case 'Response Sets':
-        if (term == '') {
-          rsFiltered = this.state.allResponseSets;
-        } else {
-          this.state.allResponseSets.map((rs) => {
-            if (rs.name.toLowerCase().includes(term.toLowerCase())){
-              rsFiltered.push(rs);
-            }
-          });
-        }
-        break;
+    case 'Response Sets':
+      if (term == '') {
+        rsFiltered = this.state.allResponseSets;
+      } else {
+        this.state.allResponseSets.map((rs) => {
+          if (rs.name.toLowerCase().includes(term.toLowerCase())){
+            rsFiltered.push(rs);
+          }
+        });
+      }
+      break;
 
-      case 'Forms':
-        break;
+    case 'Forms':
+      break;
     }
 
     this.setState({
@@ -86,7 +86,7 @@ export default class SearchWidget extends Component {
 }
 
 SearchWidget.propTypes = {
-  responseSets: PropTypes.arrayOf(ResponseSetWidget.propTypes.response_set).isRequired,
+  responseSets: PropTypes.arrayOf(ResponseSetWidget.propTypes.responseSet).isRequired,
   questions: PropTypes.arrayOf(QuestionWidget.propTypes.question).isRequired,
   routes: PropTypes.object.isRequired
 };

--- a/webpack/components/SearchWidgetBar.js
+++ b/webpack/components/SearchWidgetBar.js
@@ -1,17 +1,17 @@
 import React, { Component, PropTypes } from 'react';
 
 class SearchWidgetBar extends Component {
-    constructor(props){
-        super(props);
+  constructor(props){
+    super(props);
 
-        this.state = { 
-          term: '',
-          category: 'Select Category'
-        };
-    }
+    this.state = {
+      term: '',
+      category: 'Select Category'
+    };
+  }
 
-    render() {
-        return (
+  render() {
+    return (
             <div>
               <div className="search-group" id="search-group">
                 <div className="search-group-btn">
@@ -24,17 +24,19 @@ class SearchWidgetBar extends Component {
                     </ul>
                 </div>
 
-                <input 
-                  type="text" className="search-input" 
+                <input
+                  type="text" className="search-input"
                   id="search"
                   name="search"
                   value={this.state.term}
                   onChange={event => this.onInputChange(event.target.value)}
-                  onKeyUp={event => {if (event.keyCode ==13) this.onBtnClick(this.state.term, this.state.category);}}
+                  onKeyUp={event => {
+                    if (event.keyCode ==13) this.onBtnClick(this.state.term, this.state.category);
+                  }}
                   placeholder="Search..." />
-                
+
                 <div className="input-group-btn">
-                  <button 
+                  <button
                     className="search-btn search-btn-default"
                     id="search-btn"
                     aria-label="search-btn"
@@ -45,20 +47,20 @@ class SearchWidgetBar extends Component {
                 </div>
               </div>
             </div>
-        );
-    }
+    );
+  }
 
-    onBtnClick(term, category) {
-        this.props.onSearchTermChange(term, category);
-    }
+  onBtnClick(term, category) {
+    this.props.onSearchTermChange(term, category);
+  }
 
-    onInputChange(term) {
-        this.setState({term});
-    }
+  onInputChange(term) {
+    this.setState({term});
+  }
 
-    changeCategory(category) {
-        this.setState({category});
-    }
+  changeCategory(category) {
+    this.setState({category});
+  }
 }
 
 SearchWidgetBar.propTypes = {

--- a/webpack/containers/QuestionSearch.js
+++ b/webpack/containers/QuestionSearch.js
@@ -8,43 +8,43 @@ import QuestionResults from '../components/QuestionResults';
 import SearchBar from '../components/SearchBar';
 
 class QuestionSearch extends Component {
-    constructor(props) {
-        super(props);
+  constructor(props) {
+    super(props);
 
-        this.state = {
-            questions: props.allQs,
-            responseSets: props.allRs,
-            allQs: props.allQs
-        };
-    }
+    this.state = {
+      questions: props.allQs,
+      responseSets: props.allRs,
+      allQs: props.allQs
+    };
+  }
 
-    questionFilter(term) {
-        var questionsFiltered = [];
+  questionFilter(term) {
+    var questionsFiltered = [];
 
-        if (term == '') {
-            questionsFiltered = this.state.allQs;
-        } else {
-            this.state.allQs.map((q) => {
-                if (q.content.toLowerCase().includes(term.toLowerCase())){
-                    questionsFiltered.push(q);
-                }
-            });
+    if (term == '') {
+      questionsFiltered = this.state.allQs;
+    } else {
+      this.state.allQs.map((q) => {
+        if (q.content.toLowerCase().includes(term.toLowerCase())){
+          questionsFiltered.push(q);
         }
-
-        this.setState({
-            questions: questionsFiltered
-        });
+      });
     }
 
-    render() {
-        return (
+    this.setState({
+      questions: questionsFiltered
+    });
+  }
+
+  render() {
+    return (
             <div>
                 <SearchBar onSearchTermChange={term => this.questionFilter(term)} />
                 <QuestionResults questions={this.state.questions} responseSets={this.state.responseSets}
                                  addQuestion={this.props.addQuestion} />
             </div>
-        );
-    }
+    );
+  }
 }
 
 function mapDispatchToProps(dispatch) {

--- a/webpack/reducers/index.js
+++ b/webpack/reducers/index.js
@@ -7,12 +7,12 @@ import {
 
 export function questions(state = [], action) {
   switch (action.type) {
-    case ADD_QUESTION:
-      return [...state, action.payload];
-    case REMOVE_QUESTION:
-      return state.filter((q, index) => index != action.payload);
-    default:
-      return state;
+  case ADD_QUESTION:
+    return [...state, action.payload];
+  case REMOVE_QUESTION:
+    return state.filter((q, index) => index != action.payload);
+  default:
+    return state;
   }
 }
 

--- a/webpack/response_set_list.js
+++ b/webpack/response_set_list.js
@@ -3,5 +3,5 @@ import ReactDOM from 'react-dom';
 import ResponseSetList from './components/ResponseSetList';
 import Routes from "./routes";
 
-const response_sets = JSON.parse(document.getElementById('response-set-json').innerHTML);
-ReactDOM.render(<ResponseSetList responseSets={response_sets} routes={Routes} />, document.getElementById('response_set_list'));
+const responseSets = JSON.parse(document.getElementById('response-set-json').innerHTML);
+ReactDOM.render(<ResponseSetList responseSets={responseSets} routes={Routes} />, document.getElementById('response_set_list'));

--- a/webpack/routes.js
+++ b/webpack/routes.js
@@ -1,6 +1,5 @@
 import { camelCase } from './camelcase';
 import routes from './_routes';
-import 'babel-polyfill';
 
 let exportRoutes = routes;
 if(routes.Routes){

--- a/webpack/routes.js
+++ b/webpack/routes.js
@@ -1,5 +1,17 @@
-var routes = require("./_routes.js");
+import { camelCase } from './camelcase';
+import routes from './_routes';
+import 'babel-polyfill';
+
+let exportRoutes = routes;
 if(routes.Routes){
-  routes = routes.Routes;
+  exportRoutes = routes.Routes;
 }
-export default routes;
+
+Object.keys(exportRoutes).forEach((k) => {
+  if (k.endsWith('_path')) {
+    const camelRouteName = camelCase(k);
+    exportRoutes[camelRouteName] = exportRoutes[k];
+  }
+});
+
+export default exportRoutes;

--- a/webpack/search.js
+++ b/webpack/search.js
@@ -2,8 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import SearchWidget from './components/SearchWidget';
 import Routes from "./routes";
-import "babel-polyfill";
 
 const questions = JSON.parse(document.getElementById('question-json').innerHTML);
-const response_sets = JSON.parse(document.getElementById('response-set-json').innerHTML);
-ReactDOM.render(<SearchWidget questions={questions} responseSets={response_sets} routes={Routes} />, document.getElementById('search-widget'));
+const responseSets = JSON.parse(document.getElementById('response-set-json').innerHTML);
+ReactDOM.render(<SearchWidget questions={questions} responseSets={responseSets} routes={Routes} />, document.getElementById('search-widget'));


### PR DESCRIPTION
This PR changes some of the eslint rules to better enforce our JavaScript coding style. It will enforce whitespace rules as well as making sure that variable names are camelCase. Several changes were required to make this happen.

In some places, serialization of objects from the Rails side were modified so that JSON property names are in camelCase.

The route helper library was augmented so that there are functions for routes in camelCase.

Lastly, babel-polyfill was pulled out to a webpack entry point. This means that individual files don't have to worry about including it. It also eliminates the issue where multiple files pull it in and it throws an error in the browser.

Make sure you have checked off the following before you issue your Pull Request:

- N/A Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- N/A Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
