### PR TITLE
[SDP-297] Headless cucumber test option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -41,10 +41,11 @@ group :development, :test do
   gem 'byebug'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner', git: 'https://github.com/DatabaseCleaner/database_cleaner.git'
-  gem 'poltergeist'
   gem 'scss_lint', require: false
   gem 'capybara'
   gem 'capybara-accessible'
+  gem 'capybara-webkit'
+  gem 'headless'
   gem 'axe-matchers'
   gem 'selenium-webdriver', '2.48.0'
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,10 +84,12 @@ GEM
       xpath (~> 2.0)
     capybara-accessible (0.2.1)
       capybara (~> 2.0)
+    capybara-webkit (1.12.0)
+      capybara (>= 2.3.0, < 2.13.0)
+      json
     childprocess (0.5.9)
       ffi (~> 1.0, >= 1.0.11)
     choice (0.2.0)
-    cliver (0.3.2)
     coderay (1.1.1)
     coercible (1.0.0)
       descendants_tracker (~> 0.0.1)
@@ -145,6 +147,7 @@ GEM
     globalid (0.3.7)
       activesupport (>= 4.1.0)
     hashie (3.4.6)
+    headless (2.3.1)
     httpclient (2.8.3)
     i18n (0.7.0)
     ice_nine (0.11.2)
@@ -226,10 +229,6 @@ GEM
     parser (2.3.3.1)
       ast (~> 2.2)
     pg (0.19.0)
-    poltergeist (1.12.0)
-      capybara (~> 2.1)
-      cliver (~> 0.3.1)
-      websocket-driver (>= 0.2.0)
     powerpack (0.1.1)
     pry (0.10.4)
       coderay (~> 1.1.0)
@@ -379,6 +378,7 @@ DEPENDENCIES
   cancancan
   capybara
   capybara-accessible
+  capybara-webkit
   config
   cucumber-rails
   database_cleaner!
@@ -386,6 +386,7 @@ DEPENDENCIES
   elasticsearch
   fakeweb (~> 1.3)
   foreman
+  headless
   jbuilder (~> 2.5)
   js-routes
   json_schema
@@ -400,7 +401,6 @@ DEPENDENCIES
   overcommit
   parallel_tests
   pg
-  poltergeist
   pry
   pry-nav
   pry-rescue
@@ -419,4 +419,4 @@ DEPENDENCIES
   webpack-rails
 
 BUNDLED WITH
-   1.13.6
+   1.13.7

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -48,9 +48,8 @@ When(/^I confirm my action$/) do
   # So, apparently the poltergeist driver automatically accept/confirm/okays all alerts
   # Additionally, it doesn't support the code below, which is required when using selenium.
   # I'm torn on removing the step entirely, so I'm leaving it and this explanation for posterity.
-  if !(ENV['HEADLESS'])
-    page.driver.browser.switch_to.alert.accept
-  end
+
+  page.driver.browser.switch_to.alert.accept unless ENV['HEADLESS']
 end
 
 # Then clauses

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -48,7 +48,9 @@ When(/^I confirm my action$/) do
   # So, apparently the poltergeist driver automatically accept/confirm/okays all alerts
   # Additionally, it doesn't support the code below, which is required when using selenium.
   # I'm torn on removing the step entirely, so I'm leaving it and this explanation for posterity.
-  page.driver.browser.switch_to.alert.accept
+  if !(ENV['HEADLESS'])
+    page.driver.browser.switch_to.alert.accept
+  end
 end
 
 # Then clauses

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -7,7 +7,6 @@
 require 'cucumber/rails'
 
 require 'capybara/cucumber'
-require 'capybara/poltergeist'
 require 'capybara/accessible'
 
 require 'axe/cucumber/step_definitions'
@@ -26,14 +25,33 @@ end
 
 Capybara.default_driver = :chrome
 Capybara.javascript_driver = :chrome
-if ENV['HEADLESS']
-  # On demand: non-headless tests via Selenium/WebDriver
-  # To run the scenarios in browser (default: Firefox), use the following command line:
-  # IN_BROWSER=true bundle exec cucumber
-  # or (to have a pause of 1 second between each step):
-  # IN_BROWSER=true PAUSE=1 bundle exec cucumber
 
-  # need to setup headless testing here
+if ENV['HEADLESS']
+  require 'headless'
+  require 'capybara/webkit'
+  Capybara::Webkit.configure do |config|
+    config.block_unknown_urls # allow_url('fonts.googleapis.com')
+    config.skip_image_loading
+  end
+
+  class Capybara::Accessible::WebkitDriverAdapter
+    def modal_dialog_present?(_driver)
+      # driver.alert_messages.any?
+      false
+    end
+  end
+
+  Capybara.register_driver :accessible_webkit2 do |app|
+    driver = Capybara::Webkit::Driver.new(app, Capybara::Webkit::Configuration.to_hash)
+    adaptor = Capybara::Accessible::WebkitDriverAdapter.new
+    Capybara::Accessible.setup(driver, adaptor)
+  end
+
+  headless = Headless.new
+  headless.start
+
+  Capybara.default_driver = :accessible_webkit2
+  Capybara.javascript_driver = :acessible_webkit2
 
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -34,10 +34,14 @@ if ENV['HEADLESS']
     config.skip_image_loading
   end
 
-  class Capybara::Accessible::WebkitDriverAdapter
-    def modal_dialog_present?(_driver)
-      # driver.alert_messages.any?
-      false
+  module Capybara
+    module Accessible
+      class WebkitDriverAdapter
+        def modal_dialog_present?(_driver)
+          # driver.alert_messages.any?
+          false
+        end
+      end
     end
   end
 

--- a/setup_headless_testing.sh
+++ b/setup_headless_testing.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+echo "This setup script was written for Ubuntu 16.04.1 and may not work elsewhere."
+echo "Updating system ..."
+sudo apt-get update -qq
+echo "Adding requisite QtWebkit libs ..."
+sudo apt-get install libqt4-dev libqtwebkit-dev -y -qq
+echo "Installing XVFB (headless GUI for Firefox) ..."
+sudo apt-get install xvfb -y -qq
+echo "Installation complete."


### PR DESCRIPTION
Added content for the HEADLESS option when running cucumber tests for the sake of all of our Ubuntu 16.04 developer.

To run cucumber tests headlessly in Ubuntu 16.04 run the provided setup script, then install as normal
`./setup_headless_testing.sh; npm install; bundle install;`

When running cucumber tests, use the 'HEADLESS' environment variable to run tests using webkit.
`HEADLESS=true bundle exec cucumber`
`HEADLESS=true bundle exec rake`
`HEADLESS=true cucumber features/manage_forms.feature --fail-fast`

- [X] Passed overcommit hooks, including running all code through Rubocop
