### PR TITLE
Fixes issue preventing revising Questions

### DIFF
--- a/app/views/questions/_form.html.erb
+++ b/app/views/questions/_form.html.erb
@@ -2,6 +2,9 @@
   <div class='container' id='react-container'>
   </div>
 
+  <%= f.hidden_field :version_independent_id %>
+  <%= f.hidden_field :version %>
+
 <% end %>
 <script type="application/json" id="question-json">
   <%= raw @question.to_json %>

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -121,10 +121,6 @@ let QuestionForm = ({question= {}, selectedResponseSets=[], responseSets = [], r
               </div>
           </div>
 
-
-          <input type="hidden" name="question[version_independent_id]" id="question_version_independent_id" />
-          <input type="hidden" value="1" name="question[version]" id="question_version" />
-
           <div className="panel-footer">
             <div className="actions form-group">
               <button type="submit" name="commit" className="btn btn-default" data-disable-with={submitText}>{submitText}</button>


### PR DESCRIPTION
In changing parts of the web form from ERb to a React component, the
version and version_independent_id we not getting properly populated
in the web form. This commit pulls those field out of the React
component and puts them back in the ERb.

Make sure you have checked off the following before you issue your Pull Request:

- N/A Added unit tests for new functionality - bug fix
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- N/A Added cucumber tests for any new functionality - bug fix
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
- N/A If any changes were made to config/routes.rb run `rake jsroutes:generate`
