### PR TITLE
[SDP-353] No longer passing routes as props

### DIFF
--- a/test/frontend/components/form_edit_test.js
+++ b/test/frontend/components/form_edit_test.js
@@ -1,27 +1,25 @@
-import { expect, renderComponent, createComponent } from '../test_helper';
-import TestUtils from 'react-addons-test-utils';
+import { expect, renderComponent } from '../test_helper';
 import FormEdit from '../../../webpack/components/FormEdit';
-import routes from '../mock_routes';
 import MockRouter from '../mock_router';
 
 describe('FormEdit', () => {
-  let component, router, inputNode, props;
+  let component, router, props, inputNode;
 
   beforeEach(() => {
     router = new MockRouter();
     props  = {
-            form: {id: 6, name: "Test Form", questions: [1], versionIndependentId: "F-1", version: 1, formQuestions:[]},
-            responseSets: {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}},
-            reorderQuestion:()=>{},
-            removeQuestion: ()=>{},
-            action: 'new',
-            formSubmitter:  ()=>{},
-            router: router,
-            questions: {1: {id: 1, content: "Is this a question?", questionType: "", responseSets: [1], concepts: [{code:"Code 1",display:" Display Name 1",system:"Test system 1"}]}}
-          };
+      form: {id: 6, name: "Test Form", questions: [1], versionIndependentId: "F-1", version: 1, formQuestions:[]},
+      responseSets: {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}},
+      reorderQuestion:()=>{},
+      removeQuestion: ()=>{},
+      action: 'new',
+      formSubmitter:  ()=>{},
+      router: router,
+      questions: {1: {id: 1, content: "Is this a question?", questionType: "", responseSets: [1], concepts: [{code:"Code 1",display:" Display Name 1",system:"Test system 1"}]}}
+    };
 
     component = renderComponent(FormEdit, props);
-    inputNode = component.find("input[id='content']")[0]
+    inputNode = component.find("input[id='content']")[0];
   });
 
   it('should stop user from leaving unsaved data', () => {

--- a/test/frontend/components/form_list_test.js
+++ b/test/frontend/components/form_list_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import FormList from '../../../webpack/components/FormList';
-import routes from '../mock_routes';
 
 describe('FormList', () => {
   let component;
@@ -11,7 +10,7 @@ describe('FormList', () => {
       2: {id:2,name:"Bloop",createdBy:{email:"test_author@gmail.com"},createdAt:"2016-12-28T23:40:54.505Z",updatedAt:"2016-12-29T23:40:54.505Z",versionIndependentId:"F-1",version:1,controlNumber:"","questions":[]},
       3: {id:3,name:"I am a robot",createdBy:{email:"test_author@gmail.com"},createdAt:"2016-12-29T23:40:54.505Z",updatedAt:"2016-12-30T23:40:54.505Z",versionIndependentId:"F-1",version:1,controlNumber:"","questions":[]}
     };
-    component = renderComponent(FormList, {forms, routes});
+    component = renderComponent(FormList, {forms});
   });
 
   it('should create a list of forms', () => {

--- a/test/frontend/components/form_question_list_test.js
+++ b/test/frontend/components/form_question_list_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import FormQuestionList from '../../../webpack/components/FormQuestionList';
-import routes from '../mock_routes';
 
 describe('FormQuestionList', () => {
   let component;
@@ -9,7 +8,7 @@ describe('FormQuestionList', () => {
     const questions = [1: {id: 1, content: "Is this a question?", questionType: ""},
                        2: {id: 2, content: "Whats your name", questionType: ""},
                        3: {id: 3, content: "What is a question?", questionType: ""}];
-    component = renderComponent(FormQuestionList, {questions, routes});
+    component = renderComponent(FormQuestionList, {questions});
   });
 
   it('should create list of questions', () => {

--- a/test/frontend/components/form_widget_test.js
+++ b/test/frontend/components/form_widget_test.js
@@ -1,13 +1,12 @@
 import { expect, renderComponent } from '../test_helper';
 import FormWidget from '../../../webpack/components/FormWidget';
-import routes from '../mock_routes';
 
 describe('FormWidget', () => {
   let component;
 
   beforeEach(() => {
     const form = {id:1,name:"Bloop",createdBy:{email:"test_author@gmail.com"},createdAt:"2016-12-27T23:40:54.505Z",updatedAt:"2016-12-27T23:40:54.505Z",versionIndependentId:"F-1",version:1,controlNumber:"","questions":[]};
-    component = renderComponent(FormWidget, {form, routes});
+    component = renderComponent(FormWidget, {form});
   });
 
   it('should create a form block', () => {

--- a/test/frontend/components/question_details_test.js
+++ b/test/frontend/components/question_details_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import QuestionDetails from '../../../webpack/components/QuestionDetails';
-import routes from '../mock_routes';
 
 describe('QuestionDetails', () => {
   let component;
@@ -8,7 +7,7 @@ describe('QuestionDetails', () => {
   beforeEach(() => {
     const question = {id: 1, concepts: [], content: "Is this a question?", createdBy: { email: "test@test.com" }, questionType: ""};
     const currentUser = {id: 1, email: "test@test.com"};
-    const responseSets = []
+    const responseSets = [];
     component = renderComponent(QuestionDetails, {question, responseSets, currentUser});
   });
 

--- a/test/frontend/components/question_form_test.js
+++ b/test/frontend/components/question_form_test.js
@@ -1,7 +1,5 @@
-import { expect, renderComponent, createComponent } from '../test_helper';
-import TestUtils from 'react-addons-test-utils';
+import { expect, renderComponent } from '../test_helper';
 import QuestionForm from '../../../webpack/components/QuestionForm';
-import routes from '../mock_routes';
 import MockRouter from '../mock_router';
 
 describe('QuestionForm', () => {
@@ -12,7 +10,6 @@ describe('QuestionForm', () => {
     props  = {
       question: {id: 1, content: "Is this a question?", questionType: "", responseSets: [1], concepts: [{code:"Code 1", display:" Display Name 1", system:"Test system 1"}]},
       router: router,
-      routes: routes,
       questionSubmitter: ()=>{},
       questionTypes: {},
       responseSets:  {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}},

--- a/test/frontend/components/question_list_test.js
+++ b/test/frontend/components/question_list_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import QuestionList from '../../../webpack/components/QuestionList';
-import routes from '../mock_routes';
 
 describe('QuestionList', () => {
   let component;
@@ -9,7 +8,7 @@ describe('QuestionList', () => {
     const questions = {1: {id: 1, content: "Is this a question?", questionType: ""},
                        2: {id: 2, content: "Whats your name", questionType: ""},
                        3: {id: 3, content: "What is a question?", questionType: ""}};
-    component = renderComponent(QuestionList, {questions, routes});
+    component = renderComponent(QuestionList, {questions});
   });
 
   it('should create list of questions', () => {

--- a/test/frontend/components/question_widget_test.js
+++ b/test/frontend/components/question_widget_test.js
@@ -1,13 +1,12 @@
 import { expect, renderComponent } from '../test_helper';
 import QuestionWidget from '../../../webpack/components/QuestionWidget';
-import routes from '../mock_routes';
 
 describe('QuestionWidget', () => {
   let component;
 
   beforeEach(() => {
-    const question = {id: 1, content: "Is this a question?", question_type: ""};
-    component = renderComponent(QuestionWidget, {question, routes});
+    const question = {id: 1, content: "Is this a question?", questionType: ""};
+    component = renderComponent(QuestionWidget, {question});
   });
 
   it('should create question block', () => {

--- a/test/frontend/components/response_set_form_test.js
+++ b/test/frontend/components/response_set_form_test.js
@@ -1,7 +1,5 @@
-import { expect, renderComponent, createComponent } from '../test_helper';
-import TestUtils from 'react-addons-test-utils';
+import { expect, renderComponent } from '../test_helper';
 import ResponseSetForm from '../../../webpack/components/ResponseSetForm';
-import routes from '../mock_routes';
 import MockRouter from '../mock_router';
 
 describe('ResponseSetForm', () => {
@@ -10,11 +8,10 @@ describe('ResponseSetForm', () => {
   beforeEach(() => {
     router = new MockRouter();
     props  = {
-      responseSet: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1", 
-                    responses:[{value: 'val', codeSystem: 'codesystem', displayName: 'displayname'}]},
+      responseSet: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1",
+        responses:[{value: 'val', codeSystem: 'codesystem', displayName: 'displayname'}]},
       router: router,
       action: 'revise',
-      routes: routes,
     };
     component = renderComponent(ResponseSetForm, props);
     inputNode = component.find("input[id='content']")[0]

--- a/test/frontend/components/response_set_list_test.js
+++ b/test/frontend/components/response_set_list_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import ResponseSetList from '../../../webpack/components/ResponseSetList';
-import routes from '../mock_routes';
 
 describe('ResponseSetList', () => {
   let component;
@@ -9,7 +8,7 @@ describe('ResponseSetList', () => {
     const responseSets = {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
                           2: {id: 2, name: "Colors Improved", description: "A better list of colors", oid: "3.16.840.1.113883.3.1502.3.1"},
                           3: {id: 3, name: "People", description: "A list of people", oid: "4.16.840.1.113883.3.1502.3.1"}};
-    component = renderComponent(ResponseSetList, {responseSets, routes});
+    component = renderComponent(ResponseSetList, {responseSets});
   });
 
   it('should create list of response sets', () => {

--- a/test/frontend/components/search_result_test.js
+++ b/test/frontend/components/search_result_test.js
@@ -1,6 +1,5 @@
 import { expect, renderComponent } from '../test_helper';
 import SearchResult from '../../../webpack/components/SearchResult';
-import routes from '../mock_routes';
 
 describe('SearchResult', () => {
   let qComponent;

--- a/test/frontend/containers/coded_set_table_edit_container_test.js
+++ b/test/frontend/containers/coded_set_table_edit_container_test.js
@@ -1,22 +1,17 @@
-import _$ from 'jquery';
-import React from 'react';
-import ReactDOM from 'react-dom';
-import TestUtils from 'react-addons-test-utils';
 import {expect, renderComponent} from '../test_helper';
 import CodedSetTableEditContainer from '../../../webpack/containers/CodedSetTableEditContainer';
 
-const $ = _$(window);
 
 describe('CodedSetTableEditContainer', () => {
-  let component, componentInstance;
+  let component;
 
   beforeEach(() => {
     const props = {initialItems: [{value: "Code1", displayName: "Display Name 1", codeSystem:"Test system 1"},
                     {value: "Code2", displayName: "Display Name 2", codeSystem:"Test system 2"},
                     {value: "Code3", displayName: "Display Name 3", codeSystem:"Test system 3"}],
-                    parentName:'question',
-                    childName:'concept'
-    }
+      parentName: 'question',
+      childName: 'concept'
+    };
     component = renderComponent(CodedSetTableEditContainer, props);
   });
 

--- a/test/frontend/containers/question_edit_container_test.js
+++ b/test/frontend/containers/question_edit_container_test.js
@@ -7,14 +7,14 @@ import MockRouter from '../mock_router';
 
 describe('QuestionEditContainer ', () => {
   it('will show question edit page', () => {
-    const props = {params:{}, 
-    questions: {1: {id:1, contents:'test', questionTypeId:1, responseTypeId:1, responseSets:[1]}},
-    questionTypes:{1: {id: 1, name: 'Test'}},
-    responseSets: {1: {id: 1, name: 'Test'}},
-    responseTypes:{1: {id: 1, name: 'Test'}},
-    route: {id: 1, name: 'test'},
-    router: new MockRouter()
-  }
+    const props = {params:{},
+      questions: {1: {id:1, contents:'test', questionTypeId:1, responseTypeId:1, responseSets:[1]}},
+      questionTypes:{1: {id: 1, name: 'Test'}},
+      responseSets: {1: {id: 1, name: 'Test'}},
+      responseTypes:{1: {id: 1, name: 'Test'}},
+      route: {id: 1, name: 'test'},
+      router: new MockRouter()
+    };
     const component = renderComponent(QuestionEditContainer, props);
     expect(component.find("div[class='container']").length).to.exist;
     expect(component.find("input[name='content']").length).to.exist;

--- a/test/frontend/containers/question_show_container_test.js
+++ b/test/frontend/containers/question_show_container_test.js
@@ -7,14 +7,14 @@ import QuestionShowContainer from '../../../webpack/containers/QuestionShowConta
 describe('QuestionShowContainer ', () => {
   it('will show a question', () => {
     const props = {
-     question:{id: 1, concepts: [], content: "Is this a question?", createdBy: { email: "test@test.com" }, questionType: ""},
-     params:{qId: 1},
+      question: {id: 1, concepts: [], content: "Is this a question?", createdBy: { email: "test@test.com" }, questionType: ""},
+      params: {qId: 1},
       router: {}
-    }
+    };
     const state = {
       questions: {1: {id:1, concepts: [], createdBy: {email: 'test'}, contents:'test', questionTypeId:1, responseTypeId:1, responseSets:[1]}},
       responseSets: {1: {id: 1, name: 'Test'}}
-    }
+    };
     const component = renderComponent(QuestionShowContainer, props, state);
     expect(component.find("div[id='question_id_1']")).to.exist;
   });

--- a/test/frontend/mock_routes.js
+++ b/test/frontend/mock_routes.js
@@ -1,9 +1,0 @@
-exports.questionPath = (q) => `/questions/${q.id}`;
-exports.questionsPath = (q) => `/questions/`;
-exports.reviseQuestionPath = (q) => `/questions/${q.id}/revise`;
-exports.formPath = (f) => `/forms/${f.id}/`;
-exports.formsPath = (f) => `/forms/`;
-exports.responseSetPath = (r) => `/responseSets/${r.id}`;
-exports.extendResponseSetPath = (r) => `/responseSets/${r.id}/extend`;
-exports.reviseResponseSetPath = (r) => `/responseSets/${r.id}/revise`;
-

--- a/webpack/components/FormList.js
+++ b/webpack/components/FormList.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import FormWidget from './FormWidget';
-import allRoutes from '../prop-types/route_props';
 import _ from 'lodash';
 
 class FormList extends Component {
@@ -19,7 +18,7 @@ class FormList extends Component {
 
   renderRow(rowValues, key) {
     let items = _.values(rowValues).map( (aForm) => {
-      return <FormWidget key={aForm.id} form={aForm} routes={this.props.routes} />;
+      return <FormWidget key={aForm.id} form={aForm} />;
     }
     );
 
@@ -34,7 +33,6 @@ class FormList extends Component {
 
 FormList.propTypes = {
   forms: PropTypes.object.isRequired,
-  routes: allRoutes
 };
 
 export default FormList;

--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -1,6 +1,5 @@
 import React, { Component, PropTypes } from 'react';
 import { questionProps } from "../prop-types/question_props";
-import allRoutes from '../prop-types/route_props';
 import QuestionWidget from './QuestionWidget';
 
 class FormQuestionList extends Component {
@@ -8,7 +7,7 @@ class FormQuestionList extends Component {
     return (
       <div className="question-group">
         {this.props.questions.map((q, i) => {
-          return <QuestionWidget key={i} question={q} routes={this.props.routes} />;
+          return <QuestionWidget key={i} question={q} />;
         })}
       </div>
     );
@@ -16,8 +15,7 @@ class FormQuestionList extends Component {
 }
 
 FormQuestionList.propTypes = {
-  questions: PropTypes.arrayOf(questionProps),
-  routes: allRoutes
+  questions: PropTypes.arrayOf(questionProps)
 };
 
 export default FormQuestionList;

--- a/webpack/components/FormWidget.js
+++ b/webpack/components/FormWidget.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import { Link } from 'react-router';
-import allRoutes from '../prop-types/route_props';
-import {formProps} from '../prop-types/form_props';
+import { formProps } from '../prop-types/form_props';
 
 export default class FormWidget extends Component {
   render() {
@@ -44,6 +43,5 @@ export default class FormWidget extends Component {
 }
 
 FormWidget.propTypes = {
-  form: formProps,
-  routes: allRoutes
+  form: formProps
 };

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -5,7 +5,6 @@ import ResponseSetList from "./ResponseSetList";
 import CodedSetTable from "../components/CodedSetTable";
 import moment from 'moment';
 import _ from 'lodash';
-import Routes from "../routes";
 import { hashHistory, Link } from 'react-router';
 import currentUserProps from "../prop-types/current_user_props";
 
@@ -138,7 +137,7 @@ export default class QuestionDetails extends Component {
                 <h3 className="panel-title">Linked Response Sets</h3>
               </div>
               <div className="box-content">
-                <ResponseSetList responseSets={_.keyBy(responseSets, 'id')} routes={Routes} />
+                <ResponseSetList responseSets={_.keyBy(responseSets, 'id')} />
               </div>
             </div>
           }

--- a/webpack/components/QuestionWidget.js
+++ b/webpack/components/QuestionWidget.js
@@ -5,7 +5,6 @@ import { bindActionCreators } from 'redux';
 import { questionProps }  from "../prop-types/question_props";
 import { deleteQuestion } from "../actions/questions_actions";
 import currentUserProps from "../prop-types/current_user_props";
-import allRoutes from '../prop-types/route_props';
 
 class QuestionWidget extends Component {
   constructor(props){
@@ -97,8 +96,7 @@ function mapDispatchToProps(dispatch) {
 QuestionWidget.propTypes = {
   question: questionProps,
   currentUser: currentUserProps,
-  deleteQuestion: PropTypes.func,
-  routes: allRoutes
+  deleteQuestion: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionWidget);

--- a/webpack/components/ResponseSetList.js
+++ b/webpack/components/ResponseSetList.js
@@ -7,7 +7,7 @@ export default class ResponseSetList extends Component {
     return (
       <div className="response-set-list">
         {_.values(this.props.responseSets).map((rs) => {
-          return <ResponseSetWidget key={rs.id} responseSet={rs} routes={this.props.routes} />;
+          return <ResponseSetWidget key={rs.id} responseSet={rs} />;
         })}
       </div>
     );
@@ -15,6 +15,5 @@ export default class ResponseSetList extends Component {
 }
 
 ResponseSetList.propTypes = {
-  responseSets: PropTypes.object.isRequired,
-  routes: ResponseSetWidget.propTypes.routes.isRequired
+  responseSets: PropTypes.object.isRequired
 };

--- a/webpack/components/ResponseSetWidget.js
+++ b/webpack/components/ResponseSetWidget.js
@@ -1,6 +1,7 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { Link } from 'react-router';
 import { responseSetProps } from '../prop-types/response_set_props';
+import routes from '../routes';
 
 export default class ResponseSetWidget extends Component {
   render() {
@@ -42,7 +43,7 @@ export default class ResponseSetWidget extends Component {
                       </Link>
                     </li>
                     <li>
-                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={this.props.routes.responseSetPath(this.props.responseSet)}>Delete</a>
+                      <a data-confirm="Are you sure?" rel="nofollow" data-method="delete" href={routes.responseSetPath(this.props.responseSet)}>Delete</a>
                     </li>
                   </ul>
                 </div>
@@ -56,8 +57,5 @@ export default class ResponseSetWidget extends Component {
 }
 
 ResponseSetWidget.propTypes = {
-  responseSet: responseSetProps,
-  routes: PropTypes.shape({
-    responseSetPath: PropTypes.func.isRequired
-  })
+  responseSet: responseSetProps
 };

--- a/webpack/components/SearchWidget.js
+++ b/webpack/components/SearchWidget.js
@@ -1,4 +1,4 @@
-import React, { Component, PropTypes } from 'react';
+import React, { Component } from 'react';
 import { questionsProps } from "../prop-types/question_props";
 import { responseSetsProps } from "../prop-types/response_set_props";
 import QuestionList from './QuestionList';
@@ -79,8 +79,8 @@ export default class SearchWidget extends Component {
     return (
       <div className="search-widget">
         <SearchWidgetBar onSearchTermChange={(term, category) => this.refreshSearch(term, category)} />
-        <ResponseSetList responseSets={this.state.responseSets} routes={this.props.routes} />
-        <QuestionList questions={this.state.questions} routes={this.props.routes} />
+        <ResponseSetList responseSets={this.state.responseSets} />
+        <QuestionList questions={this.state.questions} />
       </div>
     );
   }
@@ -89,5 +89,4 @@ export default class SearchWidget extends Component {
 SearchWidget.propTypes = {
   responseSets: responseSetsProps,
   questions: questionsProps,
-  routes: PropTypes.object.isRequired
 };


### PR DESCRIPTION
If a component needs to access Rails routes, it now imports them
directly. Using Rails routes in the components should be avoided anyway
since hitting the server should be done in actions.

Removed the mock_routes as they are no longer needed by the test suite.

Fixed many eslint issues in the tests. Not all, as we have some
commented code in there that we may enable later, but creates some
unused variables.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [NA] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [NA] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [NA] If any database changes were made, run `rake generate_erd` to update the README.md
- [NA] If any changes were made to config/routes.rb run `rake jsroutes:generate`
