### PR TITLE
[SDP-404] Updating concept search modal to work without selecting a system

### DIFF
--- a/webpack/actions/concepts_actions.js
+++ b/webpack/actions/concepts_actions.js
@@ -17,17 +17,18 @@ export function fetchConceptSystems() {
 }
 
 export function fetchConcepts(system, searchTerm, version) {
+  var params  = {search:  searchTerm};
+  if (system && system !== ''){
+    params.version = version;
+    params.system  = system;
+  }
   return {
     type: FETCH_CONCEPTS,
     payload: axios.get(routes.conceptServiceSearchPath(), {
       headers: {
         'Accept': 'application/json'
       },
-      params: {
-        system:  system,
-        version: version,
-        search:  searchTerm
-      }
+      params: params
     })
   };
 }

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -9,7 +9,7 @@ class CodedSetTableEditContainer extends Component {
   constructor(props) {
     super(props);
     var items = props.initialItems.length < 1 ? [{value: '', codeSystem: '', displayName: ''}] : props.initialItems;
-    this.state = {items: items, parentName: props.parentName, childName: props.childName, showConceptModal: false, selectedSystem:'', selectedConcepts:[], searchTerm:''};
+    this.state = {items: items, parentName: props.parentName, childName: props.childName, showConceptModal: false, selectedSystem: '', selectedConcepts: [], searchTerm: ''};
     this.handleSearchChange = this.handleSearchChange.bind(this);
     this.hideCodeSearch = this.hideCodeSearch.bind(this);
   }
@@ -56,11 +56,11 @@ class CodedSetTableEditContainer extends Component {
   }
 
   showCodeSearch(){
-    this.setState({ showConceptModal: true });
+    this.setState({ showConceptModal: true});
   }
 
   hideCodeSearch(){
-    this.setState({showConceptModal: false });
+    this.setState({showConceptModal: false});
     this.setState({selectedSystem: ''});
     this.setState({selectedConcepts: []});
   }
@@ -87,7 +87,7 @@ class CodedSetTableEditContainer extends Component {
     if(e.target.checked){
       newConcepts = _.concat(this.state.selectedConcepts, selectedConcept);
     }else{
-      newConcepts = _.filter(this.state.selectedConcepts, (c)=> {
+      newConcepts = _.filter(this.state.selectedConcepts, (c) => {
         return (c.code !== selectedConcept.code);
       });
     }
@@ -95,7 +95,7 @@ class CodedSetTableEditContainer extends Component {
   }
 
   addSelectedConcepts(){
-    this.addItemRows(this.state.selectedConcepts.map((c)=> {
+    this.addItemRows(this.state.selectedConcepts.map((c) => {
       return {displayName: c.display, codeSystem: c.system, value: c.code};
     }));
     this.hideCodeSearch();
@@ -113,47 +113,47 @@ class CodedSetTableEditContainer extends Component {
               <DropdownButton
                 componentClass={InputGroup.Button}
                 id="system-select-dropdown"
-                title={this.state.selectedSystem ? this.state.selectedSystem : 'Code System'} onSelect={(key, e)=> this.searchConcepts(e.target.text)} >
+                title={this.state.selectedSystem ? this.state.selectedSystem : 'Code System'} onSelect={(key, e) => this.searchConcepts(e.target.text)} >
                 <MenuItem key={0} value={''}>None</MenuItem>
-                {_.values(this.props.conceptSystems).map((s,i) => {
+                {_.values(this.props.conceptSystems).map((s, i) => {
                   return <MenuItem key={i} value={s.name}>{s.name}</MenuItem>;
                 })}
               </DropdownButton>
-            <FormControl type="text" onChange={(e)=>this.handleSearchChange(e)} placeholder="Search Codes"/>
-             <FormControl.Feedback>
-              <Glyphicon glyph="search"/>
-            </FormControl.Feedback>
+              <FormControl type="text" onChange={(e) => this.handleSearchChange(e)} placeholder="Search Codes"/>
+              <FormControl.Feedback>
+                <Glyphicon glyph="search"/>
+              </FormControl.Feedback>
             </InputGroup>
           </FormGroup>
-            <table className="table table-striped scroll-table-header">
-              <thead>
-                <tr>
+          <table className="table table-striped scroll-table-header">
+            <thead>
+              <tr>
                 <th style={{width: '9%', paddingRight:' 0px', paddingBottom: '0px'}}>Add</th>
                 <th style={{width: '50%', padding:' 0px'}}>Display Name</th>
                 <th style={{width: '10%', padding:' 0px'}}>Code</th>
                 <th style={{width: '30%', padding:' 0px'}}>Code System</th>
-                </tr>
-              </thead>
-            </table>
-            <div className='table-scrolling-div'>
+              </tr>
+            </thead>
+          </table>
+          <div className='table-scrolling-div'>
             <table className="table table-striped scroll-table-body">
-            <tbody>
-              {_.values(this.props.concepts[this.state.selectedSystem]).map((c,i) => {
-                return (
-                  <tr key={i}>
-                  <td><ControlLabel bsClass='checkbox-label'><Checkbox onChange={(e)=>this.selectConcept(e,i)} name={`checkbox_${i}`}></Checkbox></ControlLabel></td>
-                   <td>{c.display}</td>
-                   <td>{c.code}</td>
-                   <td>{c.system}</td>
-                  </tr>);
-              })}
-            </tbody>
+              <tbody>
+                {_.values(this.props.concepts[this.state.selectedSystem]).map((c, i) => {
+                  return (
+                    <tr key={i}>
+                      <td><ControlLabel bsClass='checkbox-label'><Checkbox onChange={(e) => this.selectConcept(e,i)} name={`checkbox_${i}`}></Checkbox></ControlLabel></td>
+                      <td>{c.display}</td>
+                      <td>{c.code}</td>
+                      <td>{c.system}</td>
+                    </tr>);
+                })}
+              </tbody>
             </table>
-            </div>
+          </div>
         </Modal.Body>
         <Modal.Footer>
-        <Button onClick={()=>this.hideCodeSearch()} bsStyle="primary">Cancel</Button>
-        <Button onClick={()=>this.addSelectedConcepts()} bsStyle="primary">Add</Button>
+          <Button onClick={() => this.hideCodeSearch()} bsStyle="primary">Cancel</Button>
+          <Button onClick={() => this.addSelectedConcepts()} bsStyle="primary">Add</Button>
         </Modal.Footer>
       </Modal>
     );
@@ -161,32 +161,33 @@ class CodedSetTableEditContainer extends Component {
 
   render() {
     return (
-      <table className="set-table ">
-      {this.conceptModal()}
+      <table className="set-table">
+        {this.conceptModal()}
         <thead>
           <tr>
-            <th><a title="Search Codes" href="#" onClick={(e)=>{
-              e.preventDefault();
-              this.showCodeSearch();
-            }}><i className="fa fa-search fa-2x"></i></a></th>
+            <th>
+              <a title="Search Codes" href="#" onClick={(e) => {
+                e.preventDefault();
+                this.showCodeSearch();
+              }}><i className="fa fa-search fa-2x"></i></a>
+            </th>
             <th>{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
             <th>Code System</th>
             <th>Display Name</th>
-            <th > <a title="Add Row" href="#" onClick={(e) => {
-              e.preventDefault();
-              this.addItemRow();
-            }}><i className="fa fa-plus fa-2x"></i></a>
+            <th>
+              <a title="Add Row" href="#" onClick={(e) => {
+                e.preventDefault();
+                this.addItemRow();
+              }}><i className="fa fa-plus fa-2x"></i></a>
             </th>
           </tr>
         </thead>
         <tbody>
-
           {this.state.items.map((r, i) => {
-
             return (
               <tr key={i}>
-              <td>
-              </td>
+                <td>
+                </td>
                 <td>
                   <label className="hidden" htmlFor={`value_${i}`}>Value</label>
                   <input className="input-format" type="text" value={r.value} name="value" id={`value_${i}`} onChange={this.handleChange(i, 'value')}/>
@@ -200,7 +201,7 @@ class CodedSetTableEditContainer extends Component {
                   <input className="input-format" type="text" value={r.displayName} name="displayName" id={`displayName_${i}`} onChange={this.handleChange(i, 'displayName')}/>
                 </td>
                 <td>
-                <label className="hidden" htmlFor={`remove_${i}`}>Remove</label>
+                  <label className="hidden" htmlFor={`remove_${i}`}>Remove</label>
                   <a href="#" title="Remove" id={`remove_${i}`} onClick={(e) => {
                     e.preventDefault();
                     this.removeItemRow(i);
@@ -216,10 +217,7 @@ class CodedSetTableEditContainer extends Component {
 }
 
 function mapStateToProps(state) {
-  const props = {};
-  props.conceptSystems = state.conceptSystems;
-  props.concepts = state.concepts;
-  return props;
+  return {concepts: state.concepts, conceptSystems: state.conceptSystems};
 }
 
 function mapDispatchToProps(dispatch) {

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -9,7 +9,7 @@ class CodedSetTableEditContainer extends Component {
   constructor(props) {
     super(props);
     var items = props.initialItems.length < 1 ? [{value: '', codeSystem: '', displayName: ''}] : props.initialItems;
-    this.state = {items: items, parentName: props.parentName, childName: props.childName, showConceptModal: false, selectedSystem:'', selectedConcepts:[]};
+    this.state = {items: items, parentName: props.parentName, childName: props.childName, showConceptModal: false, selectedSystem:'', selectedConcepts:[], searchTerm:''};
     this.handleSearchChange = this.handleSearchChange.bind(this);
     this.hideCodeSearch = this.hideCodeSearch.bind(this);
   }
@@ -65,17 +65,20 @@ class CodedSetTableEditContainer extends Component {
     this.setState({selectedConcepts: []});
   }
 
-  searchConcepts(system, search='', version=1){
-    this.setState({selectedSystem: system});
-    this.props.fetchConcepts(system, search, version);
+  searchConcepts(system){
+    if(system=='None'){
+      this.setState({selectedSystem: ''});
+      this.props.fetchConcepts('', this.state.searchTerm, 1);
+    } else {
+      this.setState({selectedSystem: system});
+      this.props.fetchConcepts(system, this.state.searchTerm, 1);
+    }
   }
 
   handleSearchChange(e){
     var value = e.target.value;
-    this.setState({selectedConcepts: []});
-    if(this.state.selectedSystem){
-      this.props.fetchConcepts(this.state.selectedSystem, value, 1);
-    }
+    this.setState({selectedConcepts: [], searchTerm: value});
+    this.props.fetchConcepts(this.state.selectedSystem, value, 1);
   }
 
   selectConcept(e,i){
@@ -110,16 +113,17 @@ class CodedSetTableEditContainer extends Component {
               <DropdownButton
                 componentClass={InputGroup.Button}
                 id="system-select-dropdown"
-                title="Code System" onSelect={(key, e)=> this.searchConcepts(e.target.text)} >
+                title={this.state.selectedSystem ? this.state.selectedSystem : 'Code System'} onSelect={(key, e)=> this.searchConcepts(e.target.text)} >
+                <MenuItem key={0} value={''}>None</MenuItem>
                 {_.values(this.props.conceptSystems).map((s,i) => {
                   return <MenuItem key={i} value={s.name}>{s.name}</MenuItem>;
                 })}
-            </DropdownButton>
-          <FormControl type="text" onChange={(e)=>this.handleSearchChange(e)} placeholder="Search Codes"/>
-           <FormControl.Feedback>
-            <Glyphicon glyph="search"/>
-          </FormControl.Feedback>
-          </InputGroup>
+              </DropdownButton>
+            <FormControl type="text" onChange={(e)=>this.handleSearchChange(e)} placeholder="Search Codes"/>
+             <FormControl.Feedback>
+              <Glyphicon glyph="search"/>
+            </FormControl.Feedback>
+            </InputGroup>
           </FormGroup>
             <table className="table table-striped scroll-table-header">
               <thead>
@@ -161,14 +165,14 @@ class CodedSetTableEditContainer extends Component {
       {this.conceptModal()}
         <thead>
           <tr>
-            <th><a  title="Search Codes" href="#" onClick={(e)=>{
+            <th><a title="Search Codes" href="#" onClick={(e)=>{
               e.preventDefault();
               this.showCodeSearch();
             }}><i className="fa fa-search fa-2x"></i></a></th>
             <th>{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
             <th>Code System</th>
             <th>Display Name</th>
-            <th > <a  title="Add Row" href="#" onClick={(e) => {
+            <th > <a title="Add Row" href="#" onClick={(e) => {
               e.preventDefault();
               this.addItemRow();
             }}><i className="fa fa-plus fa-2x"></i></a>
@@ -228,12 +232,12 @@ CodedSetTableEditContainer.propTypes = {
     codeSystem:  PropTypes.string,
     displayName: PropTypes.string
   })),
+  concepts:  PropTypes.object,
+  childName: PropTypes.string,
   parentName:  PropTypes.string,
-  childName:   PropTypes.string,
   itemWatcher: PropTypes.func,
+  fetchConcepts:  PropTypes.func,
   conceptSystems: PropTypes.object,
-  concepts: PropTypes.object,
-  fetchConcepts: PropTypes.func,
   fetchConceptSystems: PropTypes.func
 };
 

--- a/webpack/styles/widgets/_modal.scss
+++ b/webpack/styles/widgets/_modal.scss
@@ -3,6 +3,7 @@
 }
 #system-select-dropdown{
   height: 34px;
+  max-width: 200px;
 }
 .modal-header-concept{
   padding-top:10px;


### PR DESCRIPTION
The UI and backing code is updated, works with either version of the concept microservice, can't see it working yet because the new version of the microservice isn't up yet. When it is updated, this code will just work.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- na Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- na If any database changes were made, run `rake generate_erd` to update the README.md
- na If any changes were made to config/routes.rb run `rake jsroutes:generate`
