### PR TITLE
Address Form Question Bug [SDP-363]

### DIFF
--- a/test/frontend/reducers/test_concept_systems.js
+++ b/test/frontend/reducers/test_concept_systems.js
@@ -11,7 +11,6 @@ describe('concept systems reducer', () => {
     const action = {type: FETCH_CONCEPT_SYSTEMS_FULFILLED, payload: conceptData};
     const startState = {};
     const nextState = conceptSystems(startState, action);
-    console.log(nextState)
     expect(Object.keys(nextState).length).to.equal(1);
   });
 });

--- a/test/frontend/reducers/test_concepts.js
+++ b/test/frontend/reducers/test_concepts.js
@@ -12,7 +12,6 @@ describe('concepts reducer', () => {
     const action = {type: FETCH_CONCEPTS_FULFILLED, payload: conceptData};
     const startState = {};
     const nextState = concepts(startState, action);
-    console.log(nextState)
     expect(Object.keys(nextState).length).to.equal(1);
   });
 });

--- a/test/frontend/reducers/test_forms.js
+++ b/test/frontend/reducers/test_forms.js
@@ -23,6 +23,15 @@ describe('forms reducer', () => {
     expect(Object.keys(nextState).length).to.equal(2);
   });
 
+  it('should not overwrite forms already in store', () => {
+    const payloadData = {data: twoForms};
+    const action = {type: FETCH_FORMS_FULFILLED, payload: payloadData};
+    const preExistingForm = {id: 2, name:"Existing Form", userId: "testAuthor@gmail.com", questions: []};
+    const startState = {2: preExistingForm};
+    const nextState = forms(startState, action);
+    expect(Object.keys(nextState).length).to.equal(3);
+  });
+
   it('should add a question', () => {
     const form = {id: 1, name: "Red Form",  userId: "testAuthor@gmail.com", formQuestions:[]}
     const question = {id: 1, content: "Is this a question?", questionType: ""};

--- a/test/frontend/reducers/test_questions.js
+++ b/test/frontend/reducers/test_questions.js
@@ -29,6 +29,16 @@ describe('questions reducer', () => {
     expect(Object.keys(nextState).length).to.equal(3);
   });
 
+  it('should not overwrite questions already in store', () => {
+    const questionData = {data: [{id: 1, content: "Is this a question?", questionType: ""},
+                                 {id: 2, content: "Whats your name", questionType: ""}]};
+    const preExistingQuestion = {id: 3, content: "What is a question?", questionType: ""};
+    const action = {type: FETCH_QUESTIONS_FULFILLED, payload: questionData};
+    const startState = {3: preExistingQuestion};
+    const nextState = questions(startState, action);
+    expect(Object.keys(nextState).length).to.equal(3);
+  });
+
   it('should fetch a question', () => {
     const questionData = {data: {id: 1, content: "Is this a question?", questionType: ""}};
     const action = {type: FETCH_QUESTION_FULFILLED, payload: questionData};

--- a/test/frontend/reducers/test_response_sets.js
+++ b/test/frontend/reducers/test_response_sets.js
@@ -28,6 +28,16 @@ describe('responseSets reducer', () => {
     expect(Object.keys(nextState).length).to.equal(3);
   });
 
+  it('should not overwrite response sets already in store', () => {
+    const responseSetData = {data: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
+                                 {id: 3, name: "Things", description: "A list of things", oid: "2.16.840.1.113883.3.1502.3.3"}]};
+    const action = {type: FETCH_RESPONSE_SETS_FULFILLED, payload: responseSetData};
+    const preExistingResponseSet = {id: 2, name: "People", description: "A list of people", oid: "2.16.840.1.113883.3.1502.3.2"};
+    const startState = {2: preExistingResponseSet};
+    const nextState = responseSets(startState, action);
+    expect(Object.keys(nextState).length).to.equal(3);
+  });
+
   it('should fetch a response set', () => {
     const responseSetData = {data: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}};
     const action = {type: FETCH_RESPONSE_SET_FULFILLED, payload: responseSetData};

--- a/webpack/reducers/forms_reducer.js
+++ b/webpack/reducers/forms_reducer.js
@@ -13,7 +13,7 @@ export default function forms(state = {}, action) {
   let form , index, newState, newForm, direction, question;
   switch (action.type) {
     case FETCH_FORMS_FULFILLED:
-      return _.keyBy(action.payload.data, 'id');
+      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
     case FETCH_FORM_FULFILLED:
       const formClone = Object.assign({}, state);
       formClone[action.payload.data.id] = action.payload.data;

--- a/webpack/reducers/questions_reducer.js
+++ b/webpack/reducers/questions_reducer.js
@@ -15,7 +15,7 @@ function addQuestionToState(action, state){
 export default function questions(state = {}, action) {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'), state);
+      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
     case SAVE_QUESTION_FULFILLED:
     case FETCH_QUESTION_FULFILLED:
       return addQuestionToState(action, state);

--- a/webpack/reducers/questions_reducer.js
+++ b/webpack/reducers/questions_reducer.js
@@ -15,7 +15,7 @@ function addQuestionToState(action, state){
 export default function questions(state = {}, action) {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
-      return Object.assign(_.keyBy(action.payload.data, 'id'), state);
+      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'), state);
     case SAVE_QUESTION_FULFILLED:
     case FETCH_QUESTION_FULFILLED:
       return addQuestionToState(action, state);

--- a/webpack/reducers/response_sets_reducer.js
+++ b/webpack/reducers/response_sets_reducer.js
@@ -9,7 +9,7 @@ import {
 export default function responseSets(state = {}, action) {
   switch (action.type) {
     case FETCH_RESPONSE_SETS_FULFILLED:
-      return Object.assign(_.keyBy(action.payload.data, 'id'), state);
+      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'), state);
     case FETCH_RESPONSE_SET_FULFILLED:
     case SAVE_RESPONSE_SET_FULFILLED:
       const responseSetClone = Object.assign({}, state);

--- a/webpack/reducers/response_sets_reducer.js
+++ b/webpack/reducers/response_sets_reducer.js
@@ -9,7 +9,7 @@ import {
 export default function responseSets(state = {}, action) {
   switch (action.type) {
     case FETCH_RESPONSE_SETS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'), state);
+      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
     case FETCH_RESPONSE_SET_FULFILLED:
     case SAVE_RESPONSE_SET_FULFILLED:
       const responseSetClone = Object.assign({}, state);


### PR DESCRIPTION
The middleware issue was actually in the reducers. 

In FETCH_QUESTIONS_FULFILLED reducer we are just doing a `_.keyBy(data…` and returning that as the new questions state. This works fine when you do a FETCH_QUESTIONS action because you load all the questions. The issue is that the questions_from_form middleware also fires off FETCH_QUESTIONS_FULFILLED actions with the questions from that form. So depending on the order the actions resolve you get different stuff in the store than would be expected. 

This PR resolves that edge case for Forms, Questions, and ResponseSets.

Also removed some erroneous logging statements from tests and moved state from the back of Object.assign calls because then new data would not overwrite old data. 

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
