### PR TITLE
Some clean up for eslint

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,48 +1,48 @@
 {
-    "rules": {
-        "linebreak-style": [
-            2,
-            "unix"
-        ],
-        "semi": [
-            2,
-            "always"
-        ],
-        "camelcase": 2,
-        "indent": ["error", 2],
-        "brace-style": 2,
-        "no-nested-ternary": 2,
-        "no-trailing-spaces": 2,
-        'react/jsx-no-duplicate-props': 2,
-        'react/jsx-no-undef': 2,
-        'react/jsx-uses-react': 2,
-        'react/jsx-uses-vars': 2,
-        'react/no-danger': 2,
-        'react/no-deprecated': 2,
-        'react/no-did-mount-set-state': 2,
-        'react/no-did-update-set-state': 2,
-        'react/no-direct-mutation-state': 2,
-        'react/no-is-mounted': 2,
-        'react/no-unknown-property': 2,
-        'react/prop-types': 2,
-        'react/react-in-jsx-scope': 2,
-        'no-case-declarations': 0
-    },
-    "env": {
-        "es6": true,
-        "browser": true,
-        "mocha": true,
-        "commonjs": true
-    },
-    "extends": ["eslint:recommended"],
-    "parserOptions": {
-      "sourceType": "module",
-      "ecmaFeatures": {
-          "jsx": true,
-          "experimentalObjectRestSpread": true
-      }
-    },
-    "plugins": [
-        "react"
-    ]
+  "rules": {
+    "linebreak-style": [
+      2,
+      "unix"
+    ],
+    "semi": [
+      2,
+      "always"
+    ],
+    "camelcase": 2,
+    "indent": ["error", 2, { "SwitchCase": 1 }],
+    "brace-style": 2,
+    "no-nested-ternary": 2,
+    "no-trailing-spaces": 2,
+    "react/jsx-no-duplicate-props": 2,
+    "react/jsx-no-undef": 2,
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/no-danger": 2,
+    "react/no-deprecated": 2,
+    "react/no-did-mount-set-state": 2,
+    "react/no-did-update-set-state": 2,
+    "react/no-direct-mutation-state": 2,
+    "react/no-is-mounted": 2,
+    "react/no-unknown-property": 2,
+    "react/prop-types": 2,
+    "react/react-in-jsx-scope": 2,
+    "no-case-declarations": 0
+  },
+  "env": {
+    "es6": true,
+    "browser": true,
+    "mocha": true,
+    "commonjs": true
+  },
+  "extends": ["eslint:recommended"],
+  "parserOptions": {
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "jsx": true,
+      "experimentalObjectRestSpread": true
+    }
+  },
+  "plugins": [
+    "react"
+  ]
 }

--- a/webpack/components/SearchWidget.js
+++ b/webpack/components/SearchWidget.js
@@ -22,50 +22,50 @@ export default class SearchWidget extends Component {
     var rsFiltered = [];
 
     switch (category) {
-    case 'Select Category':
-      if (term == '') {
-        questionsFiltered = this.state.allQuestions;
-        rsFiltered = this.state.allResponseSets;
-      } else {
-        this.state.allQuestions.map((q) => {
-          if (q.content.toLowerCase().includes(term.toLowerCase())){
-            questionsFiltered.push(q);
-          }
-        });
-        this.state.allResponseSets.map((rs) => {
-          if (rs.name.toLowerCase().includes(term.toLowerCase())){
-            rsFiltered.push(rs);
-          }
-        });
-      }
-      break;
+      case 'Select Category':
+        if (term == '') {
+          questionsFiltered = this.state.allQuestions;
+          rsFiltered = this.state.allResponseSets;
+        } else {
+          this.state.allQuestions.map((q) => {
+            if (q.content.toLowerCase().includes(term.toLowerCase())){
+              questionsFiltered.push(q);
+            }
+          });
+          this.state.allResponseSets.map((rs) => {
+            if (rs.name.toLowerCase().includes(term.toLowerCase())){
+              rsFiltered.push(rs);
+            }
+          });
+        }
+        break;
 
-    case 'Questions':
-      if (term == '') {
-        questionsFiltered = this.state.allQuestions;
-      } else {
-        this.state.allQuestions.map((q) => {
-          if (q.content.toLowerCase().includes(term.toLowerCase())){
-            questionsFiltered.push(q);
-          }
-        });
-      }
-      break;
+      case 'Questions':
+        if (term == '') {
+          questionsFiltered = this.state.allQuestions;
+        } else {
+          this.state.allQuestions.map((q) => {
+            if (q.content.toLowerCase().includes(term.toLowerCase())){
+              questionsFiltered.push(q);
+            }
+          });
+        }
+        break;
 
-    case 'Response Sets':
-      if (term == '') {
-        rsFiltered = this.state.allResponseSets;
-      } else {
-        this.state.allResponseSets.map((rs) => {
-          if (rs.name.toLowerCase().includes(term.toLowerCase())){
-            rsFiltered.push(rs);
-          }
-        });
-      }
-      break;
+      case 'Response Sets':
+        if (term == '') {
+          rsFiltered = this.state.allResponseSets;
+        } else {
+          this.state.allResponseSets.map((rs) => {
+            if (rs.name.toLowerCase().includes(term.toLowerCase())){
+              rsFiltered.push(rs);
+            }
+          });
+        }
+        break;
 
-    case 'Forms':
-      break;
+      case 'Forms':
+        break;
     }
 
     this.setState({

--- a/webpack/reducers/comments.js
+++ b/webpack/reducers/comments.js
@@ -7,11 +7,11 @@ import {
 
 export default function comments(state = [], action) {
   switch (action.type) {
-  case FETCH_COMMENTS_FULFILLED:
-    return [...action.payload.data];
-  case ADD_COMMENT_FULFILLED:
-    return [...state, action.payload.data];
-  default:
-    return state;
+    case FETCH_COMMENTS_FULFILLED:
+      return [...action.payload.data];
+    case ADD_COMMENT_FULFILLED:
+      return [...state, action.payload.data];
+    default:
+      return state;
   }
 }

--- a/webpack/reducers/questions.js
+++ b/webpack/reducers/questions.js
@@ -6,11 +6,11 @@ import {
 
 export default function questions(state = [], action) {
   switch (action.type) {
-  case ADD_QUESTION:
-    return [...state, action.payload];
-  case REMOVE_QUESTION:
-    return state.filter((q, index) => index != action.payload);
-  default:
-    return state;
+    case ADD_QUESTION:
+      return [...state, action.payload];
+    case REMOVE_QUESTION:
+      return state.filter((q, index) => index != action.payload);
+    default:
+      return state;
   }
 }


### PR DESCRIPTION
The .eslintrc now follows our indenting rules
Now all double quotes in the .eslintrc file so it is valid JSON
SwitchCase indenting now follows @rdingwell's preferred style

Make sure you have checked off the following before you issue your Pull Request:

- N/A Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- N/A Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
- N/A If any changes were made to config/routes.rb run `rake jsroutes:generate`
