### PR TITLE
Adding notifications controller to return a current users notificatio…

### DIFF
--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,0 +1,15 @@
+class NotificationsController < ApplicationController
+  def index
+    notifications = current_user ? current_user.notifications : []
+    render json: notifications
+  end
+
+  def mark_read
+    notifications = current_user.notifications.find(params[:ids])
+    notifications.each do |note|
+      note.read = true
+      note.save
+    end
+    render plain: '', status: 200
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,9 @@ Rails.application.routes.draw do
     get :extend, on: :member
   end
 
+  get 'notifications', to: 'notifications#index', as: :notifications
+  post 'notifications/mark_read', to: 'notifications#mark_read', as: :notifications_mark_read
+
   namespace :api, defaults: { format: :json } do
     resources :questions, only: [:index, :show] do
       get :usage, on: :member

--- a/test/controllers/notifications_controller_test.rb
+++ b/test/controllers/notifications_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class NotificationsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  test 'can get users notifications' do
+    admin = users(:admin)
+    sign_in(admin)
+    get notifications_path
+    assert_response :success
+    json = ActiveSupport::JSON.decode @response.body
+    assert_equal admin.notifications.length, json.length
+  end
+
+  test 'retuns empty arry when user not logged in' do
+    get notifications_path
+    assert_response :success
+    json = ActiveSupport::JSON.decode @response.body
+    assert_equal 0, json.length
+  end
+
+  test 'can mark notifications as read ' do
+    admin = users(:admin)
+    sign_in(admin)
+    assert_not_equal admin.notifications.unread.count, admin.notifications.count
+    post notifications_mark_read_path, params: { ids: [admin.notifications.collect(&:id)] }
+    admin.reload
+    assert_equal 0, admin.notifications.unread.count
+  end
+end


### PR DESCRIPTION
…ns or to set a number of a current users notifications to be marked as read

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- n/a Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- n/a If any database changes were made, run `rake generate_erd` to update the README.md
- [x] If any changes were made to config/routes.rb run `rake jsroutes:generate`
