### PR TITLE
Only showing most recent versions of response sets

### DIFF
--- a/app/views/response_sets/_response_set.json.jbuilder
+++ b/app/views/response_sets/_response_set.json.jbuilder
@@ -1,4 +1,4 @@
 json.extract! response_set, :id, :name, :description, :oid, :created_by, :responses, :coded, \
-              :version, :all_versions, :other_versions, :most_recent, :version_independent_id, \
+              :version, :all_versions, :most_recent, :version_independent_id, \
               :questions, :created_at, :updated_at, :parent
 json.url response_set_url(response_set, format: :json)

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "redux-devtools": "^3.3.1",
     "redux-logger": "^2.7.4",
     "redux-promise-middleware": "^4.2.0",
+    "reselect": "^2.5.4",
     "resolve-url-loader": "^1.6.0",
     "sass-loader": "^4.0.2",
     "stats-webpack-plugin": "^0.2.1",

--- a/test/frontend/components/errors_test.js
+++ b/test/frontend/components/errors_test.js
@@ -1,0 +1,21 @@
+import {
+  expect,
+  renderComponent
+} from '../test_helper';
+import Errors from '../../../webpack/components/Errors';
+
+describe('Errors', () => {
+  let component;
+
+  beforeEach(() => {
+    const errors = {
+      oid: ['must be unique'],
+      name: ['too short', 'not jazzy enough']
+    };
+    component = renderComponent(Errors, {errors});
+  });
+
+  it('should display the correct number of errors', () => {
+    expect(component.find('h2')).to.contain('3 error(s) prohibited the form from being saved.');
+  });
+});

--- a/test/frontend/components/errors_test.js
+++ b/test/frontend/components/errors_test.js
@@ -16,6 +16,6 @@ describe('Errors', () => {
   });
 
   it('should display the correct number of errors', () => {
-    expect(component.find('h2')).to.contain('3 error(s) prohibited the form from being saved.');
+    expect(component.find('h2')).to.contain('3 error(s) prohibited this form from being saved');
   });
 });

--- a/test/frontend/components/version_info_test.js
+++ b/test/frontend/components/version_info_test.js
@@ -1,0 +1,32 @@
+import { expect, renderComponent } from '../test_helper';
+import VersionInfo from '../../../webpack/components/VersionInfo';
+
+describe('VersionInfo', () => {
+  let component;
+
+  beforeEach(() => {
+    const responseSet = {
+      id: 3,
+      name: 'Test',
+      version: 3,
+      mostRecent: 4,
+      createdAt: new Date(),
+      allVersions: [
+        {id: 1, name: 'Test', version: 1, mostRecent: 4, createdAt: new Date()},
+        {id: 2, name: 'Test', version: 2, mostRecent: 4, createdAt: new Date()},
+        {id: 3, name: 'Test', version: 3, mostRecent: 4, createdAt: new Date()},
+        {id: 4, name: 'Test', version: 4, mostRecent: 4, createdAt: new Date()},
+      ]
+    };
+    component = renderComponent(VersionInfo, {versionable: responseSet, versionableType: 'responseSet'});
+  });
+
+  it('should create a list of versions', () => {
+    expect(component.find("li").length).to.equal(4);
+  });
+
+  it('should show the currently selected version', () => {
+    expect(component.find("li:nth-child(3)")).to.contain('(Currently Selected)');
+  });
+
+});

--- a/test/frontend/selectors/test_response_set_selectors.js
+++ b/test/frontend/selectors/test_response_set_selectors.js
@@ -1,0 +1,18 @@
+import { expect } from '../test_helper';
+import { getMostRecentResponseSets } from '../../../webpack/selectors/response_set_selectors';
+
+describe('getMostRecentResponseSets', () => {
+  it('should only show the most recent versions of response sets', () => {
+    const state = {responseSets: {
+      1: {name: 'Old', version: 1, mostRecent: 2},
+      2: {name: 'New', version: 2, mostRecent: 2},
+      3: {name: 'Thingy', version: 5, mostRecent: 5},
+      4: {name: 'Old Things', version: 2, mostRecent: 5}
+    }};
+    const mr = getMostRecentResponseSets(state);
+    expect(mr[1]).to.be.undefined;
+    expect(mr[2].name).to.equal('New');
+    expect(mr[3].name).to.equal('Thingy');
+    expect(mr[4]).to.be.undefined;
+  });
+});

