### PR TITLE
SDP-313 Elastic search

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -48,5 +48,8 @@ Metrics/PerceivedComplexity:
 
 Style/GuardClause:
   Enabled: false
+Style/ClassVars:
+  Exclude: 
+    - 'config/initializers/elastic_search.rb'
 #Style/HashSyntax:
 #  UseHashRocketsWithSymbolValues: true

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'js-routes'
 gem 'acts_as_tree'
 gem 'acts_as_commentable'
 gem 'omniauth_openid_connect'
-
+gem 'elasticsearch'
 gem 'config'
 
 group :development, :test do

--- a/Gemfile
+++ b/Gemfile
@@ -32,8 +32,9 @@ gem 'acts_as_commentable'
 gem 'omniauth_openid_connect'
 gem 'elasticsearch'
 gem 'config'
-gem 'fakeweb', '~> 1.3'
+
 group :development, :test do
+  gem 'fakeweb', '~> 1.3'
   gem 'rubocop', '~> 0.44.1', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ gem 'acts_as_commentable'
 gem 'omniauth_openid_connect'
 gem 'elasticsearch'
 gem 'config'
-
+gem 'fakeweb', '~> 1.3'
 group :development, :test do
   gem 'rubocop', '~> 0.44.1', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,8 +125,18 @@ GEM
     diff-lcs (1.2.5)
     docile (1.1.5)
     dumb_delegator (0.8.0)
+    elasticsearch (5.0.1)
+      elasticsearch-api (= 5.0.1)
+      elasticsearch-transport (= 5.0.1)
+    elasticsearch-api (5.0.1)
+      multi_json
+    elasticsearch-transport (5.0.1)
+      faraday
+      multi_json
     equalizer (0.0.11)
     erubis (2.7.0)
+    faraday (0.11.0)
+      multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
     foreman (0.82.0)
       thor (~> 0.19.1)
@@ -181,6 +191,7 @@ GEM
       metaclass (~> 0.0.1)
     multi_json (1.12.1)
     multi_test (0.1.2)
+    multipart-post (2.0.0)
     nio4r (1.2.1)
     nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
@@ -369,6 +380,7 @@ DEPENDENCIES
   cucumber-rails
   database_cleaner!
   devise (~> 4.2.0)
+  elasticsearch
   foreman
   jbuilder (~> 2.5)
   js-routes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,7 @@ GEM
       multi_json
     equalizer (0.0.11)
     erubis (2.7.0)
+    fakeweb (1.3.0)
     faraday (0.11.0)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.14)
@@ -381,6 +382,7 @@ DEPENDENCIES
   database_cleaner!
   devise (~> 4.2.0)
   elasticsearch
+  fakeweb (~> 1.3)
   foreman
   jbuilder (~> 2.5)
   js-routes

--- a/app/jobs/delete_from_index_job.rb
+++ b/app/jobs/delete_from_index_job.rb
@@ -1,0 +1,16 @@
+class DeleteFromIndex < ApplicationJob
+  queue_as :default
+
+  def perform(type, id)
+    # call elasticsearch
+    exists = Vocabulary::Elasticsearch.client.exists? index: 'vocabulary',
+                                                      type: type.underscore,
+                                                      id: id
+
+    if exists
+      Vocabulary::Elasticsearch.client.delete index: 'vocabulary',
+                                              type: type.underscore,
+                                              id: data[:id]
+    end
+  end
+end

--- a/app/jobs/delete_from_index_job.rb
+++ b/app/jobs/delete_from_index_job.rb
@@ -6,7 +6,7 @@ class DeleteFromIndexJob < ApplicationJob
     # call elasticsearch
     SDP::Elasticsearch.with_client do |client|
       if client.exists?(index: 'vocabulary', type: type.underscore, id: id)
-        client.delete index: 'vocabulary', type: type.underscore, id: data[:id]
+        client.delete index: 'vocabulary', type: type.underscore, id: id
       end
     end
   end

--- a/app/jobs/delete_from_index_job.rb
+++ b/app/jobs/delete_from_index_job.rb
@@ -1,16 +1,13 @@
-class DeleteFromIndex < ApplicationJob
+require 'sdp/elastic_search'
+class DeleteFromIndexJob < ApplicationJob
   queue_as :default
 
   def perform(type, id)
     # call elasticsearch
-    exists = Vocabulary::Elasticsearch.client.exists? index: 'vocabulary',
-                                                      type: type.underscore,
-                                                      id: id
-
-    if exists
-      Vocabulary::Elasticsearch.client.delete index: 'vocabulary',
-                                              type: type.underscore,
-                                              id: data[:id]
+    SDP::Elasticsearch.with_client do |client|
+      if client.exists?(index: 'vocabulary', type: type.underscore, id: id)
+        client.delete index: 'vocabulary', type: type.underscore, id: data[:id]
+      end
     end
   end
 end

--- a/app/jobs/sync_index_job.rb
+++ b/app/jobs/sync_index_job.rb
@@ -1,0 +1,7 @@
+require 'sdp/elastic_search'
+class SyncIndexJob < ApplicationJob
+  queue_as :default
+  def perform
+    SDP::Elasticsearch.sync
+  end
+end

--- a/app/jobs/update_index_job.rb
+++ b/app/jobs/update_index_job.rb
@@ -1,21 +1,15 @@
+require 'sdp/elastic_search'
 class UpdateIndexJob < ApplicationJob
   queue_as :default
 
   def perform(type, data)
     # call elasticsearch
-    exists = Vocabulary::Elasticsearch.client.exists? index: 'vocabulary',
-                                                      type: type.underscore,
-                                                      id: data[:id]
-    if exists
-      Vocabulary::Elasticsearch.client.update index: 'vocabulary',
-                                              type: type.underscore,
-                                              id: data[:id],
-                                              body: { doc: data }
-    else
-      Vocabulary::Elasticsearch.client.create index: 'vocabulary',
-                                              type: type.underscore,
-                                              id: data[:id],
-                                              body:  data
+    SDP::Elasticsearch.with_client do |client|
+      if client.exists? index: 'vocabulary', type: type.underscore, id: data[:id]
+        client.update index: 'vocabulary', type: type.underscore, id: data[:id], body: { doc: data }
+      else
+        client.create index: 'vocabulary', type: type.underscore, id: data[:id], body: data
+      end
     end
   end
 end

