### PR TITLE
Handle errors on Response Set Save [SDP-277]

### DIFF
--- a/test/frontend/components/errors_test.js
+++ b/test/frontend/components/errors_test.js
@@ -1,0 +1,21 @@
+import {
+  expect,
+  renderComponent
+} from '../test_helper';
+import Errors from '../../../webpack/components/Errors';
+
+describe('Errors', () => {
+  let component;
+
+  beforeEach(() => {
+    const errors = {
+      oid: ['must be unique'],
+      name: ['too short', 'not jazzy enough']
+    };
+    component = renderComponent(Errors, {errors});
+  });
+
+  it('should display the correct number of errors', () => {
+    expect(component.find('h2')).to.contain('3 error(s) prohibited the form from being saved.');
+  });
+});

--- a/test/frontend/components/errors_test.js
+++ b/test/frontend/components/errors_test.js
@@ -16,6 +16,6 @@ describe('Errors', () => {
   });
 
   it('should display the correct number of errors', () => {
-    expect(component.find('h2')).to.contain('3 error(s) prohibited the form from being saved.');
+    expect(component.find('h2')).to.contain('3 error(s) prohibited this form from being saved');
   });
 });

--- a/webpack/actions/response_set_actions.js
+++ b/webpack/actions/response_set_actions.js
@@ -27,14 +27,18 @@ export function fetchResponseSet(id) {
   };
 }
 
-export function saveResponseSet(responseSet, callback=null) {
+export function saveResponseSet(responseSet, successHandler=null, failureHandler=null) {
   const authenticityToken = getCSRFToken();
   const postPromise = axios.post(routes.responseSetsPath(),
                       {responseSet, authenticityToken},
                       {headers: {'X-Key-Inflection': 'camel', 'Accept': 'application/json'}});
-  if (callback) {
-    postPromise.then(callback);
+  if (failureHandler) {
+    postPromise.catch(failureHandler);
   }
+  if (successHandler) {
+    postPromise.then(successHandler);
+  }
+
   return {
     type: SAVE_RESPONSE_SET,
     payload: postPromise

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -7,19 +7,21 @@ export default class Errors extends Component {
         <div id="error_explanation">
           <h2>{this.errorCount()} error(s) prohibited this form from being saved:</h2>
           <ul>
-          {_.forOwn(this.props.errors, (field) => {
-            return _.map(this.props.errors[field], (e) => {
-              return <li>{field} - {e}</li>;
-            });
-          })}
+          {_.map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
           </ul>
         </div>
       );
+    } else {
+      return <div id="error_explanation" />;
     }
   }
 
   errorCount() {
-    return _.reduce(_.values(this.props.errors), 'length', 0);
+    return _.reduce(_.values(this.props.errors), (sum, v) => sum + v.length, 0);
+  }
+
+  errorList() {
+    return _.flatten(_.values(this.props.errors));
   }
 }
 

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -1,0 +1,28 @@
+import React, { Component, PropTypes } from 'react';
+import _ from 'lodash';
+export default class Errors extends Component {
+  render() {
+    if (_.keys(this.props.errors).length > 0) {
+      return (
+        <div id="error_explanation">
+          <h2>{this.errorCount()} error(s) prohibited this form from being saved:</h2>
+          <ul>
+          {_.forOwn(this.props.errors, (field) => {
+            return _.map(this.props.errors[field], (e) => {
+              return <li>{field} - {e}</li>;
+            });
+          })}
+          </ul>
+        </div>
+      );
+    }
+  }
+
+  errorCount() {
+    return _.reduce(_.values(this.props.errors), 'length', 0);
+  }
+}
+
+Errors.propTypes = {
+  errors: PropTypes.objectOf(PropTypes.array)
+};

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import CodedSetTableForm from './CodedSetTableForm';
+import Errors from './Errors';
 import { responseSetProps } from '../prop-types/response_set_props';
 
 export default class ResponseSetForm extends Component {
@@ -55,6 +56,7 @@ export default class ResponseSetForm extends Component {
   render() {
     return (
       <form onSubmit={(e) => this.handleSubmit(e)}>
+        <Errors errors={this.state.errors} />
         <div className="row">
           <div className="row">
             <div className="col-md-4">
@@ -98,13 +100,10 @@ export default class ResponseSetForm extends Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.props.responseSetSubmitter(this.state, (response) => {
-      // TODO: Handle when the saving response set fails.
-      if (response.status === 201) {
-        this.props.router.push(`/responseSets/${response.data.id}`);
-      } else {
-        // update state
-      }
+    this.props.responseSetSubmitter(this.state, (successResponse) => {
+      this.props.router.push(`/responseSets/${successResponse.data.id}`);
+    }, (failureResponse) => {
+      this.setState({errors: failureResponse.response.data});
     });
   }
 

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -91,11 +91,16 @@ export default class ResponseSetForm extends Component {
                              childName={'response'} />
 
           <div className="actions">
-            <input type="submit" value={`${this.props.action} Response Set`}/>
+            <input type="submit" value={`${this.actionWord()} Response Set`}/>
           </div>
         </div>
       </form>
     );
+  }
+
+  actionWord() {
+    const wordMap = {'new': 'Create', 'revise': 'Revise', 'extend': 'Extend'};
+    return wordMap[this.props.action];
   }
 
   handleSubmit(event) {

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -102,6 +102,8 @@ export default class ResponseSetForm extends Component {
       // TODO: Handle when the saving response set fails.
       if (response.status === 201) {
         this.props.router.push(`/responseSets/${response.data.id}`);
+      } else {
+        // update state
       }
     });
   }


### PR DESCRIPTION
This completes SDP-277. The component now properly handles and displays when the server returns an error when saving a response set.

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed overcommit hooks, including running all code through Rubocop
