### PR TITLE
Search on Response set Index page - Finishing SDP-289

### DIFF
--- a/test/frontend/components/response_set_list_search_test.js
+++ b/test/frontend/components/response_set_list_search_test.js
@@ -1,0 +1,17 @@
+import { expect, renderComponent } from '../test_helper';
+import ResponseSetListSearch from '../../../webpack/components/ResponseSetListSearch';
+
+function search(){}
+
+describe('ResponseSetListSearch', () => {
+  let component;
+
+  beforeEach(() => {
+    component = renderComponent(ResponseSetListSearch, {search});
+  });
+
+  it('should create a search bar', () => {
+    expect(component.find("input[id='search']")).to.exist;
+  });
+
+});

--- a/test/frontend/components/response_set_list_test.js
+++ b/test/frontend/components/response_set_list_test.js
@@ -1,0 +1,19 @@
+import { expect, renderComponent } from '../test_helper';
+import ResponseSetList from '../../../webpack/components/ResponseSetList';
+import routes from '../mock_routes';
+
+describe('ResponseSetList', () => {
+  let component;
+
+  beforeEach(() => {
+    const responseSets = {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
+                          2: {id: 2, name: "Colors Improved", description: "A better list of colors", oid: "3.16.840.1.113883.3.1502.3.1"},
+                          3: {id: 3, name: "People", description: "A list of people", oid: "4.16.840.1.113883.3.1502.3.1"}};
+    component = renderComponent(ResponseSetList, {responseSets, routes});
+  });
+
+  it('should create list of response sets', () => {
+    expect(component.find("div[class='response-set-group']").length).to.equal(3);
+  });
+
+});

--- a/test/frontend/mock_routes.js
+++ b/test/frontend/mock_routes.js
@@ -3,7 +3,7 @@ exports.reviseQuestionPath = (q) => `/questions/${q.id}/revise`;
 exports.formPath = (f) => `/forms/${f.id}/`;
 exports.formsPath = (f) => `/forms/`;
 exports.reviseFormPath = (f) => `/forms/${f.id}/revise`;
-exports.responseSetPath = (r) => `/responseSetPath/${r.id}/`;
-exports.extendResponseSetPath = (r) => `/responseSetPath/${r.id}/extend`;
-exports.reviseResponseSetPath = (r) => `/responseSetPath/${r.id}/revise/`;
+exports.responseSetPath = (r) => `/responseSets/${r.id}`;
+exports.extendResponseSetPath = (r) => `/responseSets/${r.id}/extend`;
+exports.reviseResponseSetPath = (r) => `/responseSets/${r.id}/revise`;
 