--- a/app/jobs/update_index_job.rb
+++ b/app/jobs/update_index_job.rb
@@ -1,0 +1,21 @@
+class UpdateIndexJob < ApplicationJob
+  queue_as :default
+
+  def perform(type, data)
+    # call elasticsearch
+    exists = Vocabulary::Elasticsearch.client.exists? index: 'vocabulary',
+                                                      type: type.underscore,
+                                                      id: data[:id]
+    if exists
+      Vocabulary::Elasticsearch.client.update index: 'vocabulary',
+                                              type: type.underscore,
+                                              id: data[:id],
+                                              body: { doc: data }
+    else
+      Vocabulary::Elasticsearch.client.create index: 'vocabulary',
+                                              type: type.underscore,
+                                              id: data[:id],
+                                              body:  data
+    end
+  end
+end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -14,11 +14,11 @@ class Form < ApplicationRecord
                                            unless: proc { |f| f.version > 1 && f.other_versions.map(&:control_number).include?(f.control_number) } }
 
   after_save do |form|
-    UpdateIndexJob.perform_async('form', ESFormSerializer.new(form))
+    UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
   end
 
-  after_delete do |form|
-    DeleteFromIndexJob.perform_async('form', form.id)
+  after_destroy do |form|
+    DeleteFromIndexJob.perform_later('form', form.id)
   end
   # Builds a new Form object with the same version_independent_id. Increments
   # the version by one and builds a new set of Response objects to go with it.

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -13,13 +13,17 @@ class Form < ApplicationRecord
                              uniqueness: { message: 'forms should have different OMB Control Numbers',
                                            unless: proc { |f| f.version > 1 && f.other_versions.map(&:control_number).include?(f.control_number) } }
 
-  after_save do |form|
-    UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
+  after_commit :index, on: [:create, :update]
+  after_commit :delete_index, on: :destroy
+
+  def index
+    UpdateIndexJob.perform_later('form', ESFormSerializer.new(self).as_json)
   end
 
-  after_destroy do |form|
-    DeleteFromIndexJob.perform_later('form', form.id)
+  def delete_index
+    DeleteFromIndexJob.perform_later('form', id)
   end
+
   # Builds a new Form object with the same version_independent_id. Increments
   # the version by one and builds a new set of Response objects to go with it.
   def build_new_revision

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -3,13 +3,11 @@ class FormQuestion < ApplicationRecord
   belongs_to :question
   belongs_to :response_set
 
-  after_destroy do |fq|
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question).as_json)
-    UpdateIndexJob.perform_later('response_set', ESQuestionSerializer.new(fq.response_set).as_json) if fq.response_set
-  end
+  after_commit :reindex, on: [:create, :update]
+  after_commit :delete_index, on: :destroy
 
-  after_save do |fq|
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question))
-    UpdateIndexJob.perform_later('response_set', ESQuestionSerializer.new(fq.response_set).as_json) if fq.response_set
+  def reindex
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json)
+    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json) if response_set
   end
 end

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -3,13 +3,13 @@ class FormQuestion < ApplicationRecord
   belongs_to :question
   belongs_to :response_set
 
-  after_delete do |fq|
-    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(fq.question))
-    UpdateIndexJob.perform_async('response_set', ESQuestionSerializer.new(fq.response_set)) if fq.response_set
+  after_destroy do |fq|
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question).as_json)
+    UpdateIndexJob.perform_later('response_set', ESQuestionSerializer.new(fq.response_set).as_json) if fq.response_set
   end
 
   after_save do |fq|
-    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(fq.question))
-    UpdateIndexJob.perform_async('response_set', ESQuestionSerializer.new(fq.response_set)) if fq.response_set
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question))
+    UpdateIndexJob.perform_later('response_set', ESQuestionSerializer.new(fq.response_set).as_json) if fq.response_set
   end
 end

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -2,4 +2,14 @@ class FormQuestion < ApplicationRecord
   belongs_to :form
   belongs_to :question
   belongs_to :response_set
+
+  after_delete do |fq|
+    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(fq.question))
+    UpdateIndexJob.perform_async('response_set', ESQuestionSerializer.new(fq.response_set)) if fq.response_set
+  end
+
+  after_save do |fq|
+    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(fq.question))
+    UpdateIndexJob.perform_async('response_set', ESQuestionSerializer.new(fq.response_set)) if fq.response_set
+  end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -17,11 +17,11 @@ class Question < ApplicationRecord
   accepts_nested_attributes_for :concepts, allow_destroy: true
 
   after_save do |question|
-    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(question))
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json)
   end
 
-  after_delete do |question|
-    DeleteFromIndexJob.perform_async('question', question.id)
+  after_destroy do |question|
+    DeleteFromIndexJob.perform_later('question', question.id)
   end
 
   def self.search(search)

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -16,6 +16,14 @@ class Question < ApplicationRecord
   validates :content, presence: true
   accepts_nested_attributes_for :concepts, allow_destroy: true
 
+  after_save do |question|
+    UpdateIndexJob.perform_async('question', ESQuestionSerializer.new(question))
+  end
+
+  after_delete do |question|
+    DeleteFromIndexJob.perform_async('question', question.id)
+  end
+
   def self.search(search)
     where('content ILIKE ?', "%#{search}%")
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -14,6 +14,14 @@ class ResponseSet < ApplicationRecord
 
   accepts_nested_attributes_for :responses, allow_destroy: true
 
+  after_save do |form|
+    UpdateIndexJob.perform_async('form', ESFormSerializer.new(form))
+  end
+
+  after_delete do |form|
+    DeleteFromIndexJob.perform_async('form', form.id)
+  end
+
   def self.search(search)
     where('name ILIKE ?', "%#{search}%")
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -15,11 +15,11 @@ class ResponseSet < ApplicationRecord
   accepts_nested_attributes_for :responses, allow_destroy: true
 
   after_save do |form|
-    UpdateIndexJob.perform_async('form', ESFormSerializer.new(form))
+    UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
   end
 
-  after_delete do |form|
-    DeleteFromIndexJob.perform_async('form', form.id)
+  after_destroy do |form|
+    DeleteFromIndexJob.perform_later('form', form.id)
   end
 
   def self.search(search)

