### PR TITLE
Fixed specifier bug in html by breaking out new question css specifie…

### DIFF
--- a/app/views/questions/new.html.erb
+++ b/app/views/questions/new.html.erb
@@ -1,12 +1,5 @@
 <div class="row basic-bg">
   <div class="col-md-12">
-    <div class="panel">
-      <div class="panel-heading panel-default">
-        <i class="fa fa-question-circle-o"></i>
-        New Question
-        <i class="fa fa-question-circle-o pull-right"></i>
-      </div>
-    </div>
     <!-- Change author: current_user.email to current_user.uid when controller change is made -->
     <%= render 'form', question: @question, author: current_user.email %>
   </div>

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -77,12 +77,12 @@ let QuestionForm = ({question= {}, selectedResponseSets=[], responseSets = [], r
           </div>
           <div className="panel-body">
           <div className="row">
-              <div className="col-md-8 form-group">
+              <div className="col-md-8 question-form-group">
                   <label className="input-label" htmlFor="question_content">Question</label>
                   <input className="input-format" placeholder="Question text" type="text" name="question[content]" id="question_content" defaultValue={question.content}/>
               </div>
 
-              <div className="col-md-4 form-group">
+              <div className="col-md-4 question-form-group">
                   <label className="input-label" htmlFor="question_question_type_id">Type</label>
                   <select className="input-format" name="question[question_type_id]" id="question_question_type_id" defaultValue={question.question_type_id}>
                     <option value=""></option>
@@ -94,7 +94,7 @@ let QuestionForm = ({question= {}, selectedResponseSets=[], responseSets = [], r
           </div>
 
           <div className="row ">
-              <div className="col-md-8 form-group">
+              <div className="col-md-8 question-form-group">
                   <label className="input-label" htmlFor="response_type_id">Primary Response Type</label>
                   <select name="response_type_id" id="response_type_id" className="input-format" defaultValue={question.response_type_id}>
                     {responseTypes.map((rt) => {
@@ -102,12 +102,12 @@ let QuestionForm = ({question= {}, selectedResponseSets=[], responseSets = [], r
                     })}
                   </select>
               </div>
-              <div className="col-md-4 form-group"></div>
+              <div className="col-md-4 question-form-group"></div>
           </div>
 
           <div className="row ">
 
-              <div className="col-md-6 form-group">
+              <div className="col-md-6 question-form-group">
                 <label htmlFor="linked_response_sets">Response Sets</label>
                   <div name="linked_response_sets">
                     {responseSets.map((rs, i) => {

--- a/webpack/styles/widgets/_questions.scss
+++ b/webpack/styles/widgets/_questions.scss
@@ -1,3 +1,8 @@
+.question-form-group {
+  @extend .panel-group;
+  text-align: left;
+  margin-bottom: 20px;
+}
 
 .question-group {
   @extend .panel-group;


### PR DESCRIPTION
Quick bug fix where new question page wasn't displaying correctly since the _forms.scss was added. Fixed specifier bug in html by breaking out new question css specifier - matched page to design repository.

Full bug detail:
In the HTML for creating a new question a bunch of the divs are `form-group` type, example https://github.com/CDCgov/SDP-Vocabulary-Service/blob/development/webpack/components/QuestionForm.js#L97
In the design repo this wasn't a problem but with the way webpack is working once we added _form.scss that added the
```.form-group {
  @extend .panel-group;
  margin-top: 20px;
  text-align: left;
  margin-bottom: 20px;
  width: 180px;
}
```
now the width is 180px fixed for all those divs which is ruining some of them that are supposed to be col-md-6 and col-md-8  on the question created stuff, suggesting fix by using question-form-group div specifier that removes width and padding

Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [n/a] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
