### PR TITLE
[SDP-238] Modified API error handling

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,21 @@
+module Api
+  class ApplicationController < ActionController::Base
+    rescue_from Exception do |e|
+      error(e)
+    end
+
+    protected
+
+    def error(e)
+      error_info = {
+        message: 'internal-server-error',
+        exception: "#{e.class.name} : #{e.message}"
+      }
+      render json: error_info.to_json, status: 500
+    end
+
+    def not_found
+      render json: { message: 'Resource Not Found' }, status: 404
+    end
+  end
+end

--- a/app/controllers/api/forms_controller.rb
+++ b/app/controllers/api/forms_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class FormsController < ApplicationController
+  class FormsController < Api::ApplicationController
     respond_to :json
 
     def index
@@ -7,6 +7,10 @@ module Api
 
     def show
       @form = Form.by_id_and_version(params[:id], params[:version])
+      if @form.nil?
+        not_found
+        return
+      end
       render json: @form, serializer: FormSerializer
     end
   end

--- a/app/controllers/api/questions_controller.rb
+++ b/app/controllers/api/questions_controller.rb
@@ -1,5 +1,6 @@
 module Api
-  class QuestionsController < ApplicationController
+  class QuestionsController < Api::ApplicationController
+    include Api
     respond_to :json
 
     def index
@@ -11,11 +12,19 @@ module Api
 
     def show
       @question = Question.by_id_and_version(params[:id], params[:version])
+      if @question.nil?
+        not_found
+        return
+      end
       render json: @question, serializer: QuestionsSerializer
     end
 
     def usage
       @question = Question.by_id_and_version(params[:id, params[:version]])
+      if @question.nil?
+        not_found
+        return
+      end
       render json: @question, serializer: UsageSerializer
     end
   end

--- a/app/controllers/api/response_sets_controller.rb
+++ b/app/controllers/api/response_sets_controller.rb
@@ -1,5 +1,5 @@
 module Api
-  class ResponseSetsController < ApplicationController
+  class ResponseSetsController < Api::ApplicationController
     respond_to :json
 
     def index
@@ -11,11 +11,19 @@ module Api
 
     def show
       @value_set = ResponseSet.by_id_and_version(params[:id], params[:version])
+      if @value_set.nil?
+        not_found
+        return
+      end
       render json: @value_set, serializer: ValueSetsSerializer
     end
 
     def usage
       @value_set = ResponseSet.by_id_and_version(params[:id], params[:version])
+      if @value_set.nil?
+        not_found
+        return
+      end
       render json: @value_set, serializer: UsageSerializer
     end
   end

--- a/app/serializers/form_questions_serializer.rb
+++ b/app/serializers/form_questions_serializer.rb
@@ -7,6 +7,6 @@ class FormQuestionsSerializer < ActiveModel::Serializer
   end
 
   def response_set
-    ValueSetsSerializer.new(object.response_set)
+    ValueSetsSerializer.new(object.response_set) if object.response_set
   end
 end

--- a/test/controllers/api/forms_controller_test.rb
+++ b/test/controllers/api/forms_controller_test.rb
@@ -23,4 +23,11 @@ class FormsControllerTest < ActionDispatch::IntegrationTest
     res = JSON.parse response.body
     assert_equal(res['version'], 1)
   end
+
+  test 'api should 404 on form that doesnt exist' do
+    get api_form_url(@form.version_independent_id, version: 99)
+    assert_response :not_found
+    res = JSON.parse response.body
+    assert_equal(res['message'], 'Resource Not Found')
+  end
 end

--- a/test/controllers/api/questions_controller_test.rb
+++ b/test/controllers/api/questions_controller_test.rb
@@ -31,4 +31,11 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     res = JSON.parse response.body
     assert_equal(res['version'], 1)
   end
+
+  test 'api should 404 on question that doesnt exist' do
+    get api_question_url(@question.version_independent_id, version: 99)
+    assert_response :not_found
+    res = JSON.parse response.body
+    assert_equal(res['message'], 'Resource Not Found')
+  end
 end

--- a/test/controllers/api/response_sets_controller_test.rb
+++ b/test/controllers/api/response_sets_controller_test.rb
@@ -32,4 +32,11 @@ class ResponseSetsControllerTest < ActionDispatch::IntegrationTest
     res = JSON.parse response.body
     assert_equal(res['version'], 1)
   end
+
+  test 'api should 404 on value set that doesnt exist' do
+    get api_valueSet_url(@response_set.version_independent_id, version: 99)
+    assert_response :not_found
+    res = JSON.parse response.body
+    assert_equal(res['message'], 'Resource Not Found')
+  end
 end


### PR DESCRIPTION
API now produces json when errors occur
API no longer fails when question on form has no response set
Added relevant tests

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [X] Added unit tests for new functionality
- [X] Passed all unit tests using `rails test` with 90%+ coverage
- [N/A] Added cucumber tests for any new functionality
- [N/A] Passed all cucumber tests using `bundle exec cucumber`
- [X] Passed overcommit hooks, including running all code through Rubocop
- [N/A] If any database changes were made, run `rake generate_erd` to update the README.md
- [N/A] If any changes were made to config/routes.rb run `rake jsroutes:generate`