--- a/app/serializers/code_serializer.rb
+++ b/app/serializers/code_serializer.rb
@@ -1,0 +1,7 @@
+include ActiveModel::Serialization
+
+class CodeSerializer < ActiveModel::Serializer
+  attribute :value, key: 'code'
+  attribute :code_system, 'codeSystem'
+  attribute :display_name, key: 'displayName'
+end

--- a/app/serializers/code_serializer.rb
+++ b/app/serializers/code_serializer.rb
@@ -2,6 +2,6 @@ include ActiveModel::Serialization
 
 class CodeSerializer < ActiveModel::Serializer
   attribute :value, key: 'code'
-  attribute :code_system, 'codeSystem'
+  attribute :code_system, key: 'codeSystem'
   attribute :display_name, key: 'displayName'
 end

--- a/app/serializers/es_form_serializer.rb
+++ b/app/serializers/es_form_serializer.rb
@@ -33,7 +33,7 @@ class ESFormSerializer < ActiveModel::Serializer
       { id: fq.question_id,
         name: fq.question.content,
         codes: (fq.question.concepts || []).collect { |c| CodeSerializer.new(c).as_json },
-        response_set: fq.response_set.name,
+        response_set: fq.response_set.try(:name),
         response_set_id: fq.response_set_id }
     end
   end

--- a/app/serializers/es_form_serializer.rb
+++ b/app/serializers/es_form_serializer.rb
@@ -8,22 +8,31 @@ class ESFormSerializer < ActiveModel::Serializer
   attribute :status
   attribute :category
   attribute :description
-  attribute :createdAt
-  attribute :updatedAt
+  attribute :updated_at, key: :updatedAt
+  attribute :created_at, key: :createdAt
   attribute :suggest
-  attribute :updatedBy
-  attribute :createdBy
+  attribute :updated_by, key: :updatedBy
+  attribute :created_by, key: :createdBy
   attribute :questions
+  attribute(:codes) { codes }
 
   def codes
-    object.codes.collect { |c| CodeSerializer.new(c) }
+    [] # object.concepts.collect { |c| CodeSerializer.new(c).as_json }
+  end
+
+  def updated_at
+    object.updated_at.as_json if object.updated_at
+  end
+
+  def created_at
+    object.created_at.as_json if object.created_at
   end
 
   def questions
     object.form_questions.collect do |fq|
       { id: fq.question_id,
         name: fq.question.content,
-        codes: question_codes(fq.question.codes),
+        codes: (fq.question.concepts || []).collect { |c| CodeSerializer.new(c).as_json },
         response_set: fq.response_set.name,
         response_set_id: fq.response_set_id }
     end
@@ -31,5 +40,23 @@ class ESFormSerializer < ActiveModel::Serializer
 
   def suggest
     object.name
+  end
+
+  def category
+  end
+
+  def description
+  end
+
+  def status
+    'draft'
+  end
+
+  def updated_by
+    # UserSerializer.new(object.updated_by).as_json if object.updated_by
+  end
+
+  def created_by
+    UserSerializer.new(object.created_by).as_json if object.created_by
   end
 end

--- a/app/serializers/es_form_serializer.rb
+++ b/app/serializers/es_form_serializer.rb
@@ -1,0 +1,35 @@
+include ActiveModel::Serialization
+
+class ESFormSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :name
+  attribute :version_independent_id
+  attribute :version
+  attribute :status
+  attribute :category
+  attribute :description
+  attribute :createdAt
+  attribute :updatedAt
+  attribute :suggest
+  attribute :updatedBy
+  attribute :createdBy
+  attribute :questions
+
+  def codes
+    object.codes.collect { |c| CodeSerializer.new(c) }
+  end
+
+  def questions
+    object.form_questions.collect do |fq|
+      { id: fq.question_id,
+        name: fq.question.content,
+        codes: question_codes(fq.question.codes),
+        response_set: fq.response_set.name,
+        response_set_id: fq.response_set_id }
+    end
+  end
+
+  def suggest
+    object.name
+  end
+end

--- a/app/serializers/es_question_serializer.rb
+++ b/app/serializers/es_question_serializer.rb
@@ -8,13 +8,13 @@ class ESQuestionSerializer < ActiveModel::Serializer
   attribute :status
   attribute :category
   attribute :description
-  attribute :created_at, key: :createdAt
   attribute :updated_at, key: :updatedAt
+  attribute :created_at, key: :createdAt
   attribute :suggest
   attribute :updated_by, key: :updatedBy
   attribute :created_by, key: :createdBy
   attribute :response_sets, key: :responseSets
-  attribute :codes
+  attribute(:codes) { codes }
   attribute :forms
 
   def forms
@@ -46,6 +46,14 @@ class ESQuestionSerializer < ActiveModel::Serializer
   end
 
   def description
+  end
+
+  def updated_at
+    object.updated_at.as_json if object.updated_at
+  end
+
+  def created_at
+    object.created_at.as_json if object.created_at
   end
 
   def updated_by

--- a/app/serializers/es_question_serializer.rb
+++ b/app/serializers/es_question_serializer.rb
@@ -1,0 +1,58 @@
+include ActiveModel::Serialization
+
+class ESQuestionSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :content, key: :name
+  attribute :version_independent_id
+  attribute :version
+  attribute :status
+  attribute :category
+  attribute :description
+  attribute :created_at, key: :createdAt
+  attribute :updated_at, key: :updatedAt
+  attribute :suggest
+  attribute :updated_by, key: :updatedBy
+  attribute :created_by, key: :createdBy
+  attribute :response_sets, key: :responseSets
+  attribute :codes
+  attribute :forms
+
+  def forms
+    object.form_questions.collect do |fq|
+      { id: fq.form.id, name: fq.form.name }
+    end
+  end
+
+  def codes
+    object.concepts.collect { |c| CodeSerializer.new(c).as_json }
+  end
+
+  def response_sets
+    object.response_sets.collect do |rs|
+      { id: rs.id, name: rs.name }
+    end
+  end
+
+  def suggest
+    object.content
+  end
+
+  def category
+    object.question_type.name if object.question_type
+  end
+
+  def status
+    'draft'
+  end
+
+  def description
+  end
+
+  def updated_by
+    UserSerializer.new(object.updated_by).as_json if object.updated_by
+  end
+
+  def created_by
+    UserSerializer.new(object.created_by).as_json if object.created_by
+  end
+end