--- a/webpack/actions/response_set_actions.js
+++ b/webpack/actions/response_set_actions.js
@@ -8,11 +8,12 @@ import {
 
 import { getCSRFToken } from './index';
 
-export function fetchResponseSets() {
+export function fetchResponseSets(searchTerms) {
   return {
     type: FETCH_RESPONSE_SETS,
     payload: axios.get(routes.responseSetsPath(), {
-      headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'}
+      headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'},
+      params: { search: searchTerms }
     })
   };
 }

--- a/webpack/components/Header.js
+++ b/webpack/components/Header.js
@@ -94,7 +94,7 @@ let Header = ({currentUser}) => {
           <span className="icon-bar"></span>
           <span className="icon-bar"></span>
           </button>
-          <a className="cdc-brand" href="/">CDC Vocabulary Service</a>
+          <Link to="/" className="cdc-brand">CDC Vocabulary Service</Link>
         </div>
         <SignedInMenu currentUser={currentUser} />
         <LoginMenu currentUser={currentUser} />

--- a/webpack/components/ResponseSetListSearch.js
+++ b/webpack/components/ResponseSetListSearch.js
@@ -1,0 +1,45 @@
+import React, { Component, PropTypes } from 'react';
+
+class ResponseSetListSearch extends Component {
+
+  constructor(props){
+    super(props);
+    this.state={searchTerms: ''};
+    this.onInputChange = this.onInputChange.bind(this);
+    this.onFormSubmit  = this.onFormSubmit.bind(this);
+  }
+
+  onInputChange(event){
+    this.setState({searchTerms: event.target.value});
+  }
+
+  onFormSubmit(event){
+    event.preventDefault();
+    this.props.search(this.state.searchTerms);
+    this.setState({searchTerms: ''});
+  }
+
+  render() {
+    return (
+      <form onSubmit={this.onFormSubmit}>
+        <div className="row">
+          <div className="col-md-12">
+            <div className="input-group question-group">
+              <label htmlFor="search" className="hidden">Search Response Sets</label>
+              <input onChange={this.onInputChange} type="text" id="search" name="search" className="form-control" placeholder="Search Response Sets..."/>
+              <span className="input-group-btn">
+                <button className="btn btn-default" type="submit">Go!</button>
+              </span>
+            </div>
+          </div>
+        </div>
+      </form>
+    );
+  }
+}
+
+ResponseSetListSearch.propTypes = {
+  search: PropTypes.func.isRequired
+};
+
+export default ResponseSetListSearch;

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -10,27 +10,30 @@ class DashboardContainer extends Component {
 
   render() {
     return (
-    <div className="conatiner">
-      <div className="row dashboard">
-        <div className="col-md-8 dashboard-details">
-          <div className="row">
-            <div className="col-md-12">
-              {this.analyticsGroup()}
+      <div>
+        <div className="row dashboard">
+          <div className="col-md-8">
+            <div className="dashboard-details">
+              <div className="row">
+                <div className="col-md-12">
+                  {this.analyticsGroup()}
+                </div>
+              </div>
+
+              <div id="search-widget">
+              </div>
             </div>
           </div>
 
-          <div id="search-widget">
-          </div>
-        </div>
-
-        <div className="col-md-4">
-          <div className="dashboard-activity">
-            {this.recentItems()}
-            {this.activityPanel()}
+          <div className="col-md-4">
+            <div className="dashboard-activity">
+              {this.recentItems()}
+              {this.activityPanel()}
+            </div>
           </div>
         </div>
       </div>
-    </div>);
+    );
   }
 
   analyticsGroup() {

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -5,6 +5,7 @@ import { fetchResponseSet } from '../actions/response_set_actions';
 import ResponseSetDetails from '../components/ResponseSetDetails';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
+import _ from 'lodash';
 
 class ResponseSetShowContainer extends Component {
   componentWillMount() {
@@ -29,7 +30,7 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.responseSet = state.responseSets[ownProps.params.rsId];
   if (props.responseSet) {
-    props.questions = props.responseSet.questions.map((qId) => state.questions[qId]);
+    props.questions = _.compact(props.responseSet.questions.map((qId) => state.questions[qId]));
   }
   return props;
 }

--- a/webpack/containers/ResponseSetsContainer.js
+++ b/webpack/containers/ResponseSetsContainer.js
@@ -3,13 +3,24 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchResponseSets } from '../actions/response_set_actions';
 import ResponseSetList from '../components/ResponseSetList';
+import ResponseSetListSearch from '../components/ResponseSetListSearch';
 import Routes from '../routes';
 import { responseSetProps } from '../prop-types/response_set_props';
 
 class ResponseSetsContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.search = this.search.bind(this);
+  }
+
   componentWillMount() {
     this.props.fetchResponseSets();
   }
+
+  search(searchTerms){
+    this.props.fetchResponseSets(searchTerms);
+  }
+
   render() {
     if(!this.props.responseSets){
       return (
@@ -17,8 +28,12 @@ class ResponseSetsContainer extends Component {
       );
     }
     return (
-      <div>
-        <ResponseSetList responseSets={this.props.responseSets} routes={Routes} />
+      <div className='row basic-bg'>
+        <div className='col-md-12'>
+          <ResponseSetListSearch search={this.search} />
+          <ResponseSetList responseSets={this.props.responseSets} routes={Routes} />
+          <a className='btn btn-default' href={Routes.newResponseSetPath()}>New Response Set</a>
+        </div>
       </div>
     );
   }

--- a/webpack/styles/layouts/_panels.scss
+++ b/webpack/styles/layouts/_panels.scss
@@ -6,16 +6,20 @@
 .dashboard-details {
   background-color: white;
   min-height: 90vh;
+  margin-left: 20px;
 }
 
 .dashboard-activity {
   background-color: white;
   min-height: 90vh;
+  margin-left: -10px;
+  margin-right: 20px;
 }
 
 .basic-bg {
   margin-bottom: 20px;
-  margin-top: 130px;
+  margin-right: 20px;
+  margin-left: 20px;
   padding-left: 20px;
   padding-right: 20px;
   padding-top: 10px;

--- a/webpack/styles/navigation/_nav.scss
+++ b/webpack/styles/navigation/_nav.scss
@@ -3,6 +3,7 @@
   background-color: $cdc-dark-blue;
   height: 50px;
   margin-bottom: 0px;
+
   a {
     color: white;
   }
@@ -11,8 +12,19 @@
   }
 }
 
+a.cdc-brand:hover {
+  color:white;
+}
+
+a.cdc-brand:focus {
+  color:white;
+}
+
 .cdc-brand {
   @extend .navbar-brand;
+  a:hover, a:focus {
+    color: white;
+  }
   padding: 13px 0px 0px 0px;
 }
 
@@ -23,7 +35,7 @@
 
 .cdc-utlt-navbar-nav {
   @extend .navbar-nav;
-  padding: 0px 0px 0px 0px;
+  padding: 0px 0px 0px 20px;
   .utlt-navbar-item>a {
     height: 50px;
   }

--- a/webpack/styles/widgets/_analytics.scss
+++ b/webpack/styles/widgets/_analytics.scss
@@ -2,6 +2,8 @@
 .analytics-group {
   margin-top: 14px;
   margin-bottom: 20px;
+  margin-left: 20px;
+  margin-right: 20px;
   height: 150px;
   text-align: center;
   border: 1px solid $light-gray;


### PR DESCRIPTION
Finished up SDP-289 - Convert index page for Response Sets into React component

Implemented search on the response set's Index page the same as it was implemented on the forms and questions index pages.

Also did some minor cleanup to the css to get it back toward Eny's mockups. 

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [n/a] Added cucumber tests for any new functionality
- [n/a] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
