### PR TITLE
[SDP-318] Response Set Parent, Versioning, and Reducer tests added

### DIFF
--- a/app/views/response_sets/_response_set.json.jbuilder
+++ b/app/views/response_sets/_response_set.json.jbuilder
@@ -1,4 +1,4 @@
 json.extract! response_set, :id, :name, :description, :oid, :created_by, :responses, :coded, \
-              :version, :version_independent_id, :questions, \
-              :created_at, :updated_at, :parent
+              :version, :all_versions, :other_versions, :most_recent, :version_independent_id, \
+              :questions, :created_at, :updated_at, :parent
 json.url response_set_url(response_set, format: :json)

--- a/test/frontend/middleware/test_parent_from_response_sets.js
+++ b/test/frontend/middleware/test_parent_from_response_sets.js
@@ -1,0 +1,44 @@
+import { expect } from '../test_helper';
+import MockStore from '../mock_store';
+
+import parentFromResponseSets from '../../../webpack/middleware/parent_from_response_sets';
+
+import {
+  FETCH_RESPONSE_SETS_FULFILLED,
+  FETCH_RESPONSE_SET_FULFILLED
+} from '../../../webpack/actions/types';
+
+describe('parentFromResponseSets middleware', () => {
+  let store;
+  let action;
+
+  const next = () => {
+    1 + 1; //do nothing
+  };
+
+  beforeEach(() => {
+    store = new MockStore();
+    action = {
+      type: FETCH_RESPONSE_SETS_FULFILLED,
+      payload: {data: [
+        {id: 1, name: 'People', description: 'List of people', parent: null},
+        {id: 2, name: 'Colors', parent: {id: 1, name: 'People', description: 'List of people', parent: null}},
+        {id: 3, name: 'Things', parent: {id: 1, name: 'People', description: 'List of people', parent: null}}
+      ]}
+    };
+  });
+
+  it('will dispatch actions for parent response sets in response sets', () => {
+    parentFromResponseSets(store)(next)(action);
+    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_RESPONSE_SET_FULFILLED);
+    expect(dispatchedAction).to.exist;
+    expect(dispatchedAction.payload.data.name).to.equal('People');
+  });
+
+  it('will transform the response set payload', () => {
+    parentFromResponseSets(store)(next)(action);
+    const rs = action.payload.data[1];
+    expect(rs.parent.name).to.equal('People');
+    expect(rs.parent.description).to.be.an('undefined');
+  });
+});

