### PR TITLE
[SDP-86]Add description to ui

### DIFF
--- a/app/views/forms/_form.json.jbuilder
+++ b/app/views/forms/_form.json.jbuilder
@@ -1,3 +1,4 @@
-json.extract! form, :id, :name, :created_at, :updated_at, :questions, :version_independent_id, :version, :form_questions, :control_number
+json.extract! form, :id, :name, :description, :created_at, :updated_at, :questions, \
+              :version_independent_id, :version, :form_questions, :control_number
 json.user_id form.created_by.email if form.created_by.present?
 json.url form_url(form, format: :json)

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -12,15 +12,16 @@ Feature: Manage Forms
     And I should see the option to Revise the Form with the name "Test Form"
 
   Scenario: Show Form in Detail
-    Given I have a Form with the name "Test Form"
+    Given I have a Form with the name "Test Form" and the description "Form description"
     And I am logged in as test_author@gmail.com
     When I go to the list of Forms
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to View the Form with the name "Test Form"
     Then I should see "Test Form"
+    Then I should see "Form description"
 
   Scenario: Revise Form
-    Given I have a Form with the name "Test Form"
+    Given I have a Form with the name "Test Form" and the description "Form description"
     And I have a Question with the content "What is your gender?" and the type "MC"
     And I have a Response Set with the name "Gender Partial"
     And I am logged in as test_author@gmail.com
@@ -28,12 +29,14 @@ Feature: Manage Forms
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to Revise the Form with the name "Test Form"
     And I fill in the "name" field with "Gender Form"
+    And I fill in the "description" field with "Revised Description"
     And I click on the button to add the Question "What is your gender?"
-    #Then I select the "Gender Partial" option in the "response_set_ids" list
-    And I click on the "Save" button
+    Then I select the "Gender Partial" option in the "response_set_ids" list
+    And I click on the "new Form" button
     Then I should see "Name: Gender Form"
-    #And I should see "What is your gender?"
-    #And I should see "Gender Partial"
+    Then I should see "Revised Description"
+    And I should see "What is your gender?"
+    And I should see "Gender Partial"
 
   Scenario: Reorder Questions
     Given I have a Form with the name "Test Form"
@@ -46,11 +49,11 @@ Feature: Manage Forms
     And I click on the option to Revise the Form with the name "Test Form"
     And I click on the button to add the Question "What is your gender?"
     And I click on the button to add the Question "What is your name?"
-    #And I move the Question "What is your name?" up
-    #And I move the Question "What is your name?" down
-    And I click on the "Save" button
-    #And I should see "What is your gender?"
-    #And I should see "Gender Partial"
+    And I move the Question "What is your name?" up
+    And I move the Question "What is your name?" down
+    And I click on the "new Form" button
+    And I should see "What is your gender?"
+    And I should see "Gender Partial"
 
   Scenario: Create New Form from List
     Given I have a Response Set with the name "Gender Full"
@@ -60,11 +63,12 @@ Feature: Manage Forms
     And I click on the "New Form" link
     And I fill in the "name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
+    And I fill in the "description" field with "Form description"
     And I click on the button to add the Question "What is your gender?"
-    #Then I select the "Gender Full" option in the "response_set_ids" list
-    And I click on the "Save" button
+    Then I select the "Gender Full" option in the "response_set_ids" list
+    And I click on the "new Form" button
     Then I should see "Test Form"
-    #And I should see "What is your gender?"
+    And I should see "What is your gender?"
 
   Scenario: Create New Form from List with warning modal
     Given I have a Response Set with the name "Gender Full"
@@ -77,7 +81,10 @@ Feature: Manage Forms
     When I go to the list of Forms
     And I click on the "Save & Leave" button
     Then I should see "Test Form"
-    #And I should see "What is your gender?"
+    And I should see "What is your gender?"
+    Then I should see "Name: Test Form"
+    Then I should see "Description: Form description"
+    And I should see "What is your gender?"
 
   Scenario: Abandon New Form from List with warning modal
     Given I have a Response Set with the name "Gender Full"
@@ -100,8 +107,8 @@ Feature: Manage Forms
     And I fill in the "name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234"
     And I click on the button to add the Question "What is your gender?"
-    #Then I select the "Gender Full" option in the "response_set_ids" list
-    And I click on the "Save" button
+    Then I select the "Gender Full" option in the "response_set_ids" list
+    And I click on the "new Form" button
     Then I should see "error(s) prohibited this form from being saved"
     And I should see "Control number: must be a valid OMB Control Number"
 
@@ -124,20 +131,20 @@ Feature: Manage Forms
     And I click on the "New Form" link
     And I fill in the "name" field with "Test Form"
     And I click on the button to add the Question "What is your gender?"
