### PR TITLE
Fixing annoying proptypes warning

### DIFF
--- a/test/frontend/mock_routes.js
+++ b/test/frontend/mock_routes.js
@@ -3,7 +3,6 @@ exports.questionsPath = (q) => `/questions/`;
 exports.reviseQuestionPath = (q) => `/questions/${q.id}/revise`;
 exports.formPath = (f) => `/forms/${f.id}/`;
 exports.formsPath = (f) => `/forms/`;
-exports.reviseFormPath = (f) => `/forms/${f.id}/revise`;
 exports.responseSetPath = (r) => `/responseSets/${r.id}`;
 exports.extendResponseSetPath = (r) => `/responseSets/${r.id}/extend`;
 exports.reviseResponseSetPath = (r) => `/responseSets/${r.id}/revise`;

--- a/webpack/prop-types/route_props.js
+++ b/webpack/prop-types/route_props.js
@@ -3,7 +3,6 @@ import { PropTypes } from 'react';
 const allRoutes = PropTypes.shape({
   formPath: PropTypes.func.isRequired,
   formsPath: PropTypes.func.isRequired,
-  reviseFormPath: PropTypes.func.isRequired,
   questionPath: PropTypes.func.isRequired,
   reviseQuestionPath: PropTypes.func.isRequired,
   responseSetPath: PropTypes.func.isRequired


### PR DESCRIPTION
The revise form route went away but allRoutes still had it as required, so there was an annoying warning on page loads. No jira issue, just saw this and wanted to fix it quick.

- [x] Passed overcommit hooks, including running all code through Rubocop

