### PR TITLE
Eliminate console.log messages during testing

### DIFF
--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -26,8 +26,10 @@ else
 
   Capybara.register_driver :accessible_poltergeist_with_promises do |app|
     libs_path = Rails.root.join('features/support/js_libs/')
+    js_log = File.open('log/test_phantomjs.log', 'a')
     driver = Capybara::Poltergeist::Driver.new(app,
-                                               extensions: %W(#{libs_path}promise.js))
+                                               extensions: %W(#{libs_path}promise.js),
+                                               phantomjs_logger: js_log)
     adaptor = Capybara::Accessible::PoltergeistDriverAdapter.new
     Capybara::Accessible.setup(driver, adaptor)
   end


### PR DESCRIPTION
Previously, when tests were run, you would see messages like:
"%c prev state color: #9E9E9E; font-weight: bold [object Object]"

This was caused by the redux.js logging tools. By default the
combination of cucumber, Capybara, Poltergeist and PhantomJS write
JavaScript console.log messages to standard out. This change configures
that logging to go to a file in the log directory.

Make sure you have checked off the following before you issue your Pull Request:

- N/A Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- N/A Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
- N/A If any changes were made to config/routes.rb run `rake jsroutes:generate`