-    #And I select the "Gender Partial" option in the "response_set_ids" list
-    And I click on the "Save" button
+    And I select the "Gender Partial" option in the "response_set_ids" list
+    And I click on the "new Form" button
 
 
-    Scenario: Export Form to Redcap
-      Given I have a Form with the name "Test Form"
-      And I have a Question with the content "What is your gender?" and the type "MC"
-      And I have a Response Set with the name "Gender Partial" and the description "Gender example" and with the Responses Male, Female
-      And I am logged in as test_author@gmail.com
-      When I go to the list of Forms
-      And I click on the "New Form" link
-      And I fill in the "name" field with "Test Form"
-      And I click on the button to add the Question "What is your gender?"
-      #And I select the "Gender Partial" option in the "response_set_ids" list
-      And I click on the "Save" button
-      And I click on the "Export to Redcap" link
-      Then I should get a download with the filename "test form_redcap.xml"
+  Scenario: Export Form to Redcap
+    Given I have a Form with the name "Test Form"
+    And I have a Question with the content "What is your gender?" and the type "MC"
+    And I have a Response Set with the name "Gender Partial" and the description "Gender example" and with the Responses Male, Female
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Forms
+    And I click on the "New Form" link
+    And I fill in the "name" field with "Test Form"
+    And I click on the button to add the Question "What is your gender?"
+    And I select the "Gender Partial" option in the "response_set_ids" list
+    And I click on the "new Form" button
+    And I click on the "Export to Redcap" link
+    Then I should get a download with the filename "test form_redcap.xml"

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -11,12 +11,13 @@ Feature: Manage Questions
     And I should see the option to Revise the Question with the content "What is your gender?"
 
   Scenario: Show Question in Detail
-    Given I have a Question with the content "What is your gender?" and the type "MC"
+    Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC"
     And I am logged in as test_author@gmail.com
     When I go to the list of Questions
     When I click on the menu link for the Question with the content "What is your gender?"
     And I click on the option to Details the Question with the content "What is your gender?"
     Then I should see "Content: What is your gender?"
+    Then I should see "Description: This is a question"
 
   Scenario: Comment on a Question in Detail
     Given I have a Question with the content "What is your gender?" and the type "MC"
@@ -30,7 +31,7 @@ Feature: Manage Questions
     Then I should see "Is This a Comment?"
 
   Scenario: Revise Question
-    Given I have a Question with the content "What is your gender?" and the type "MC"
+    Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC"
     And I have a Response Set with the name "Gender Partial"
     And I have a Response Type with the name "Response Set"
     And I am logged in as test_author@gmail.com
@@ -38,10 +39,12 @@ Feature: Manage Questions
     When I click on the menu link for the Question with the content "What is your gender?"
     And I click on the option to Revise the Question with the content "What is your gender?"
     And I fill in the "Question" field with "What is your favorite color?"
+    And I fill in the "Description" field with "This is a revised description"
     And I drag the "Gender Partial" option to the "Selected Response Sets" list
     And I select the "Response Set" option in the "Primary Response Type" list
     And I click on the "Revise Question" button
     And I should see "What is your favorite color?"
+    And I should see "This is a revised description"
 
   Scenario: Create New Question from List
     Given I have a Response Set with the name "Gender Full"
@@ -51,11 +54,13 @@ Feature: Manage Questions
     When I go to the list of Questions
     And I click on the "New Question" link
     And I fill in the "Question" field with "What is your favorite color?"
+    And I fill in the "Description" field with "This is a description"
     And I drag the "Gender Full" option to the "Selected Response Sets" list
     And I select the "Multiple Choice" option in the "Type" list
     And I select the "Integer" option in the "Primary Response Type" list
     And I click on the "Create Question" button
     And I should see "What is your favorite color?"