--- a/app/serializers/es_response_set_serializer.rb
+++ b/app/serializers/es_response_set_serializer.rb
@@ -1,0 +1,38 @@
+include ActiveModel::Serialization
+
+class ESResponseSetSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :name
+  attribute :version_independent_id
+  attribute :version
+  attribute :status
+  attribute :category
+  attribute :description
+  attribute :createdAt
+  attribute :updatedAt
+  attribute :suggest
+  attribute :updatedBy
+  attribute :createdBy
+  attribute :questions
+  attribute :codes
+
+  def codes
+    object.responses.collect { |c| CodeSerializer.new(c) }
+  end
+
+  def forms
+    object.form_questions.collect do |fq|
+      { id: fq.form.id, name: fq.form.name }
+    end
+  end
+
+  def questions
+    object.form_questions.collect do |fq|
+      { id: fq.question_id, name: fq.question_content }
+    end
+  end
+
+  def suggest
+    object.name
+  end
+end

--- a/app/serializers/es_response_set_serializer.rb
+++ b/app/serializers/es_response_set_serializer.rb
@@ -8,16 +8,24 @@ class ESResponseSetSerializer < ActiveModel::Serializer
   attribute :status
   attribute :category
   attribute :description
-  attribute :createdAt
-  attribute :updatedAt
+  attribute :updated_at, key: :updatedAt
+  attribute :created_at, key: :createdAt
   attribute :suggest
-  attribute :updatedBy
-  attribute :createdBy
+  attribute :updated_by, key: :updatedBy
+  attribute :created_by, key: :createdBy
   attribute :questions
   attribute :codes
 
   def codes
-    object.responses.collect { |c| CodeSerializer.new(c) }
+    object.responses.collect { |c| CodeSerializer.new(c).as_json }
+  end
+
+  def updated_at
+    object.updated_at.as_json if object.updated_at
+  end
+
+  def created_at
+    object.created_at.as_json if object.created_at
   end
 
   def forms
@@ -28,11 +36,26 @@ class ESResponseSetSerializer < ActiveModel::Serializer
 
   def questions
     object.form_questions.collect do |fq|
-      { id: fq.question_id, name: fq.question_content }
+      { id: fq.question_id, name: fq.question.content }
     end
   end
 
   def suggest
     object.name
+  end
+
+  def category
+  end
+
+  def status
+    'draft'
+  end
+
+  def updated_by
+    UserSerializer.new(object.updated_by).as_json if object.updated_by
+  end
+
+  def created_by
+    UserSerializer.new(object.created_by).as_json if object.created_by
   end
 end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,7 @@
+include ActiveModel::Serialization
+
+class UserSerializer < ActiveModel::Serializer
+  attribute :id
+  attribute :email
+  attribute :full_name, key: :name
+end

--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -1,0 +1,11 @@
+
+require 'elasticsearch'
+
+module Vocabulary
+  module Elasticsearch
+    @@client = ::Elasticsearch::Client.new Settings.elasticsearch
+    def self.client
+      @@client
+    end
+  end
+end

--- a/config/initializers/elastic_search.rb
+++ b/config/initializers/elastic_search.rb
@@ -3,7 +3,12 @@ require 'elasticsearch'
 
 module Vocabulary
   module Elasticsearch
-    @@client = ::Elasticsearch::Client.new Settings.elasticsearch
+    client_opts = Settings.elasticsearch
+    # this is required to allow updating the adapter used by faraday
+    # the argument is a symbol to the client so we need to change it
+    # to make sure it works -- really required for testing using fake web
+    client_opts[:adapter] = client_opts['adapter']
+    @@client = ::Elasticsearch::Client.new client_opts
     def self.client
       @@client
     end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -18,3 +18,6 @@ oid_prefix:
   Form: '2.16.840.1.113883.3.1502.1'
   Question: '2.16.840.1.113883.3.1502.2'
   ResponseSet: '2.16.840.1.113883.3.1502.3'
+
+elasticsearch:
+  log: false

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,1 +1,3 @@
 default_url_helper_host: "localhost:3000"
+elasticsearch:
+  log: true

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,1 +1,3 @@
 default_url_helper_host: <%= ENV['RAILS_URL_HELPER_HOST']
+elasticsearch:
+  log: false

--- a/config/settings/test.yml
+++ b/config/settings/test.yml
@@ -1,1 +1,5 @@
 default_url_helper_host: "localhost:3000"
