### PR TITLE
Form Exporting

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,9 @@ Rails:
 Rails/HasAndBelongsToMany:
   Exclude:
     - 'app/models/role.rb'
+Metrics/BlockLength:
+  Exclude:
+    - 'config/routes.rb'
 Metrics/LineLength:
   Max: 150
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,7 @@ Rails/HasAndBelongsToMany:
 Metrics/BlockLength:
   Exclude:
     - 'config/routes.rb'
+    - 'lib/tasks/admin.rake'
 Metrics/LineLength:
   Max: 150
   Exclude:

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -30,6 +30,11 @@ class FormsController < ApplicationController
     @response_sets = ResponseSet.latest_versions
   end
 
+  # GET /forms/1/export
+  def export
+    @form = Form.find(params[:id])
+  end
+
   # POST /forms
   # POST /forms.json
   def create

--- a/app/views/forms/export.html.erb
+++ b/app/views/forms/export.html.erb
@@ -1,0 +1,21 @@
+<div class="no-print">
+  <%= link_to 'Export', '#', onClick: 'window.print()', class:"btn btn-default" %>
+  <hr>
+</div>
+<!-- Add in basic-bg class -->
+
+<!-- Start content to export -->
+<h3>Form Name: <%= @form.name %></h3><br>
+
+<% @form.form_questions.each do |fq| %>
+  <%= fq.question.content %>
+  <p>
+    <% fq.response_set.responses.each.with_index do |r, i| %>
+      <%= i+1 %>. <%= r.value %><br>
+    <% end %>
+  </p>
+<% end %>
+
+
+<!-- End Content to export -->
+<br><br><br>

--- a/app/views/forms/export.html.erb
+++ b/app/views/forms/export.html.erb
@@ -1,21 +1,23 @@
-<div class="no-print">
-  <%= link_to 'Export', '#', onClick: 'window.print()', class:"btn btn-default" %>
-  <hr>
+<div class="basic-bg">
+  <div class="no-print">
+    <%= link_to 'Export', '#', onClick: 'window.print()', class:"btn btn-default" %>
+    <hr>
+  </div>
+  <!-- Add in basic-bg class -->
+
+  <!-- Start content to export -->
+  <h3>Form Name: <%= @form.name %></h3><br>
+
+  <% @form.form_questions.each do |fq| %>
+    <%= fq.question.content %>
+    <p>
+      <% fq.response_set.responses.each.with_index do |r, i| %>
+        <%= i+1 %>. <%= r.value %><br>
+      <% end %>
+    </p>
+  <% end %>
+
+
+  <!-- End Content to export -->
+  <br><br><br>
 </div>
-<!-- Add in basic-bg class -->
-
-<!-- Start content to export -->
-<h3>Form Name: <%= @form.name %></h3><br>
-
-<% @form.form_questions.each do |fq| %>
-  <%= fq.question.content %>
-  <p>
-    <% fq.response_set.responses.each.with_index do |r, i| %>
-      <%= i+1 %>. <%= r.value %><br>
-    <% end %>
-  </p>
-<% end %>
-
-
-<!-- End Content to export -->
-<br><br><br>

--- a/app/views/forms/new.html.erb
+++ b/app/views/forms/new.html.erb
@@ -1,5 +1,5 @@
 <div class="basic-bg">
-<h3>Create Form</h3>
-<hr>
-<%= render 'form', form: @form %>
+  <h3>Create Form</h3>
+  <hr>
+  <%= render 'form', form: @form %>
 </div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -7,10 +7,10 @@
 
   <p>
     <strong>Questions:</strong><br>
-    <% @form.questions.zip(@form.response_sets).each do |q, rs| %>
-      <%= link_to q.content, question_path(q) %><br>
-      <% if rs %>
-        -   <%= link_to rs.name, response_set_path(rs) %><br>
+    <% @form.form_questions.each do |fq| %>
+      <%= link_to fq.question.content, question_path(fq.question) %><br>
+      <% if fq.response_set %>
+      -  <%= link_to fq.response_set.name, response_set_path(fq.response_set) %><br>
       <% end %>
     <% end %>
   </p>
@@ -23,7 +23,9 @@
 <div class="no-print">
   <%= render partial: 'shared/version_info', locals: {versionable: @form} %>
 
-  <%= link_to 'Revise', revise_form_path(@form) %> |
-  <%= link_to 'Back', forms_path %> |
-  <%= link_to 'Export', '#', onClick: 'window.print()' %>
+  <% if user_signed_in? & @form.most_recent? %>
+    <%= link_to 'Revise', revise_form_path(@form) %> |
+  <% end %>
+  <%= link_to 'Export', export_form_path(@form) %> |
+  <%= link_to 'Back', forms_path %>
 </div>