+    And I should see "This is a description"
 
   Scenario: Create New Question from List with Warning Modal
     Given I have a Response Set with the name "Gender Full"

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -1,3 +1,8 @@
+Given(/^I have a Form with the name "([^"]*)" and the description "([^"]*)"$/) do |name, description|
+  user = get_user 'test_author@gmail.com'
+  Form.create!(name: name, description: description, created_by: user)
+end
+
 Given(/^I have a Form with the name "([^"]*)"$/) do |name|
   user = get_user 'test_author@gmail.com'
   Form.create!(name: name, created_by: user)

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,3 +1,9 @@
+Given(/^I have a Question with the content "([^"]*)" and the description "([^"]*)" and the type "([^"]*)"$/) do |content, description, type|
+  user = get_user('test_author@gmail.com')
+  qt314 = QuestionType.find_or_create_by(name: type)
+  Question.create!(content: content, description: description, question_type_id: qt314.id, version: 1, created_by: user)
+end
+
 Given(/^I have a Question with the content "([^"]*)" and the type "([^"]*)"$/) do |content, type|
   user = get_user('test_author@gmail.com')
   qt314 = QuestionType.find_or_create_by(name: type)

--- a/test/frontend/components/question_details_test.js
+++ b/test/frontend/components/question_details_test.js
@@ -11,7 +11,7 @@ describe('QuestionDetails', () => {
   });
 
   it('should display a question', () => {
-    expect(component.find("p").length).to.equal(7);
+    expect(component.find("p").length).to.equal(8);
   });
 
 });

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -68,10 +68,11 @@ class FormEdit extends Component {
     const versionIndependentId = form.versionIndependentId;
     const version = form.version + 1;
     const name = form.name || '';
+    const description = form.description || '';
     const formQuestions = form.formQuestions;
     const controlNumber = form.controlNumber;
     const showModal = false;
-    return {formQuestions, name, id, version, versionIndependentId, controlNumber, showModal};
+    return {formQuestions, name, id, version, versionIndependentId, controlNumber, description, showModal};
   }
 
   constructor(props) {
@@ -197,7 +198,8 @@ class FormEdit extends Component {
             </div>
             <div className="col-md-6">
               <div className="actions">
-                <input type="submit" value={`${this.props.action||'New'} Form`}/>
+                <label htmlFor={`${this.props.action||'New'} Form`}></label>
+                <input name={`${this.props.action||'New'} Form`} type="submit" value={`${this.props.action||'New'} Form`}/>
               </div>
             </div>
           </div>
@@ -211,6 +213,10 @@ class FormEdit extends Component {
           <div className="col-md-12">
             <label htmlFor="name">Name:</label>
             <input type="text" value={this.state.name} name="name" id="name" onChange={this.handleChange('name')}/>
+          </div>
+          <div className="col-md-12">
+            <label htmlFor="description">Description:</label>
+            <textarea type="text" value={this.state.description} name="description" id="description" onChange={this.handleChange('description')}/>
           </div>
           <div className="col-md-12">
             <label htmlFor="controlNumber">OMB Number:</label>

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -15,7 +15,8 @@ class FormShow extends Component {
     return (
       <div id={"form_id_"+form.id}>
         <p><strong>Name:</strong> {form.name} </p>
-        <p><strong>Created By:</strong> {form.userId} </p>
+        <p><strong>Description:</strong> {form.description} </p>
+        <p><strong>Created By:</strong>  {form.userId} </p>
         <QuestionList questions={_.keyBy(form.questions, 'id')} routes={Routes} />
         <div className="no-print">
           <a className="btn btn-default" href={`/landing#/forms/${this.props.form.id}/revise`}>Revise</a>

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -17,6 +17,10 @@ export default class QuestionDetails extends Component {
         { question.content }
         </p>
         <p>
+        <strong>Description: </strong>
+        { question.description }
+        </p>
+        <p>
           <strong>Author: </strong>
           { question.createdBy && question.createdBy.email }
         </p>

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -130,6 +130,7 @@ class QuestionForm extends Component{
   stateForNew() {
     return {
       content: '',
+      description: '',
       questionTypeId: null,
       versionIndependentId: null,
       version: 1,
@@ -195,15 +196,18 @@ class QuestionForm extends Component{
               </div>
 
               <div className="row ">
-                  <div className="col-md-8 question-form-group">
-                      <label className="input-label" htmlFor="responseTypeId">Primary Response Type</label>
-                      <select name="responseTypeId" id="responseTypeId" className="input-format" defaultValue={state.responseTypeId} onChange={this.handleChange('responseTypeId')} >
-                        {_.values(responseTypes).map((rt) => {
-                          return (<option key={rt.id} value={rt.id}>{rt.name}</option>);
-                        })}
-                      </select>
-                  </div>
-                  <div className="col-md-4 question-form-group"></div>
+                <div className="col-md-8 question-form-group">
+                  <label className="input-label" htmlFor="content">Description</label>
+                  <textarea className="input-format" placeholder="Question description" type="text" name="description" id="description" defaultValue={state.description} onChange={this.handleChange('description')} />
+                </div>
+                <div className="col-md-4 question-form-group">
+                    <label className="input-label" htmlFor="responseTypeId">Primary Response Type</label>
+                    <select name="responseTypeId" id="responseTypeId" className="input-format" defaultValue={state.responseTypeId} onChange={this.handleChange('responseTypeId')} >
+                      {_.values(responseTypes).map((rt) => {
+                        return (<option key={rt.id} value={rt.id}>{rt.name}</option>);
+                      })}
+                    </select>
+                </div>
               </div>
 
               <div className="row ">


### PR DESCRIPTION
Description appears in ui for forms, response sets, questions. Tweaked cucumber tests, but they still fail for unrelated reasons.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- na If any database changes were made, run `rake generate_erd` to update the README.md
- na If any changes were made to config/routes.rb run `rake jsroutes:generate`