+elasticsearch:
+  log: false
+  host: http://example.com:9200
+  adapter: :net_http

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -28,187 +28,316 @@
   "mappings": {
     "question": {
       "properties": {
-        "suggest" : {"type" : "completion"},
-        "id" :{"type" : "string"},
-        "version_independent_id" : {"type" : "string"},
-        "version" : {"type" : "string"},
-        "status" :{"type" : "string"},
-        "category":{"type" : "string"},
-        "name" : {"type" : "string",
+        "suggest": {
+          "type": "completion"
+        },
+        "id": {
+          "type": "string"
+        },
+        "version_independent_id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
           "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "description" : {"type" : "string",
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "description": {
+          "type": "string",
           "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "createdAt" :{"type" : "date"},
-        "updatedAt" :{"type" : "date"},
-        "createdBy":{
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "createdAt": {
+          "type": "date"
+        },
+        "updatedAt": {
+          "type": "date"
+        },
+        "createdBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "updatedBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "content": {
+          "type": "string"
+        },
+        "responseSets": {
           "type": "nested",
           "properties": {
-            "name" : {"type": "string"},
-            "email" : {"type": "string"},
-            "id" : {"type": "string"}
+            "id": {
+              "type": "string"
+            },
+            "name": {
+              "type": "string"
+            }
           }
-         },
-         "updatedBy":{
-           "type": "nested",
-           "properties": {
-             "name" : {"type": "string"},
-             "email" : {"type": "string"},
-             "id" : {"type": "string"}
-           }
-          },
-        "content": {"type" : "string"},
-        "responseSets":{
-          "type" : "nested",
-           "properties" :{
-             "id" : {"type" : "string"},
-             "name" : {"type" : "string"}
-             }},
+        },
         "codes": {
           "type": "nested",
           "properties": {
-            "code":    { "type": "string"  },
-            "displayName": { "type": "string"  },
-            "codeSystem":     { "type": "string"   },
-            "codeSystemOid":   { "type": "string"   },
-            "date":    { "type": "date"    }
-          }
-        }
-      }
-    },
-    "form":{
-      "properties" :{
-        "suggest" : {"type" : "completion"},
-        "id" :{"type" : "string"},
-        "version_independent_id" : {"type" : "string"},
-        "version" : {"type" : "string"},
-        "status" :{"type" : "string"},
-        "category":{"type" : "string"},
-        "name" : {"type" : "string",
-          "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "description" : {"type" : "string",
-          "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "createdAt" :{"type" : "date"},
-        "updatedAt" :{"type" : "date"},
-        "createdBy":{
-          "type": "nested",
-          "properties": {
-            "name" : {"type": "string"},
-            "email" : {"type": "string"},
-            "id" : {"type": "string"}
-          }
-         },
-         "updatedBy":{
-           "type": "nested",
-           "properties": {
-             "name" : {"type": "string"},
-             "email" : {"type": "string"},
-             "id" : {"type": "string"}
-           }
-          },
-        "questions" : {
-          "type" : "nested",
-          "properties":{
-            "content":{"type" : "string"},
-            "responseSet":{"type" : "string"},
-            "id" : {"type" : "string"}
-          }
-        }
-      }
-    },
-    "responseSet":{
-      "properties" :{
-        "suggest" : {"type" : "completion"},
-        "id" :{"type" : "string"},
-        "version_independent_id" : {"type" : "string"},
-        "version" : {"type" : "string"},
-        "status" :{"type" : "string"},
-        "category":{"type" : "string"},
-        "name" : {"type" : "string",
-          "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "description" : {"type" : "string",
-          "fields": {
-              "trigram": {
-                "type": "text",
-                "analyzer": "trigram"
-              },
-              "reverse": {
-                "type": "text",
-                "analyzer": "reverse"
-              }
-            }},
-        "createdAt" :{"type" : "date"},
-        "updatedAt" :{"type" : "date"},
-        "createdBy":{
-          "type": "nested",
-          "properties": {
-            "name" : {"type": "string"},
-            "email" : {"type": "string"},
-            "id" : {"type": "string"}
-          }
-         },
-         "updatedBy":{
-           "type": "nested",
-           "properties": {
-             "name" : {"type": "string"},
-             "email" : {"type": "string"},
-             "id" : {"type": "string"}
-           }
-          },
-          "codes": {
-            "type": "nested",
-            "properties": {
-              "code":    { "type": "string"  },
-              "displayName": { "type": "string"  },
-              "codeSystem":     { "type": "string"   },
-              "codeSystemOid":   { "type": "string"   },
-              "date":    { "type": "date"    }
+            "code": {
+              "type": "string"
+            },
+            "displayName": {
+              "type": "string"
+            },
+            "codeSystem": {
+              "type": "string"
+            },
+            "codeSystemOid": {
+              "type": "string"
+            },
+            "date": {
+              "type": "date"
             }
           }
+        }
+      }
+    },
+    "form": {
+      "properties": {
+        "suggest": {
+          "type": "completion"
+        },
+        "id": {
+          "type": "string"
+        },
+        "version_independent_id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "fields": {
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "description": {
+          "type": "string",
+          "fields": {
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "createdAt": {
+          "type": "date"
+        },
+        "updatedAt": {
+          "type": "date"
+        },
+        "createdBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "updatedBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "questions": {
+          "type": "nested",
+          "properties": {
+            "content": {
+              "type": "string"
+            },
+            "responseSet": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "response_set": {
+      "properties": {
+        "suggest": {
+          "type": "completion"
+        },
+        "id": {
+          "type": "string"
+        },
+        "version_independent_id": {
+          "type": "string"
+        },
+        "version": {
+          "type": "string"
+        },
+        "status": {
+          "type": "string"
+        },
+        "category": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string",
+          "fields": {
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "description": {
+          "type": "string",
+          "fields": {
+            "trigram": {
+              "type": "text",
+              "analyzer": "trigram"
+            },
+            "reverse": {
+              "type": "text",
+              "analyzer": "reverse"
+            }
+          }
+        },
+        "createdAt": {
+          "type": "date"
+        },
+        "updatedAt": {
+          "type": "date"
+        },
+        "createdBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "updatedBy": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "email": {
+              "type": "string"
+            },
+            "id": {
+              "type": "string"
+            }
+          }
+        },
+        "codes": {
+          "type": "nested",
+          "properties": {
+            "code": {
+              "type": "string"
+            },
+            "displayName": {
+              "type": "string"
+            },
+            "codeSystem": {
+              "type": "string"
+            },
+            "codeSystemOid": {
+              "type": "string"
+            },
+            "date": {
+              "type": "date"
+            }
+          }
+        }
       }
     }
   }

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -1,15 +1,61 @@
 {
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "analysis": {
+        "analyzer": {
+          "trigram": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["standard", "shingle"]
+          },
+          "reverse": {
+            "type": "custom",
+            "tokenizer": "standard",
+            "filter": ["standard", "reverse"]
+          }
+        },
+        "filter": {
+          "shingle": {
+            "type": "shingle",
+            "min_shingle_size": 2,
+            "max_shingle_size": 3
+          }
+        }
+      }
+    }
+  },
   "mappings": {
     "question": {
       "properties": {
-        "completion" : {"type" : "completion"},
+        "suggest" : {"type" : "completion"},
         "id" :{"type" : "string"},
         "version_independent_id" : {"type" : "string"},
         "version" : {"type" : "string"},
         "status" :{"type" : "string"},
         "category":{"type" : "string"},
-        "name" : {"type" : "string"},
-        "description" : {"type" : "string"},
+        "name" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
+        "description" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
         "createdAt" :{"type" : "date"},
         "updatedAt" :{"type" : "date"},
         "createdBy":{
@@ -49,14 +95,34 @@
     },
     "form":{
       "properties" :{
-        "completion" : {"type" : "completion"},
+        "suggest" : {"type" : "completion"},
         "id" :{"type" : "string"},
         "version_independent_id" : {"type" : "string"},
         "version" : {"type" : "string"},
         "status" :{"type" : "string"},
         "category":{"type" : "string"},
-        "name" : {"type" : "string"},
-        "description" : {"type" : "string"},
+        "name" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
+        "description" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
         "createdAt" :{"type" : "date"},
         "updatedAt" :{"type" : "date"},
         "createdBy":{
@@ -87,14 +153,34 @@
     },
     "responseSet":{
       "properties" :{
-        "completion" : {"type" : "completion"},
+        "suggest" : {"type" : "completion"},
         "id" :{"type" : "string"},
         "version_independent_id" : {"type" : "string"},
         "version" : {"type" : "string"},
         "status" :{"type" : "string"},
         "category":{"type" : "string"},
-        "name" : {"type" : "string"},
-        "description" : {"type" : "string"},
+        "name" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
+        "description" : {"type" : "string",
+          "fields": {
+              "trigram": {
+                "type": "text",
+                "analyzer": "trigram"
+              },
+              "reverse": {
+                "type": "text",
+                "analyzer": "reverse"
+              }
+            }},
         "createdAt" :{"type" : "date"},
         "updatedAt" :{"type" : "date"},
         "createdBy":{

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -1,0 +1,129 @@
+{
+  "mappings": {
+    "question": {
+      "properties": {
+        "completion" : {"type" : "completion"},
+        "id" :{"type" : "string"},
+        "version_independent_id" : {"type" : "string"},
+        "version" : {"type" : "string"},
+        "status" :{"type" : "string"},
+        "category":{"type" : "string"},
+        "name" : {"type" : "string"},
+        "description" : {"type" : "string"},
+        "createdAt" :{"type" : "date"},
+        "updatedAt" :{"type" : "date"},
+        "createdBy":{
+          "type": "nested",
+          "properties": {
+            "name" : {"type": "string"},
+            "email" : {"type": "string"},
+            "id" : {"type": "string"}
+          }
+         },
+         "updatedBy":{
+           "type": "nested",
+           "properties": {
+             "name" : {"type": "string"},
+             "email" : {"type": "string"},
+             "id" : {"type": "string"}
+           }
+          },
+        "content": {"type" : "string"},
+        "responseSets":{
+          "type" : "nested",
+           "properties" :{
+             "id" : {"type" : "string"},
+             "name" : {"type" : "string"}
+             }},
+        "codes": {
+          "type": "nested",
+          "properties": {
+            "code":    { "type": "string"  },
+            "displayName": { "type": "string"  },
+            "codeSystem":     { "type": "string"   },
+            "codeSystemOid":   { "type": "string"   },
+            "date":    { "type": "date"    }
+          }
+        }
+      }
+    },
+    "form":{
+      "properties" :{
+        "completion" : {"type" : "completion"},
+        "id" :{"type" : "string"},
+        "version_independent_id" : {"type" : "string"},
+        "version" : {"type" : "string"},
+        "status" :{"type" : "string"},
+        "category":{"type" : "string"},
+        "name" : {"type" : "string"},
+        "description" : {"type" : "string"},
+        "createdAt" :{"type" : "date"},
+        "updatedAt" :{"type" : "date"},
+        "createdBy":{
+          "type": "nested",
+          "properties": {
+            "name" : {"type": "string"},
+            "email" : {"type": "string"},
+            "id" : {"type": "string"}
+          }
+         },
+         "updatedBy":{
+           "type": "nested",
+           "properties": {
+             "name" : {"type": "string"},
+             "email" : {"type": "string"},
+             "id" : {"type": "string"}
+           }
+          },
+        "questions" : {
+          "type" : "nested",
+          "properties":{
+            "content":{"type" : "string"},
+            "responseSet":{"type" : "string"},
+            "id" : {"type" : "string"}
+          }
+        }
+      }
+    },
+    "responseSet":{
+      "properties" :{
+        "completion" : {"type" : "completion"},
+        "id" :{"type" : "string"},
+        "version_independent_id" : {"type" : "string"},
+        "version" : {"type" : "string"},
+        "status" :{"type" : "string"},
+        "category":{"type" : "string"},
+        "name" : {"type" : "string"},
+        "description" : {"type" : "string"},
+        "createdAt" :{"type" : "date"},
+        "updatedAt" :{"type" : "date"},
+        "createdBy":{
+          "type": "nested",
+          "properties": {
+            "name" : {"type": "string"},
+            "email" : {"type": "string"},
+            "id" : {"type": "string"}
+          }
+         },
+         "updatedBy":{
+           "type": "nested",
+           "properties": {
+             "name" : {"type": "string"},
+             "email" : {"type": "string"},
+             "id" : {"type": "string"}
+           }
+          },
+          "codes": {
+            "type": "nested",
+            "properties": {
+              "code":    { "type": "string"  },
+              "displayName": { "type": "string"  },
+              "codeSystem":     { "type": "string"   },
+              "codeSystemOid":   { "type": "string"   },
+              "date":    { "type": "date"    }
+            }
+          }
+      }
+    }
+  }
+}

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -101,7 +101,7 @@ Feature: Manage Forms
     And I click on the button to add the Question "What is your gender?"
     And I select the "Gender Partial" option in the "response_set_ids" list
     And I click on the "Save" button
-    And I click on the "Print" link
+  
 
     Scenario: Export Form to Redcap
       Given I have a Form with the name "Test Form"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -28,7 +28,7 @@ When(/^I click on the option to (.*) the (.+) with the (.+) "([^"]*)"$/) do |act
 end
 
 When(/^I click on the (.*) search filter$/) do |action|
-  page.find("#menu_item_#{action}").trigger('click')
+  page.find("#menu_item_#{action}").click
 end
 
 When(/^I fill in the "([^"]*)" field with "([^"]*)"$/) do |field_name, new_value|
@@ -48,7 +48,7 @@ When(/^I confirm my action$/) do
   # So, apparently the poltergeist driver automatically accept/confirm/okays all alerts
   # Additionally, it doesn't support the code below, which is required when using selenium.
   # I'm torn on removing the step entirely, so I'm leaving it and this explanation for posterity.
-  # page.driver.browser.switch_to.alert.accept
+  page.driver.browser.switch_to.alert.accept
 end
 
 # Then clauses

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -9,12 +9,12 @@ end
 
 When(/^I click on the button to add the Question "([^"]*)"$/) do |question_content|
   object_id = Question.search(question_content).first.id.to_s
-  page.find("#question_#{object_id}_add").trigger('click')
+  page.find("#question_#{object_id}_add").click
 end
 
 When(/^I click on the menu link for the Form with the (.+) "([^"]*)"$/) do |attribute, attribute_value|
   object_id = attribute_to_id('Form', attribute, attribute_value)
-  page.find("#form_#{object_id}_menu").trigger('click')
+  page.find("#form_#{object_id}_menu").click
 end
 
 When(/^I move the Question "([^"]*)" (up|down)$/) do |question_content, direction|

--- a/features/step_definitions/notification_steps.rb
+++ b/features/step_definitions/notification_steps.rb
@@ -4,7 +4,7 @@ Given(/^I have a Notification with the message "([^"]*)" and the url "([^"]*)"$/
 end
 
 When(/^I click on the "([^"]*)" notification$/) do |message|
-  page.find('.notification-menu-item', text: message).trigger('click')
+  page.find('.notification-menu-item', text: message).click
 end
 
 Then(/^I should see "([^"]*)" new notifications$/) do |value|

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -15,7 +15,7 @@ end
 # When clauses
 When(/^I click on the menu link for the Question with the (.+) "([^"]*)"$/) do |attribute, attribute_value|
   object_id = attribute_to_id('Question', attribute, attribute_value)
-  page.find("#question_#{object_id}_menu").trigger('click')
+  page.find("#question_#{object_id}_menu").click
 end
 
 When(/^I drag the "([^"]*)" option to the "([^"]*)" list$/) do |option, target|

--- a/features/step_definitions/response_set_steps.rb
+++ b/features/step_definitions/response_set_steps.rb
@@ -23,5 +23,5 @@ When(/^I click on the link to remove the Response "([^"]*)"$/) do |response_name
 end
 When(/^I click on the menu link for the Response Set with the (.+) "([^"]*)"$/) do |attribute, attribute_value|
   object_id = attribute_to_id('Response Set', attribute, attribute_value)
-  page.find("#response_set_#{object_id}_menu").trigger('click')
+  page.find("#response_set_#{object_id}_menu").click
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -23,6 +23,8 @@ if ENV['IN_BROWSER']
     sleep(ENV['PAUSE'].to_i || 0)
   end
 else
+  require 'fakeweb'
+  FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
 
   Capybara.register_driver :accessible_poltergeist_with_promises do |app|
     libs_path = Rails.root.join('features/support/js_libs/')

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,33 +11,29 @@ require 'capybara/poltergeist'
 require 'capybara/accessible'
 
 require 'axe/cucumber/step_definitions'
+require 'fakeweb'
+FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
 
-if ENV['IN_BROWSER']
+Capybara.register_driver :chrome do |app|
+  driver =  Capybara::Selenium::Driver.new(app, browser: :chrome)
+  adaptor = Capybara::Accessible::SeleniumDriverAdapter.new
+  Capybara::Accessible.setup(driver, adaptor)
+end
+
+AfterStep do
+  sleep(ENV['PAUSE'].to_i || 0)
+end
+
+Capybara.default_driver = :chrome
+Capybara.javascript_driver = :chrome
+if ENV['HEADLESS']
   # On demand: non-headless tests via Selenium/WebDriver
   # To run the scenarios in browser (default: Firefox), use the following command line:
   # IN_BROWSER=true bundle exec cucumber
   # or (to have a pause of 1 second between each step):
   # IN_BROWSER=true PAUSE=1 bundle exec cucumber
-  Capybara.default_driver = :accessible_selenium
-  AfterStep do
-    sleep(ENV['PAUSE'].to_i || 0)
-  end
-else
-  require 'fakeweb'
-  FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
 
-  Capybara.register_driver :accessible_poltergeist_with_promises do |app|
-    libs_path = Rails.root.join('features/support/js_libs/')
-    js_log = File.open('log/test_phantomjs.log', 'a')
-    driver = Capybara::Poltergeist::Driver.new(app,
-                                               extensions: %W(#{libs_path}promise.js),
-                                               phantomjs_logger: js_log)
-    adaptor = Capybara::Accessible::PoltergeistDriverAdapter.new
-    Capybara::Accessible.setup(driver, adaptor)
-  end
-
-  Capybara.default_driver    = :accessible_poltergeist_with_promises
-  Capybara.javascript_driver = :accessible_poltergeist
+  # need to setup headless testing here
 
 end
 

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -1,0 +1,48 @@
+module SDP
+  module Elasticsearch
+    def self.with_client
+      client = Vocabulary::Elasticsearch.client
+      yield client if client.ping
+    end
+
+    def self.ensure_index
+      with_client do |client|
+        unless client.indices.exists? index: 'vocabulary'
+          # create the index
+          json = JSON.parse(File.read(File.join(File.dirname(__FILE__), '../../docs/elastic_search_schema.json')))
+          client.indices.create index: 'vocabulary',
+                                body:  json
+        end
+      end
+    end
+
+    def self.sync
+      ensure_index
+      with_client do |_client|
+        form_ids = Form.ids
+        question_ids = Question.ids
+        rs_ids = ResponseSet.ids
+        delete_all('form', form_ids)
+        delete_all('question', question_ids)
+        delete_all('response_set', rs_ids)
+        Form.all.each do |form|
+          UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
+        end
+        Question.all.each do |question|
+          UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json)
+        end
+        ResponseSet.all.each do |response_set|
+          UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json)
+        end
+      end
+    end
+
+    def self.delete_all(type, ids)
+      with_client do |client|
+        client.delete_by_query index: 'vocabulary',
+                               type: type,
+                               body: { query: { bool: { must_not: { terms: { id: ids } } } } }
+      end
+    end
+  end
+end

--- a/test/controllers/forms_controller_test.rb
+++ b/test/controllers/forms_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class FormsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
-
+  include ActiveJob::TestHelper
   setup do
     @form = forms(:one)
     sign_in users(:admin)
@@ -19,9 +19,12 @@ class FormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create form' do
+    assert_enqueued_jobs 0
+
     assert_difference('Form.count') do
       post forms_url, params: { form: { name: @form.name, created_by_id: @form.created_by_id } }
     end
+    assert_enqueued_jobs 1
 
     assert_redirected_to form_url(Form.last)
   end
@@ -32,8 +35,10 @@ class FormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should get revise' do
+    assert_enqueued_jobs 0
     get revise_form_url(@form)
     assert_response :success
+    assert_enqueued_jobs 0
   end
 
   test 'should get export' do
@@ -49,10 +54,11 @@ class FormsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy form' do
+    assert_enqueued_jobs 0
     assert_difference('Form.count', -1) do
       delete form_url(@form)
     end
-
+    assert_enqueued_jobs 1
     assert_redirected_to forms_url
   end
 

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class QuestionsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
 
   setup do
     @question = questions(:one)
@@ -19,10 +20,11 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create question' do
+    assert_enqueued_jobs 0
     assert_difference('Question.count') do
       post questions_url, params: { question: { content: @question.content, question_type_id: @question.question_type.id } }
     end
-
+    assert_enqueued_jobs 1
     assert_redirected_to question_url(Question.last)
   end
 
@@ -37,10 +39,11 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy question' do
+    assert_enqueued_jobs 0
     assert_difference('Question.count', -1) do
       delete question_url(@question)
     end
-
+    assert_enqueued_jobs 1
     assert_redirected_to questions_url
   end
 end

--- a/test/controllers/response_sets_controller_test.rb
+++ b/test/controllers/response_sets_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class ResponseSetsControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
+  include ActiveJob::TestHelper
   setup do
     @response_set = response_sets(:one)
     @response_set2 = response_sets(:two)
@@ -21,10 +22,11 @@ class ResponseSetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should create response_set' do
+    assert_enqueued_jobs 0
     assert_difference('ResponseSet.count') do
       post response_sets_url, params: { response_set: { description: @response_set.description, name: @response_set.name, oid: '2.16.840.1.113883.3.1502.3.4' } }
     end
-
+    assert_enqueued_jobs 1
     assert_redirected_to response_set_url(ResponseSet.last)
   end
 
@@ -39,12 +41,13 @@ class ResponseSetsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy response_set' do
+    assert_enqueued_jobs 0
     assert_difference('ResponseSet.count', -1) do
       patch response_url(@resp), params: { response: { response_set_id: @response_set2.id, value: 'one' } }
       patch response_url(@resp2), params: { response: { response_set_id: @response_set2.id, value: 'two' } }
       delete response_set_url(@response_set)
     end
-
+    assert_enqueued_jobs 1
     assert_redirected_to response_sets_url
   end
 end

--- a/test/jobs/delete_from_index_job_test.rb
+++ b/test/jobs/delete_from_index_job_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+class DeleteFromIndexJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  test 'job calls delete index' do
+    DeleteFromIndexJob.perform_now('form', 1)
+    req = FakeWeb.last_request
+    assert_equal 'DELETE', req.method
+    assert_equal '/vocabulary/form/1', req.path
+  end
+end

--- a/test/jobs/update_index_job_test.rb
+++ b/test/jobs/update_index_job_test.rb
@@ -1,0 +1,20 @@
+require 'test_helper'
+
+class UpdateIndexJobJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+  test 'job calls update index' do
+    UpdateIndexJob.perform_now('form', id: 1)
+    req = FakeWeb.last_request
+    assert_equal 'POST', req.method
+    assert_equal '/vocabulary/form/1/_update', req.path
+  end
+
+  test 'job calls create index' do
+    UpdateIndexJob.perform_now('form', id: 2)
+    req = FakeWeb.last_request
+    assert_equal 'PUT', req.method
+    assert_equal '/vocabulary/form/2?op_type=create', req.path
+  end
+end

--- a/test/support/fakeweb.rb
+++ b/test/support/fakeweb.rb
@@ -1,0 +1,4 @@
+# require 'fakeweb'
+# FakeWeb.allow_net_connect = %r[^https?://localhost]
+# FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
+# FakeWeb.register_uri(:head, 'http://example.com:9200/vocabulary/form/2', status: ['404', 'Not Found'])

--- a/test/support/fakeweb.rb
+++ b/test/support/fakeweb.rb
@@ -1,4 +1,4 @@
-# require 'fakeweb'
-# FakeWeb.allow_net_connect = %r[^https?://localhost]
-# FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
-# FakeWeb.register_uri(:head, 'http://example.com:9200/vocabulary/form/2', status: ['404', 'Not Found'])
+require 'fakeweb'
+FakeWeb.allow_net_connect = %r{^https?://localhost}
+FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
+FakeWeb.register_uri(:head, 'http://example.com:9200/vocabulary/form/2', status: ['404', 'Not Found'])

--- a/test/unit/lib/elastic_search_test.rb
+++ b/test/unit/lib/elastic_search_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+require 'sdp/elastic_search'
+
+class ElasticSearchTest < ActiveSupport::TestCase
+  def test_ensure_index
+    SDP::Elasticsearch.ensure_index
+    req = FakeWeb.last_request
+    assert_equal 'HEAD', req.method
+    assert_equal '/vocabulary', req.path
+  end
+
+  def test_delete_all
+    SDP::Elasticsearch.delete_all('form', [1, 2, 3, 4])
+    req = FakeWeb.last_request
+    assert_equal 'POST', req.method
+    assert_equal '/vocabulary/form/_delete_by_query', req.path
+  end
+end


### PR DESCRIPTION
Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- N/A Added cucumber tests for any new functionality
- (within reason) Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- N/A If any database changes were made, run `rake generate_erd` to update the README.md
- N/A If any changes were made to config/routes.rb run `rake jsroutes:generate`

I updated the cucumber env to use selenium and the chromedriver.  All but 3 of the cuke tests were passing which is far better than the vast amount of phantomjs errors that we were seeing before.  

This PR adds the backend functionality for elastic search,  when forms , questions and response sets are created/updated or delete an after_commit hook is called to update the index accordingly.  

All of the items are denormalized to a certain extent and mapped into a somewhat generic structure.  For instance in the index forms, questions and response sets all have a name attribute. In the rails models only forms and response sets have those and question has a content field.  The content field is mapped into the name attribute for inclusion in elastic search.  This is because es works best when all of the classes in a single index have a somewhat similar structure.   So you sill see that all 3 classes look very similar in the es index. 

 