--- a/app/views/forms/show.html.erb
+++ b/app/views/forms/show.html.erb
@@ -20,8 +20,10 @@
     <%= @form.created_by.email if @form.created_by.present? %>
   </p>
 
+<div class="no-print">
   <%= render partial: 'shared/version_info', locals: {versionable: @form} %>
 
   <%= link_to 'Revise', revise_form_path(@form) %> |
-  <%= link_to 'Back', forms_path %>
+  <%= link_to 'Back', forms_path %> |
+  <%= link_to 'Export', '#', onClick: 'window.print()' %>
 </div>

--- a/app/views/responses/edit.html.erb
+++ b/app/views/responses/edit.html.erb
@@ -1,6 +1,8 @@
-<h1>Editing Response</h1>
+<div class="basic-bg">
+  <h1>Editing Response</h1>
 
-<%= render 'form', response: @response %>
+  <%= render 'form', response: @response %>
 
-<%= link_to 'Show', @response %> |
-<%= link_to 'Back', responses_path %>
+  <%= link_to 'Show', @response %> |
+  <%= link_to 'Back', responses_path %>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   root to: 'dashboard#index'
   resources :form_questions
   resources :forms, except: [:edit, :update] do # No editing/updating on response sets, we only revise them
+    get :export, on: :member
     get :revise, on: :member
   end
   resources :question_response_sets

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -54,3 +54,21 @@ Feature: Manage Forms
     And I confirm my action
     Then I should see "Form was successfully destroyed."
     And I should not see "Test Form"
+
+  Scenario: Export Form
+    Given I have a Form with the name "Test Form"
+    And I have a Question with the content "What is your gender?" and the type "MC"
+    And I have a Response Set with the name "Gender Partial" and the description "Gender example" and with the Responses Male, Female
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Forms
+    And I click on the "New Form" link
+    And I fill in the "form_name" field with "Test Form"
+    And I click on the button to add the Question "What is your gender?"
+    And I select the "Gender Partial" option in the "response_set_ids" list
+    And I click on the "Save" button
+    And I click on the "Export" link
+    Then I should see "Form Name: Test Form"
+    And I should see "What is your gender?"
+    And I should not see "Gender Partial"
+    And I should see "Male"
+    And I should see "Female"

--- a/features/step_definitions/response_set_steps.rb
+++ b/features/step_definitions/response_set_steps.rb
@@ -1,6 +1,6 @@
 Given(/^I have a Response Set with the name "([^"]*)" and the description "([^"]*)" and \
-the author "([^"]*)" and with the Responses (.+)$/) do |set_name, desc, author, response_values|
-  set = ResponseSet.create!(name: set_name, description: desc, author: author, version: 1)
+with the Responses (.+)$/) do |set_name, desc, response_values|
+  set = ResponseSet.create!(name: set_name, description: desc, version: 1)
   response_values.split(', ').each do |value|
     Response.create!(value: value, response_set_id: set['id'])
   end

--- a/webpack/styles/layouts/_footer.scss
+++ b/webpack/styles/layouts/_footer.scss
@@ -1,5 +1,3 @@
-
-
 .footer {
   bottom: 0;
   width: 100%;
@@ -7,5 +5,4 @@
   background-color: $cdc-dark-blue;
   text-align: center;
   color: white;
-
 }

--- a/webpack/styles/layouts/_printview.scss
+++ b/webpack/styles/layouts/_printview.scss
@@ -1,0 +1,11 @@
+@media print {
+  nav {
+    display:none;
+  }
+  footer {
+    display:none;
+  }
+  div.no-print {
+    display:none;
+  }
+}

--- a/webpack/styles/layouts/_printview.scss
+++ b/webpack/styles/layouts/_printview.scss
@@ -8,4 +8,7 @@
   div.no-print {
     display:none;
   }
+  div.basic-bg {
+    margin-top: 0px;
+  }
 }

--- a/webpack/styles/master.scss
+++ b/webpack/styles/master.scss
@@ -24,6 +24,7 @@
 @import "layouts/panels";
 @import "layouts/footer";
 @import "layouts/frameworks";
+@import "layouts/printview";
 
 //NAVIGATION//
 @import "navigation/nav";


### PR DESCRIPTION
Added an export button to the show page of a form. Steps to test:
- Create a form with the questions linked to *response sets with responses* (it will enumerate the responses as options on the export page)
- Go to the forms show page and click the `Export` link at the bottom (also fixed a bug here with form revision being allowed on previous versions, similar to the q/rs bug that was previously fixed)
- This page shows a preview, but if you click the export button it will open up a print / print as pdf browser prompt that should strip out the unnecessary elements and just yield the form contents.

Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