--- a/webpack/actions/response_set_actions.js
+++ b/webpack/actions/response_set_actions.js
@@ -27,14 +27,18 @@ export function fetchResponseSet(id) {
   };
 }
 
-export function saveResponseSet(responseSet, callback=null) {
+export function saveResponseSet(responseSet, successHandler=null, failureHandler=null) {
   const authenticityToken = getCSRFToken();
   const postPromise = axios.post(routes.responseSetsPath(),
                       {responseSet, authenticityToken},
                       {headers: {'X-Key-Inflection': 'camel', 'Accept': 'application/json'}});
-  if (callback) {
-    postPromise.then(callback);
+  if (failureHandler) {
+    postPromise.catch(failureHandler);
   }
+  if (successHandler) {
+    postPromise.then(successHandler);
+  }
+
   return {
     type: SAVE_RESPONSE_SET,
     payload: postPromise

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -7,19 +7,21 @@ export default class Errors extends Component {
         <div id="error_explanation">
           <h2>{this.errorCount()} error(s) prohibited this form from being saved:</h2>
           <ul>
-          {_.forOwn(this.props.errors, (field) => {
-            return _.map(this.props.errors[field], (e) => {
-              return <li>{field} - {e}</li>;
-            });
-          })}
+          {_.map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
           </ul>
         </div>
       );
+    } else {
+      return <div id="error_explanation" />;
     }
   }
 
   errorCount() {
-    return _.reduce(_.values(this.props.errors), 'length', 0);
+    return _.reduce(_.values(this.props.errors), (sum, v) => sum + v.length, 0);
+  }
+
+  errorList() {
+    return _.flatten(_.values(this.props.errors));
   }
 }
 

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -1,0 +1,28 @@
+import React, { Component, PropTypes } from 'react';
+import _ from 'lodash';
+export default class Errors extends Component {
+  render() {
+    if (_.keys(this.props.errors).length > 0) {
+      return (
+        <div id="error_explanation">
+          <h2>{this.errorCount()} error(s) prohibited this form from being saved:</h2>
+          <ul>
+          {_.forOwn(this.props.errors, (field) => {
+            return _.map(this.props.errors[field], (e) => {
+              return <li>{field} - {e}</li>;
+            });
+          })}
+          </ul>
+        </div>
+      );
+    }
+  }
+
+  errorCount() {
+    return _.reduce(_.values(this.props.errors), 'length', 0);
+  }
+}
+
+Errors.propTypes = {
+  errors: PropTypes.objectOf(PropTypes.array)
+};

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 
 import CodedSetTableForm from './CodedSetTableForm';
+import Errors from './Errors';
 import { responseSetProps } from '../prop-types/response_set_props';
 
 export default class ResponseSetForm extends Component {
@@ -55,6 +56,7 @@ export default class ResponseSetForm extends Component {
   render() {
     return (
       <form onSubmit={(e) => this.handleSubmit(e)}>
+        <Errors errors={this.state.errors} />
         <div className="row">
           <div className="row">
             <div className="col-md-4">
@@ -98,13 +100,10 @@ export default class ResponseSetForm extends Component {
 
   handleSubmit(event) {
     event.preventDefault();
-    this.props.responseSetSubmitter(this.state, (response) => {
-      // TODO: Handle when the saving response set fails.
-      if (response.status === 201) {
-        this.props.router.push(`/responseSets/${response.data.id}`);
-      } else {
-        // update state
-      }
+    this.props.responseSetSubmitter(this.state, (successResponse) => {
+      this.props.router.push(`/responseSets/${successResponse.data.id}`);
+    }, (failureResponse) => {
+      this.setState({errors: failureResponse.response.data});
     });
   }
 

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -91,11 +91,16 @@ export default class ResponseSetForm extends Component {
                              childName={'response'} />
 
           <div className="actions">
-            <input type="submit" value={`${this.props.action} Response Set`}/>
+            <input type="submit" value={`${this.actionWord()} Response Set`}/>
           </div>
         </div>
       </form>
     );
+  }
+
+  actionWord() {
+    const wordMap = {'new': 'Create', 'revise': 'Revise', 'extend': 'Extend'};
+    return wordMap[this.props.action];
   }
 
   handleSubmit(event) {

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -102,6 +102,8 @@ export default class ResponseSetForm extends Component {
       // TODO: Handle when the saving response set fails.
       if (response.status === 201) {
         this.props.router.push(`/responseSets/${response.data.id}`);
+      } else {
+        // update state
       }
     });
   }

--- a/webpack/components/VersionInfo.js
+++ b/webpack/components/VersionInfo.js
@@ -6,28 +6,15 @@ export default class VersionInfo extends Component {
 
   render() {
     const {versionable} = this.props;
-    if(!versionable.otherVersions || versionable.otherVersions.length < 1){
+    if(!versionable.allVersions || versionable.allVersions.length < 1){
       return null;
-    }
-    var mostRecent = '';
-    if(versionable.mostRecent){
-      mostRecent = (
-        <p>
-          <strong>Most Recent Version: </strong>
-          {versionable.version} (Currently Selected)
-        </p>
-      );
-    }else{
-      mostRecent = (
-        <p>
-          <strong>Most Recent Version: </strong>
-          {versionable.mostRecent} (Currently Selected)
-        </p>
-      );
     }
     return (
       <div>
-        {mostRecent}
+        <p>
+          <strong>Most Recent Version: </strong>
+          {versionable.mostRecent} {versionable.version === versionable.mostRecent ? '(Currently Selected)' : ''}
+        </p>
         <p>
           <strong>Versions:</strong>
         </p>

--- a/webpack/containers/QuestionEditContainer.js
+++ b/webpack/containers/QuestionEditContainer.js
@@ -9,6 +9,7 @@ import { responseSetsProps }  from '../prop-types/response_set_props';
 import { fetchResponseTypes } from '../actions/response_type_actions';
 import { fetchQuestionTypes } from '../actions/question_type_actions';
 import { fetchResponseSets }  from '../actions/response_set_actions';
+import { getMostRecentResponseSets } from '../selectors/response_set_selectors';
 
 class QuestionEditContainer extends Component {
   componentWillMount() {
@@ -49,7 +50,7 @@ function mapStateToProps(state, ownProps) {
   }
   props.questionTypes = state.questionTypes;
   props.responseTypes = state.responseTypes;
-  props.responseSets  = state.responseSets;
+  props.responseSets  = getMostRecentResponseSets(state);
   return props;
 }
 

--- a/webpack/containers/ResponseSetsContainer.js
+++ b/webpack/containers/ResponseSetsContainer.js
@@ -6,6 +6,7 @@ import ResponseSetList from '../components/ResponseSetList';
 import ResponseSetListSearch from '../components/ResponseSetListSearch';
 import Routes from '../routes';
 import { responseSetProps } from '../prop-types/response_set_props';
+import { getMostRecentResponseSets } from '../selectors/response_set_selectors';
 
 class ResponseSetsContainer extends Component {
   constructor(props) {
@@ -41,7 +42,7 @@ class ResponseSetsContainer extends Component {
 
 function mapStateToProps(state) {
   return {
-    responseSets: state.responseSets
+    responseSets: getMostRecentResponseSets(state)
   };
 }
 

--- a/webpack/selectors/response_set_selectors.js
+++ b/webpack/selectors/response_set_selectors.js
@@ -1,0 +1,10 @@
+import { createSelector } from 'reselect';
+import _ from 'lodash';
+
+const getResponseSets = (state) => state.responseSets;
+
+export const getMostRecentResponseSets = createSelector(
+  getResponseSets, (responseSets) => {
+    return _.pickBy(responseSets, (rs) => rs.mostRecent === rs.version);
+  }
+);


### PR DESCRIPTION
Please review #103 before this PR.

Previously, the response set index page and the question edit pages
would show all versions of response sets. This commit narrows those
pages down to just the most recent version of each response set.

This uses selectors, via the reselect library, to filter down the
redux state.

This commit also cleans up and tests the VersionInfo component. It
previously relied on the allVersions and otherVersions properties.
It now relies only on allVersions. otherVersions were removed from
the server side JSON response to minimize the amount of data being
sent around.

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed overcommit hooks, including running all code through Rubocop

