### PR TITLE
Fixes form content being lost when trying to save [SDP-242]

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -45,9 +45,8 @@ class FormsController < ApplicationController
         format.html { redirect_to @form, notice: save_message(@form) }
         format.json { render :show, status: :created, location: @form }
       else
-        load_supporting_resources_for_editing
-        format.html { render :new }
-        format.json { render json: @form.errors, status: :unprocessable_entity }
+        errors = @form.errors.map { |k, v| "#{k.to_s.humanize}: #{v}" }
+        format.json { render json: errors, status: :unprocessable_entity }
       end
     end
   end

--- a/app/views/forms/_form.html.erb
+++ b/app/views/forms/_form.html.erb
@@ -1,8 +1,9 @@
 <%= form_for(form) do |f| %>
 
 <div class="row">
-  <% if form.errors.any? %>
+
     <div id="error_explanation">
+      <% if form.errors.any? %>
       <h2><%= pluralize(form.errors.count, "error") %> prohibited this form from being saved:</h2>
 
       <ul>
@@ -10,8 +11,9 @@
         <li><%= message %></li>
       <% end %>
       </ul>
+      <% end %>
     </div>
-  <% end %>
+
 
   <%= f.hidden_field :version_independent_id %>
   <%= f.hidden_field :version %>

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -31,8 +31,7 @@ Feature: Manage Forms
     And I click on the button to add the Question "What is your gender?"
     Then I select the "Gender Partial" option in the "response_set_ids" list
     And I click on the "Save" button
-    Then I should see "Form was successfully revised."
-    And I should see "Name: Gender Form"
+    Then I should see "Name: Gender Form"
     And I should see "What is your gender?"
     And I should see "Gender Partial"
 
@@ -43,11 +42,26 @@ Feature: Manage Forms
     When I go to the list of Forms
     And I click on the "New Form" link
     And I fill in the "form_name" field with "Test Form"
+    And I fill in the "form_control_number" field with "1234-1234"
     And I click on the button to add the Question "What is your gender?"
     Then I select the "Gender Full" option in the "response_set_ids" list
     And I click on the "Save" button
-    Then I should see "Form was successfully created."
+    Then I should see "Name: Test Form"
     And I should see "What is your gender?"
+
+  Scenario: An invalid control number should not allow save
+    Given I have a Response Set with the name "Gender Full"
+    And I have a Question with the content "What is your gender?" and the type "MC"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Forms
+    And I click on the "New Form" link
+    And I fill in the "form_name" field with "Test Form"
+    And I fill in the "form_control_number" field with "1234"
+    And I click on the button to add the Question "What is your gender?"
+    Then I select the "Gender Full" option in the "response_set_ids" list
+    And I click on the "Save" button
+    Then I should see "error(s) prohibited this form from being saved"
+    And I should see "Control number: must be a valid OMB Control Number"
 
   Scenario: Delete Form
     Given I have a Form with the name "Test Form"

--- a/webpack/forms.js
+++ b/webpack/forms.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
+import $ from 'jquery';
 import FormsQuestionList from './containers/FormsQuestionList';
 import QuestionSearch from './containers/QuestionSearch';
 
@@ -31,3 +32,24 @@ ReactDOM.render(
   </Provider>,
   added
 );
+
+$('#new_form').submit((event) => {
+  event.preventDefault();
+  const submissionURL = event.target.action;
+  const formData = $(event.target).serialize();
+  const request = $.post(submissionURL, formData, null, 'json');
+  request.done((data) => {
+    const location = data.url.replace('.json', '');
+    window.location = location;
+  });
+  request.fail((jqXHR) => {
+    const errorItems = jqXHR.responseJSON.map((e) => `<li>${e}</li>`);
+    $('#error_explanation').html(`
+      <h2>${jqXHR.responseJSON.length} error(s) prohibited this form from being saved:</h2>
+      <ul>
+        ${errorItems}
+      </ul>
+    `);
+  });
+  return false;
+});


### PR DESCRIPTION
Previously, if you tried to save a form, but it had an error, like
an invalid OMB control number, you would lose the selected questions
when the page reloaded.

This addresses the issue by saving the form in an AJAX request. If
the save is successful, it redirects the browser to the form show
page. If it fails, it shows the error on the page.

The code is kind of gross in that in mixes jQuery and React/Redux.
This is due to the fact that we are trying to save work on the React
side by using the form helper stuff from Rails. This should all be
refactored so that the form is created and managed by React.

Make sure you have checked off the following before you issue your Pull Request:

- N/A Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
- N/A If any changes were made to config/routes.rb run `rake jsroutes:generate`