--- a/test/frontend/reducers/test_response_sets.js
+++ b/test/frontend/reducers/test_response_sets.js
@@ -1,0 +1,38 @@
+import { expect } from '../test_helper';
+import  responseSets  from '../../../webpack/reducers/response_sets_reducer';
+import _ from 'lodash';
+import {
+  SAVE_RESPONSE_SET_FULFILLED,
+  FETCH_RESPONSE_SET_FULFILLED,
+  FETCH_RESPONSE_SETS_FULFILLED,
+} from '../../../webpack/actions/types';
+
+describe('responseSets reducer', () => {
+
+  it('should save a response set', () => {
+    const responseSet = {data:{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}};
+    const action = {type: SAVE_RESPONSE_SET_FULFILLED, payload: responseSet };
+    const startState = [];
+    const nextState = responseSets(startState, action);
+    expect(nextState[1].id).to.equal(responseSet.data.id);
+    expect(nextState[1].name).to.equal(responseSet.data.name);
+  });
+
+  it('should fetch response sets', () => {
+    const responseSetData = {data: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
+                                 {id: 2, name: "People", description: "A list of people", oid: "2.16.840.1.113883.3.1502.3.2"},
+                                 {id: 3, name: "Things", description: "A list of things", oid: "2.16.840.1.113883.3.1502.3.3"}]};
+    const action = {type: FETCH_RESPONSE_SETS_FULFILLED, payload: responseSetData};
+    const startState = {};
+    const nextState = responseSets(startState, action);
+    expect(Object.keys(nextState).length).to.equal(3);
+  });
+
+  it('should fetch a response set', () => {
+    const responseSetData = {data: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}};
+    const action = {type: FETCH_RESPONSE_SET_FULFILLED, payload: responseSetData};
+    const startState = {};
+    const nextState = responseSets(startState, action);
+    expect(Object.keys(nextState).length).to.equal(1);
+  });
+});

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -67,6 +67,12 @@ export default class ResponseSetDetails extends Component {
           <strong>Author: </strong>
           { responseSet.createdBy && responseSet.createdBy.email }
         </p>
+        { responseSet.parent && 
+          <p>
+            <strong>Extended from: </strong>
+            <Link to={`/responseSets/${responseSet.parent.id}`}>{ responseSet.parent.name }</Link>
+          </p>
+        }
         <p>
           <strong>Created: </strong>
           { moment(responseSet.createdAt,'').format('MMMM Do YYYY, h:mm:ss a') }

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -51,7 +51,7 @@ export default class ResponseSetDetails extends Component {
         <p>
           <strong>Questions:</strong><br/>
         </p>
-        { this.props.questions.map((q) => {
+        { this.props.questions && this.props.questions.map((q) => {
           return (
             <div key={"rs_question_" + q.id}>
               <a href={Routes.questionPath(q.id)}>{q.content}</a><br/>

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -67,7 +67,7 @@ export default class ResponseSetDetails extends Component {
           <strong>Author: </strong>
           { responseSet.createdBy && responseSet.createdBy.email }
         </p>
-        { responseSet.parent && 
+        { responseSet.parent &&
           <p>
             <strong>Extended from: </strong>
             <Link to={`/responseSets/${responseSet.parent.id}`}>{ responseSet.parent.name }</Link>

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -4,6 +4,7 @@ import Routes from "../routes";
 import moment from 'moment';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
+import VersionInfo from './VersionInfo';
 
 export default class ResponseSetDetails extends Component {
   render() {
@@ -75,6 +76,7 @@ export default class ResponseSetDetails extends Component {
           { responseSet.updated_by && responseSet.updated_by.email }
           { moment(responseSet.updatedAt,'').format('MMMM Do YYYY, h:mm:ss a') }
         </p>
+        <VersionInfo versionable={responseSet} versionableType='ResponseSet' />
         <Link to={`/responseSets/${this.props.responseSet.id}/revise`}>
           Revise
         </Link> |

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -47,8 +47,9 @@ export default class ResponseSetForm extends Component {
     const responsesAttributes = filterResponses(responseSet.responses);
     const version = 1;
     const versionIndependentId = null;
+    const parentId = responseSet.id;
     return {name, oid, description, coded, responsesAttributes,
-      version, versionIndependentId};
+      version, versionIndependentId, parentId};
   }
 
   render() {
@@ -70,7 +71,9 @@ export default class ResponseSetForm extends Component {
               <label htmlFor="coded">Coded</label>
               <input type="checkbox" value={this.state.coded} name="coded" id="coded" onChange={this.handleChange('coded')}/>
             </div>
-
+            <div className="hidden">
+              <input type="hidden" name="parentId" id="parentId" value={this.state.parentId} />
+            </div>
           </div>
 
           <div className="row">

--- a/webpack/components/VersionInfo.js
+++ b/webpack/components/VersionInfo.js
@@ -1,13 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import Routes from "../routes";
 import moment from 'moment';
 import { Link } from 'react-router';
-
-const routesMap = {
-  Form: Routes.formPath,
-  Question: Routes.questionPath,
-  ResponseSet: Routes.responseSetPath
-};
 
 export default class VersionInfo extends Component {
 

--- a/webpack/components/VersionInfo.js
+++ b/webpack/components/VersionInfo.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import Routes from "../routes";
 import moment from 'moment';
+import { Link } from 'react-router';
 
 const routesMap = {
   Form: Routes.formPath,
@@ -46,7 +47,7 @@ export default class VersionInfo extends Component {
               );
             }else{
               return (
-                <li key={v.id}><a href={routesMap[this.props.versionableType](v)}>Version: {v.version}</a> - Created {moment(v.createdAt,'').fromNow()}</li>
+                <li key={v.id}><Link to={`/${this.props.versionableType}s/${v.id}`}>Version: {v.version}</Link> - Created {moment(v.createdAt,'').fromNow()}</li>
               );
             }
           })}

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -10,6 +10,12 @@ class FormShowContainer extends Component {
     this.props.fetchForm(this.props.params.formId);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if(prevProps.params.formId != this.props.params.formId){
+      this.props.fetchResponseSet(this.props.params.formId);
+    }
+  }
+
   render() {
     if(!this.props.form){
       return (

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -10,9 +10,9 @@ class FormShowContainer extends Component {
     this.props.fetchForm(this.props.params.formId);
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if(prevProps.params.formId != this.props.params.formId){
-      this.props.fetchResponseSet(this.props.params.formId);
+      this.props.fetchForm(this.props.params.formId);
     }
   }
 

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -13,9 +13,9 @@ class QuestionShowContainer extends Component {
     this.props.fetchQuestion(this.props.params.qId);
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if(prevProps.params.qId != this.props.params.qId){
-      this.props.fetchResponseSet(this.props.params.qId);
+      this.props.fetchQuestion(this.props.params.qId);
     }
   }
 

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -13,6 +13,12 @@ class QuestionShowContainer extends Component {
     this.props.fetchQuestion(this.props.params.qId);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if(prevProps.params.qId != this.props.params.qId){
+      this.props.fetchResponseSet(this.props.params.qId);
+    }
+  }
+
   reviseQuestionButton(){
     if(this.props.currentUser && this.props.currentUser.id){
       return( <a className="btn btn-primary" href={`/landing#/questions/${this.props.question.id}/revise`}>Revise</a> );

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -12,6 +12,12 @@ class ResponseSetShowContainer extends Component {
     this.props.fetchResponseSet(this.props.params.rsId);
   }
 
+  componentDidUpdate(prevProps, prevState) {
+    if(prevProps.params.rsId != this.props.params.rsId){
+      this.props.fetchResponseSet(this.props.params.rsId);
+    }
+  }
+
   render() {
     if(!this.props.responseSet){
       return (
@@ -29,7 +35,7 @@ class ResponseSetShowContainer extends Component {
 function mapStateToProps(state, ownProps) {
   const props = {};
   props.responseSet = state.responseSets[ownProps.params.rsId];
-  if (props.responseSet) {
+  if (props.responseSet && props.responseSet.questions) {
     props.questions = _.compact(props.responseSet.questions.map((qId) => state.questions[qId]));
   }
   return props;

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -12,7 +12,7 @@ class ResponseSetShowContainer extends Component {
     this.props.fetchResponseSet(this.props.params.rsId);
   }
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate(prevProps) {
     if(prevProps.params.rsId != this.props.params.rsId){
       this.props.fetchResponseSet(this.props.params.rsId);
     }

--- a/webpack/middleware/parent_from_response_sets.js
+++ b/webpack/middleware/parent_from_response_sets.js
@@ -1,0 +1,28 @@
+import {
+  FETCH_RESPONSE_SETS_FULFILLED,
+  FETCH_RESPONSE_SET_FULFILLED
+} from '../actions/types';
+
+const parentFromResponseSets = store => next => action => {
+  switch (action.type) {
+    case FETCH_RESPONSE_SETS_FULFILLED:
+      const responseSets = action.payload.data;
+      responseSets.forEach((rs) => {
+        if(rs.parent){
+          store.dispatch({type: FETCH_RESPONSE_SET_FULFILLED, payload: {data: rs.parent}});
+          rs.parent = ({id: rs.parent.id, name: rs.parent.name});
+        }
+      });
+      break;
+    case FETCH_RESPONSE_SET_FULFILLED:
+      if(action.payload.data.parent){
+        store.dispatch({type: FETCH_RESPONSE_SET_FULFILLED, payload: {data: action.payload.data.parent}});
+        action.payload.data.parent = ({id: action.payload.data.parent.id, name: action.payload.data.parent.name});
+        //action.payload.data.parent = Object.keys(action.payload.data.parent).reduce((id, name) => {return({id: id, name: name});});
+      }
+  }
+
+  next(action);
+};
+
+export default parentFromResponseSets;

--- a/webpack/middleware/parent_from_response_sets.js
+++ b/webpack/middleware/parent_from_response_sets.js
@@ -18,7 +18,6 @@ const parentFromResponseSets = store => next => action => {
       if(action.payload.data.parent){
         store.dispatch({type: FETCH_RESPONSE_SET_FULFILLED, payload: {data: action.payload.data.parent}});
         action.payload.data.parent = ({id: action.payload.data.parent.id, name: action.payload.data.parent.name});
-        //action.payload.data.parent = Object.keys(action.payload.data.parent).reduce((id, name) => {return({id: id, name: name});});
       }
   }
 

--- a/webpack/prop-types/response_set_props.js
+++ b/webpack/prop-types/response_set_props.js
@@ -15,7 +15,7 @@ const responseSetProps = PropTypes.shape({
   coded: PropTypes.boolean,
   versionIndependentId: PropTypes.string,
   version: PropTypes.number,
-  parentId: PropTypes.number,
+  parent: PropTypes.object,
   responses: PropTypes.arrayOf(responseProps)
 });
 

--- a/webpack/store/configure_store.js
+++ b/webpack/store/configure_store.js
@@ -5,6 +5,7 @@ import createLogger from 'redux-logger';
 import questionsFromResponseSets from '../middleware/questions_from_response_sets';
 import questionsFromForms from '../middleware/questions_from_forms';
 import responseSetsFromQuestions from '../middleware/response_sets_from_questions';
+import parentFromResponseSets from '../middleware/parent_from_response_sets';
 
 import rootReducer from '../reducers';
 
@@ -14,7 +15,8 @@ export default function configureStore(initialState) {
     createLogger(),
     questionsFromResponseSets,
     questionsFromForms,
-    responseSetsFromQuestions
+    responseSetsFromQuestions,
+    parentFromResponseSets
   );
 
   let store = createStore(rootReducer, initialState, middleware);


### PR DESCRIPTION
Response Set Parent, Versioning, and Reducer tests added. Fixed a bug when component is updated with a new id but not re-rendered.

Details:
The Response set extend functionality was not properly linking the parent. The links on the component pages would not re-render components and thus the parent or previous version would not be in the store, causing it to never render.

Acceptance Criteria:
Can click on the 'Extended from' link or the previous versions link on a RS show page and have it navigate successfully in the new react SPA.

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [n/a] Added cucumber tests for any new functionality
- [n/a] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
