### PR TITLE
[SDP-366, 380] New responseset modal

### DIFF
--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -111,6 +111,24 @@ Feature: Manage Forms
     And I should see "What is your gender?"
     And I should see "What is your favorite color?"
 
+  Scenario: Create New Form from List and Create a Response Set using New Response Set Modal
+    Given I have a Response Set with the name "Gender Full"
+    And I have a Question with the content "What is your gender?" and the type "MC"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Forms
+    And I click on the "New Form" link
+    And I fill in the "name" field with "Test Form"
+    And I fill in the "controlNumber" field with "1234-1234"
+    And I fill in the "description" field with "Form description"
+    And I click on the button to add the Question "What is your gender?"
+    Then I click on the "Add New Response Set" button
+    Then I fill in the "response_set_name" field with "New Response Set"
+    And I click on the "Add Response Set" button
+    Then I select the "New Response Set" option in the "responseSet" list
+    And I click on the "Save" button
+    Then I should see "Test Form"
+    And I should see "What is your gender?"
+
   Scenario: Create New Form from List with warning modal
     Given I have a Response Set with the name "Gender Full"
     And I have a Question with the content "What is your gender?" and the type "MC"

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -116,7 +116,7 @@ Feature: Manage Forms
     And I have a Question with the content "What is your gender?" and the type "MC"
     And I am logged in as test_author@gmail.com
     When I go to the list of Forms
-    And I click on the "New Form" link
+    And I click on the create "Forms" dropdown item
     And I fill in the "name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "description" field with "Form description"

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -120,7 +120,8 @@ Feature: Manage Forms
     And I fill in the "name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "description" field with "Form description"
-    And I click on the button to add the Question "What is your gender?"
+    And I fill in the "search" field with "What"
+    And I click on the "Add to Form" drop-down option for "What is your gender?"
     Then I click on the "Add New Response Set" button
     Then I fill in the "response_set_name" field with "New Response Set"
     And I click on the "Add Response Set" button

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -89,14 +89,13 @@ Feature: Manage Questions
     And I fill in the "Question" field with "What is your favorite color?"
     And I fill in the "Description" field with "This is a description"
     And I drag the "Gender Full" option to the "Selected Response Sets" list
-    Then I click on the "add-new-response-set" button
+    Then I click on the "Add New Response Set" button
     Then I fill in the "response_set_name" field with "New Response Set"
     And I click on the "Add Response Set" button
     Then I should see "New Response Set"
     And I click on the "Create Question" button
     And I should see "What is your favorite color?"
     And I should see "New Response Set"
-    And I should see "Gender Full"
 
   Scenario: Create New Question from List with Warning Modal
     Given I have a Response Set with the name "Gender Full"

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -81,42 +81,22 @@ Feature: Manage Questions
     And I should see "This is an extended description"
     And I should not see "This is a question"
 
-  Scenario: Create New Question from List
+  Scenario: Create New Question from List and Create a Response Set using New Response Set Modal
     Given I have a Response Set with the name "Gender Full"
-    And I have a Question Type with the name "Multiple Choice"
-    And I have a Response Type with the name "Integer"
     And I am logged in as test_author@gmail.com
     When I go to the list of Questions
     And I click on the create "Questions" dropdown item
     And I fill in the "Question" field with "What is your favorite color?"
     And I fill in the "Description" field with "This is a description"
     And I drag the "Gender Full" option to the "Selected Response Sets" list
-    And I select the "Multiple Choice" option in the "Category" list
-    And I select the "Integer" option in the "Primary Response Type" list
-    And I click on the "Add Row" link
-    And I click on the "Add Row" link
-    And I fill in the "value_0" field with "Test Concept 1"
-    And I fill in the "value_1" field with "Test Concept 2"
-    And I fill in the "value_2" field with "Test Concept 3"
-    And I fill in the "codeSystem_0" field with "Test System 1"
-    And I fill in the "codeSystem_1" field with "Test System 2"
-    And I fill in the "codeSystem_2" field with "Test System 3"
-    And I fill in the "displayName_0" field with "Test Name 1"
-    And I fill in the "displayName_1" field with "Test Name 2"
-    And I fill in the "displayName_2" field with "Test Name 3"
-    And I click on the "remove_2" link
+    Then I click on the "add-new-response-set" button
+    Then I fill in the "response_set_name" field with "New Response Set"
+    And I click on the "Add Response Set" button
+    Then I should see "New Response Set"
     And I click on the "Create Question" button
     And I should see "What is your favorite color?"
-    And I should see "This is a description"
-    And I should see "Test Concept 1"
-    And I should see "Test Concept 2"
-    And I should not see "Test Concept 3"
-    And I should see "Test System 1"
-    And I should see "Test System 2"
-    And I should not see "Test System 3"
-    And I should see "Test Name 1"
-    And I should see "Test Name 2"
-    And I should not see "Test Name 3"
+    And I should see "New Response Set"
+    And I should see "Gender Full"
 
   Scenario: Create New Question from List with Warning Modal
     Given I have a Response Set with the name "Gender Full"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -118,7 +118,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I click on the "Add Row" link
@@ -149,7 +149,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"
@@ -165,7 +165,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -39,7 +39,7 @@ Feature: Manage Response Sets
     And I click on the option to Details the Response Set with the name "Gender Full"
     Then I should see "Edit"
     When I click on the "Edit" button
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Save" button
     Then I should see "Gender Partial"
@@ -67,7 +67,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Revise the Response Set with the name "Gender Full"
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"
@@ -101,7 +101,7 @@ Feature: Manage Response Sets
     And I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Extend the Response Set with the name "Gender Full"
-    And I fill in the "Name" field with "Gender Partial"
+    And I fill in the "response_set_name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F / O"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -17,7 +17,7 @@ When(/^I go to the dashboard$/) do
   visit '/'
 end
 
-When(/^I wait (\d+) second\(s\)$/) do |seconds|
+Then(/^I wait (\d+) seconds$/) do |seconds|
   sleep seconds.to_i
 end
 
@@ -101,6 +101,10 @@ When(/^I drag the "([^"]*)" option to the "([^"]*)" list$/) do |option, target|
   target = '.' + target.downcase.tr(' ', '_')
   drop = find(target)
   drag.drag_to(drop)
+end
+
+Then(/^I take a screenshot named (.*)$/) do |name|
+  page.save_screenshot('/tmp/' + name + '.png')
 end
 
 def create_path(object_type, object_id)

--- a/test/frontend/components/form_edit_test.js
+++ b/test/frontend/components/form_edit_test.js
@@ -14,6 +14,7 @@ describe('FormEdit', () => {
       removeQuestion: ()=>{},
       action: 'new',
       formSubmitter:  ()=>{},
+      showResponseSetModal:  ()=>{},
       router: router,
       questions: {1: {id: 1, content: "Is this a question?", questionType: "", responseSets: [1], concepts: [{code:"Code 1",display:" Display Name 1",system:"Test system 1"}]}}
     };

--- a/test/frontend/components/response_set_form_test.js
+++ b/test/frontend/components/response_set_form_test.js
@@ -11,6 +11,7 @@ describe('ResponseSetForm', () => {
       responseSet: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1",
         responses:[{value: 'val', codeSystem: 'codesystem', displayName: 'displayname'}]},
       router: router,
+      route: 'route',
       action: 'revise',
     };
     component = renderComponent(ResponseSetForm, props);

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -15,15 +15,16 @@ let AddedQuestions = ({form, reorderQuestion, removeQuestion, responseSets, hand
   form.version = form.version || 1;
   return (
     <div id="added-questions" aria-label="Added">
-    <div className="question-group">
       <div className="row">
-          <div className="response-set-header">
-            <div className="col-md-5"><b>Content</b></div>
-            <div className="col-md-6"><b>Response Sets</b></div>
+        <div className="response-set-header">
+          <div className="col-md-5 response-set-label"><span><b>Content</b></span></div>
+          <div className="col-md-7 response-set-label">
+            <span className="right"><b>Response Sets</b></span>
             <Button onClick={()=>showResponseSetModal()} bsStyle="primary">Add New Response Set</Button>
           </div>
+        </div>
       </div>
-      <br/>
+    <div className="question-group">
       {form.formQuestions.map((q, i) =>
         <div className="row" key={i}>
           <div className="col-md-9">
@@ -271,7 +272,7 @@ FormEdit.propTypes = {
   router: PropTypes.object.isRequired,
   responseSets: PropTypes.arrayOf(responseSetProps),
   questions: PropTypes.arrayOf(questionProps).isRequired,
-  showResponseSetModal: PropTypes.func
+  showResponseSetModal: PropTypes.func.isRequired
 };
 
 export default FormEdit;

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -5,20 +5,31 @@ import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
 import QuestionItem from './QuestionItem';
 import Errors from './Errors';
+import {Button} from 'react-bootstrap';
 import _ from 'lodash';
 import ModalDialog from './ModalDialog';
 
-let AddedQuestions = ({form, reorderQuestion, removeQuestion, responseSets, handleResponseSetChange, questions}) => {
+let AddedQuestions = ({form, reorderQuestion, removeQuestion, responseSets, handleResponseSetChange, questions, showResponseSetModal}) => {
   let questionsLookup = _.keyBy(questions, 'id');
   form.formQuestions = form.formQuestions || [];
   form.version = form.version || 1;
   return (
     <div id="added-questions" aria-label="Added">
     <div className="question-group">
+      <div className="row">
+          <div className="response-set-header">
+            <div className="col-md-5"><b>Content</b></div>
+            <div className="col-md-6"><b>Response Sets</b></div>
+            <Button onClick={()=>showResponseSetModal()} bsStyle="primary">Add New Response Set</Button>
+          </div>
+      </div>
+      <br/>
       {form.formQuestions.map((q, i) =>
         <div className="row" key={i}>
           <div className="col-md-9">
-            <QuestionItem question={questionsLookup[q.questionId]} responseSets={responseSets} index={i}
+            <QuestionItem index={i}
+                          question={questionsLookup[q.questionId]}
+                          responseSets={responseSets}
                           removeQuestion={removeQuestion}
                           reorderQuestion={reorderQuestion}
                           handleResponseSetChange={handleResponseSetChange}
@@ -54,8 +65,8 @@ AddedQuestions.propTypes = {
   reorderQuestion: PropTypes.func.isRequired,
   removeQuestion: PropTypes.func.isRequired,
   handleResponseSetChange: PropTypes.func.isRequired,
+  showResponseSetModal: PropTypes.func,
   responseSets: PropTypes.arrayOf(responseSetProps)
-
 };
 
 
@@ -69,8 +80,8 @@ class FormEdit extends Component {
     const description = form.description || '';
     const formQuestions = form.formQuestions;
     const controlNumber = form.controlNumber;
-    const showModal = false;
-    return {formQuestions, name, id, version, versionIndependentId, controlNumber, description, showModal};
+    const showWarningModal = false;
+    return {formQuestions, name, id, version, versionIndependentId, controlNumber, description, showWarningModal};
   }
 
   stateForEdit(form) {
@@ -81,8 +92,8 @@ class FormEdit extends Component {
     const description = form.description || '';
     const formQuestions = form.formQuestions;
     const controlNumber = form.controlNumber;
-    const showModal = false;
-    return {formQuestions, name, id, version, versionIndependentId, controlNumber, description, showModal};
+    const showWarningModal = false;
+    return {formQuestions, name, id, version, versionIndependentId, controlNumber, description, showWarningModal};
   }
 
   constructor(props) {
@@ -114,13 +125,13 @@ class FormEdit extends Component {
   }
 
   routerWillLeave(nextLocation) {
-    this.setState({ showModal: this.unsavedState });
+    this.setState({ showWarningModal: this.unsavedState });
     this.nextLocation = nextLocation;
     return !this.unsavedState;
   }
 
   handleModalResponse(leavePage){
-    this.setState({ showModal: false });
+    this.setState({ showWarningModal: false });
     if(leavePage){
       this.unsavedState = false;
       this.props.router.push(this.nextLocation.pathname);
@@ -189,25 +200,24 @@ class FormEdit extends Component {
     return (
       <div className="col-md-8">
       <div className="" id='form-div'>
-      <ModalDialog  show={this.state.showModal}
-        title="Warning"
-        subTitle="Unsaved Changes"
-        warning={true}
-        message="You are about to leave a page with unsaved changes. How would you like to proceed?"
-        secondaryButtonMessage="Continue Without Saving"
-        primaryButtonMessage="Save & Leave"
-        cancelButtonMessage="Cancel"
-        primaryButtonAction={()=> this.handleModalResponse(false)}
-        cancelButtonAction ={()=> {
-          this.props.router.push(this.props.route.path);
-          this.setState({ showModal: false });
-        }}
-        secondaryButtonAction={()=> this.handleModalResponse(true)} />
+      <ModalDialog show={this.state.showWarningModal}
+                   title="Warning"
+                   subTitle="Unsaved Changes"
+                   warning={true}
+                   message="You are about to leave a page with unsaved changes. How would you like to proceed?"
+                   secondaryButtonMessage="Continue Without Saving"
+                   primaryButtonMessage="Save & Leave"
+                   cancelButtonMessage="Cancel"
+                   primaryButtonAction={()=> this.handleModalResponse(false)}
+                   cancelButtonAction ={()=> {
+                     this.props.router.push(this.props.route.path);
+                     this.setState({ showWarningModal: false });
+                   }}
+                   secondaryButtonAction={()=> this.handleModalResponse(true)} />
       <form onSubmit={(e) => this.handleSubmit(e)}>
         <Errors errors={this.state.errors} />
           <div className="form-inline">
             <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span></button>
-
             <input className='btn btn-default pull-right' name="Save Form" type="submit" value={`Save`}/>
             <button className="btn btn-default pull-right" disabled>Export</button>
             {this.cancelButton()}
@@ -238,11 +248,12 @@ class FormEdit extends Component {
           </div>
         </div>
         <AddedQuestions form={this.state}
-          questions={this.props.questions}
-          responseSets={this.props.responseSets}
-          reorderQuestion={this.props.reorderQuestion}
-          removeQuestion={this.props.removeQuestion}
-          handleResponseSetChange={this.handleResponseSetChange(this)} />
+                        questions={this.props.questions}
+                        responseSets={this.props.responseSets}
+                        reorderQuestion={this.props.reorderQuestion}
+                        removeQuestion ={this.props.removeQuestion}
+                        showResponseSetModal={this.props.showResponseSetModal.bind(this)}
+                        handleResponseSetChange={this.handleResponseSetChange.bind(this)} />
       </form>
       </div>
       </div>
@@ -259,7 +270,8 @@ FormEdit.propTypes = {
   route:  PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   responseSets: PropTypes.arrayOf(responseSetProps),
-  questions: PropTypes.arrayOf(questionProps).isRequired
+  questions: PropTypes.arrayOf(questionProps).isRequired,
+  showResponseSetModal: PropTypes.func
 };
 
 export default FormEdit;

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -1,9 +1,10 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import Errors from './Errors';
 import { questionProps } from '../prop-types/question_props';
 import { responseSetsProps } from '../prop-types/response_set_props';
+import Errors from './Errors';
 import ModalDialog from './ModalDialog';
+import ResponseSetModal from './ResponseSetModal';
 import ResponseSetDragWidget from './ResponseSetDragWidget';
 import CodedSetTableEditContainer from '../containers/CodedSetTableEditContainer';
 import _ from 'lodash';
@@ -26,6 +27,7 @@ class QuestionForm extends Component{
         this.state = this.stateForRevise(this.props.question);
     }
     this.handleResponseSetsChange = this.handleResponseSetsChange.bind(this);
+    this.handleResponseSetSuccess = this.handleResponseSetSuccess.bind(this);
     this.unsavedState = false;
   }
 
@@ -46,13 +48,13 @@ class QuestionForm extends Component{
   }
 
   routerWillLeave(nextLocation) {
-    this.setState({ showModal: this.unsavedState });
+    this.setState({ showWarningModal: this.unsavedState });
     this.nextLocation = nextLocation;
     return !this.unsavedState;
   }
 
   handleModalResponse(leavePage){
-    this.setState({ showModal: false });
+    this.setState({ showWarningModal: false });
     if(leavePage){
       this.unsavedState = false;
       this.props.router.push(this.nextLocation.pathname);
@@ -93,9 +95,11 @@ class QuestionForm extends Component{
       responseTypeId: null,
       conceptsAttributes: [],
       linkedResponseSets: [],
-      showModal: false
+      showWarningModal: false,
+      showResponseSetModal: false
     };
   }
+
   //not working because of map => questionType
   stateForExtend(question) {
     var extendState = {};
@@ -116,10 +120,9 @@ class QuestionForm extends Component{
     if(!question || !questionTypes || !responseSets || !responseTypes){
       return (<div>Loading....</div>);
     }
-
     return (
       <form id="question-edit-form" onSubmit={(e) => this.handleSubmit(e)}>
-      <ModalDialog  show={this.state.showModal}
+      <ModalDialog  show ={this.state.showWarningModal}
                     title="Warning"
                     subTitle="Unsaved Changes"
                     warning={true}
@@ -130,9 +133,12 @@ class QuestionForm extends Component{
                     primaryButtonAction={()=> this.handleModalResponse(false)}
                     cancelButtonAction ={()=> {
                       this.props.router.push(this.props.route.path);
-                      this.setState({ showModal: false });
+                      this.setState({ showWarningModal: false });
                     }}
                     secondaryButtonAction={()=> this.handleModalResponse(true)} />
+        <ResponseSetModal show={this.state.showResponseSetModal}
+                          closeModal={() => this.setState({showResponseSetModal: false})}
+                          saveResponseSetSuccess={this.handleResponseSetSuccess} />
         <Errors errors={this.state.errors} />
         <div className="row">
           <div>
@@ -141,13 +147,12 @@ class QuestionForm extends Component{
                 <h3 className="panel-title">{`${this.actionWord()} Question`}</h3>
               </div>
               <div className="panel-body">
-              <div className="row">
-                  <div className="col-md-8 question-form-group">
+                <div className="row">
+                    <div className="col-md-8 question-form-group">
                       <label className="input-label" htmlFor="content">Question</label>
                       <input className="input-format" placeholder="Question text" type="text" name="content" id="content" defaultValue={state.content} onChange={this.handleChange('content')} />
-                  </div>
-
-                  <div className="col-md-4 question-form-group">
+                    </div>
+                    <div className="col-md-4 question-form-group">
                       <label className="input-label" htmlFor="questionTypeId">Category</label>
                       <select className="input-format" name="questionTypeId" id="questionTypeId" defaultValue={state.questionTypeId} onChange={this.handleChange('questionTypeId')} >
                         <option value=""></option>
@@ -155,59 +160,66 @@ class QuestionForm extends Component{
                           return <option key={qt.id} value={qt.id}>{qt.name}</option>;
                         })}
                       </select>
-                  </div>
-              </div>
-
-              <div className="row ">
-                <div className="col-md-8 question-form-group">
-                  <label className="input-label" htmlFor="description">Description</label>
-                  <textarea className="input-format" placeholder="Question description" type="text" name="question_description" id="description" defaultValue={state.description} onChange={this.handleChange('description')} />
+                    </div>
                 </div>
-                <div className="col-md-4 question-form-group">
-                  <label className="input-label" htmlFor="responseTypeId">Primary Response Type</label>
+                <div className="row ">
+                  <div className="col-md-8 question-form-group">
+                    <label className="input-label" htmlFor="description">Description</label>
+                    <textarea className="input-format" placeholder="Question description" type="text" name="question_description" id="description" defaultValue={state.description} onChange={this.handleChange('description')} />
+                  </div>
+                  <div className="col-md-4 question-form-group">
+                    <label className="input-label" htmlFor="responseTypeId">Primary Response Type</label>
                     <select name="responseTypeId" id="responseTypeId" className="input-format" defaultValue={state.responseTypeId} onChange={this.handleResponseTypeChange()} >
                       {_.values(responseTypes).map((rt) => {
                         return (<option key={rt.id} value={rt.id}>{rt.name} - {rt.description}</option>);
                       })}
                     </select>
+                  </div>
+                  <div className="col-md-4 question-form-group harmonized-group">
+                    <label className="input-label" htmlFor="harmonized">Harmonized: </label>
+                    <input className="form-ckeck-input" type="checkbox" name="harmonized" id="harmonized" checked={state.harmonized} onChange={() => this.toggleHarmonized()} />
+                  </div>
                 </div>
-                <div className="col-md-4 question-form-group harmonized-group">
-                  <label className="input-label" htmlFor="harmonized">Harmonized: </label>
-                  <input className="form-ckeck-input" type="checkbox" name="harmonized" id="harmonized" checked={state.harmonized} onChange={() => this.toggleHarmonized()} />
-                </div>
-
-
-              </div>
-
-              <div className="row ">
-                <div className="col-md-12 ">
+                <div className="row ">
+                  <div className="col-md-12 ">
                     <label className="input-label" htmlFor="concept_id">Concepts</label>
                     <CodedSetTableEditContainer itemWatcher={(r) => this.handleConceptsChange(r)}
                              initialItems={this.state.conceptsAttributes}
                              parentName={'question'}
                              childName={'concept'} />
+                  </div>
                 </div>
-              </div>
-
-              <ResponseSetDragWidget responseSets={responseSets}
-                                     handleResponseSetsChange={this.handleResponseSetsChange}
-                                     selectedResponseSets={question.responseSets && question.responseSets.map((id) => this.props.responseSets[id])} />
-
-              <div className="panel-footer">
-                <div className="actions form-group">
-                  <button type="submit" name="commit" id='submit-question-form' className="btn btn-default" data-disable-with={`${this.actionWord()} Question`}>{`${this.actionWord()} Question`}</button>
-                  {this.publishButton()}
-                  {this.deleteButton()}
-                  {this.cancelButton()}
+                <div className="row response-set-row">
+                  <div className="col-md-6 response-set-label">
+                    <label htmlFor="linked_response_sets">Response Sets</label>
+                  </div>
+                  <div className="col-md-6 response-set-label">
+                    <label htmlFor="selected_response_sets">Selected Response Sets</label>
+                    <a className="btn btn-primary add-new-response-set" id='add-new-response-set' onClick={() => this.setState({showResponseSetModal:true})}>Add New Response Set</a>
+                  </div>
                 </div>
-              </div>
-
+                <ResponseSetDragWidget responseSets={responseSets}
+                                       handleResponseSetsChange={this.handleResponseSetsChange}
+                                       selectedResponseSets={this.state.linkedResponseSets && this.state.linkedResponseSets.map((r) => this.props.responseSets[r] ).filter((r) => r !== undefined)} />
+                <div className="panel-footer">
+                  <div className="actions form-group">
+                    <button type="submit" name="commit" id='submit-question-form' className="btn btn-default" data-disable-with={`${this.actionWord()} Question`}>{`${this.actionWord()} Question`}</button>
+                    {this.publishButton()}
+                    {this.deleteButton()}
+                    {this.cancelButton()}
+                  </div>
+                </div>
               </div>
             </div>
           </div>
         </div>
       </form>
     );
+  }
+
+  actionWord() {
+    const wordMap = {'new': 'Create', 'revise': 'Revise', 'extend': 'Extend', 'edit': 'Edit Draft of'};
+    return wordMap[this.props.action];
   }
 
   cancelButton() {
@@ -250,9 +262,11 @@ class QuestionForm extends Component{
     });
   }
 
-  actionWord() {
-    const wordMap = {'new': 'Create', 'revise': 'Revise', 'extend': 'Extend', 'edit': 'Edit Draft of'};
-    return wordMap[this.props.action];
+  handleResponseSetSuccess(successResponse){
+    this.handleResponseSetsChange(this.state.linkedResponseSets.map((r) => {
+      return {id: r};
+    }).concat([successResponse.data]));
+    this.setState({showResponseSetModal: false});
   }
 
   handleSubmit(event) {
@@ -326,7 +340,7 @@ QuestionForm.propTypes = {
   router: PropTypes.object,
   action: PropTypes.string,
   question: questionProps,
-  responseSets: responseSetsProps,
+  responseSets:  responseSetsProps,
   questionTypes: PropTypes.object,
   responseTypes: PropTypes.object,
   draftSubmitter: PropTypes.func.isRequired,

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -195,7 +195,7 @@ class QuestionForm extends Component{
                   </div>
                   <div className="col-md-6 response-set-label">
                     <label htmlFor="selected_response_sets">Selected Response Sets</label>
-                    <a className="btn btn-primary add-new-response-set" id='add-new-response-set' onClick={() => this.setState({showResponseSetModal:true})}>Add New Response Set</a>
+                    <button className="btn btn-primary add-new-response-set" type="button" id="add-new-response-set" onClick={() => this.setState({showResponseSetModal:true})}>Add New Response Set</button>
                   </div>
                 </div>
                 <ResponseSetDragWidget responseSets={responseSets}

--- a/webpack/components/QuestionResults.js
+++ b/webpack/components/QuestionResults.js
@@ -10,7 +10,7 @@ export default class QuestionResults extends Component {
         <div>
         {!(this.props.questions === undefined)  && this.props.questions.map((question, i) => {
           return (
-            <div className="row" key={i}>
+            <div className="row question-result" key={i}>
               <div data-question-id={question.id}>
                 {this.questionResult(question)}
               </div>
@@ -64,7 +64,7 @@ export default class QuestionResults extends Component {
               <a id={`question_${question.id}_menu`} className="dropdown-toggle" type="" data-toggle="dropdown">
                 <span className="fa fa-ellipsis-h"></span>
               </a>
-              <ul className="dropdown-menu">
+              <ul className="dropdown-menu dropdown-menu-right">
                 {this.reviseOrEditLink(question)}
                 {this.detailsLink(question)}
                 {this.addToFormLink(question)}

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -64,15 +64,13 @@ class ResponseSetDragWidget extends Component{
     return (
       <div className="row response-set-row">
           <div className="col-md-6 question-form-group">
-            <label htmlFor="linked_response_sets">Response Sets</label>
               <div className="fixed-height-list" name="linked_response_sets">
                 {this.props.responseSets && _.values(this.props.responseSets).map((rs, i) => {
                   return <DraggableResponseSet key={i} responseSet={rs}/>;
                 })}
               </div>
           </div>
-          <div className="col-md-6 drop-target selected_response_sets">
-            <label htmlFor="selected_response_sets">Selected Response Sets</label>
+          <div className="col-md-6 drop-target selected_response_sets" name="selected_response_sets">
             <DroppableTarget handleResponseSetsChange={this.props.handleResponseSetsChange} selectedResponseSets={this.props.selectedResponseSets} />
           </div>
       </div>

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -228,9 +228,9 @@ function filterResponses(responses) {
 }
 
 ResponseSetForm.propTypes = {
-  responseSet: responseSetProps.isRequired,
+  responseSet: responseSetProps,
   responseSetSubmitter: PropTypes.func.isRequired,
   action: PropTypes.string.isRequired,
-  route:  PropTypes.object.isRequired,
-  router: PropTypes.object.isRequired
+  route:  PropTypes.object,
+  router: PropTypes.object
 };

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -1,9 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import CodedSetTableEditContainer from '../containers/CodedSetTableEditContainer';
-import Errors from './Errors';
 import { responseSetProps } from '../prop-types/response_set_props';
+import Errors from './Errors';
 import ModalDialog from './ModalDialog';
+import CodedSetTableEditContainer from '../containers/CodedSetTableEditContainer';
 
 export default class ResponseSetForm extends Component {
   constructor(props) {
@@ -26,13 +26,17 @@ export default class ResponseSetForm extends Component {
   }
 
   componentDidMount() {
-    this.unbindHook = this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave.bind(this));
-    window.onbeforeunload = this.windowWillUnload.bind(this);
+    if(this.props.router && this.props.route){
+      this.unbindHook = this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave.bind(this));
+      window.onbeforeunload = this.windowWillUnload.bind(this);
+    }
   }
 
   componentWillUnmount() {
     this.unsavedState = false;
-    this.unbindHook();
+    if(this.unbindHook){
+      this.unbindHook();
+    }
   }
 
   routerWillLeave(nextLocation) {
@@ -120,7 +124,7 @@ export default class ResponseSetForm extends Component {
 
   render() {
     return (
-      <form onSubmit={(e) => this.handleSubmit(e)}>
+      <form id="response-set-edit-form" onSubmit={(e) => this.handleSubmit(e)}>
         <ModalDialog  show={this.state.showModal}
                 title="Warning"
                 subTitle="Unsaved Changes"
@@ -144,8 +148,8 @@ export default class ResponseSetForm extends Component {
             <div className="panel-body">
                 <div className="row">
                   <div className="col-md-8 question-form-group">
-                    <label className="input-label" htmlFor="name">Name</label>
-                    <input className="input-format" type="text" value={this.state.name} name="name" id="name" onChange={this.handleChange('name')}/>
+                    <label className="input-label" htmlFor="response_set_name">Name</label>
+                    <input className="input-format" type="text" value={this.state.name} name="response_set_name" id="name" onChange={this.handleChange('name')}/>
                   </div>
 
                   <div className="col-md-4 question-form-group">
@@ -175,10 +179,9 @@ export default class ResponseSetForm extends Component {
                                    childName={'response'} />
                 </div>
                 <div className="panel-footer">
-
-                    <input className="btn btn-default " type="submit" name="Save Response Set" value="Save" />
-                {this.cancelButton()}
-            </div>
+                  <input className="btn btn-default" id='submit-response-set-form' type="submit" name="Save Response Set" value="Save" />
+                  {this.cancelButton()}
+                </div>
           </div>
         </div>
       </form>

--- a/webpack/components/ResponseSetModal.js
+++ b/webpack/components/ResponseSetModal.js
@@ -1,0 +1,60 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+import { saveResponseSet } from '../actions/response_set_actions';
+import {Modal, Button} from 'react-bootstrap';
+import Errors from '../components/Errors';
+import ResponseSetForm from './ResponseSetForm';
+import $ from 'jquery';
+
+class ResponseSetModal extends Component {
+
+  constructor(props) {
+    super(props);
+    this.state = {};
+    this.saveNewResponseSet = this.saveNewResponseSet.bind(this);
+  }
+
+  saveNewResponseSet(newResponseSet){
+    this.props.saveResponseSet(newResponseSet, (successResponse) => {
+      this.setState({errors: null});
+      this.props.saveResponseSetSuccess(successResponse);
+    }, (failureResponse) => {
+      this.setState({errors: failureResponse.response.data});
+    });
+  }
+
+  render() {
+    return (
+      <Modal bsStyle='response-set' show={this.props.show} onHide={this.props.closeModal}>
+        <Modal.Header closeButton bsStyle='response-set'>
+          <Modal.Title>New Response Set</Modal.Title>
+        </Modal.Header>
+        <Errors errors={this.state.errors} />
+        <Modal.Body bsStyle='response-set'>
+          <ResponseSetForm action={'new'}
+                           router={this.props.router}
+                           responseSetSubmitter={this.saveNewResponseSet}/>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.props.closeModal}>Cancel</Button>
+          <Button onClick={()=> $('#submit-response-set-form').click()} bsStyle="primary">Add Response Set</Button>
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({saveResponseSet}, dispatch);
+}
+
+ResponseSetModal.propTypes = {
+  show: PropTypes.bool.isRequired,
+  router: PropTypes.object.isRequired,
+  closeModal: PropTypes.func.isRequired,
+  saveResponseSet: PropTypes.func,
+  saveResponseSetSuccess: PropTypes.func.isRequired
+};
+
+export default connect(null, mapDispatchToProps)(ResponseSetModal);

--- a/webpack/components/ResponseSetModal.js
+++ b/webpack/components/ResponseSetModal.js
@@ -51,7 +51,7 @@ function mapDispatchToProps(dispatch) {
 
 ResponseSetModal.propTypes = {
   show: PropTypes.bool.isRequired,
-  router: PropTypes.object.isRequired,
+  router: PropTypes.object,
   closeModal: PropTypes.func.isRequired,
   saveResponseSet: PropTypes.func,
   saveResponseSetSuccess: PropTypes.func.isRequired

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -4,6 +4,7 @@ import { bindActionCreators } from 'redux';
 import { fetchForm, saveForm, newForm, saveDraftForm } from '../actions/form_actions';
 import { addQuestion, removeQuestion, reorderQuestion, fetchQuestion, fetchQuestions } from '../actions/questions_actions';
 import FormEdit from '../components/FormEdit';
+import ResponseSetModal from '../components/ResponseSetModal';
 import { fetchResponseSets }   from '../actions/response_set_actions';
 import QuestionModalContainer  from './QuestionModalContainer';
 import QuestionSearchContainer from './QuestionSearchContainer';
@@ -29,8 +30,8 @@ class FormsEditContainer extends Component {
       this.props.params.action = 'new';
     }
     this.state = {selectedFormSaver: selectedFormSaver, showQuestionModal: false};
-    this.closeQuestionModal  = this.closeQuestionModal.bind(this);
-    this.saveQuestionSuccess = this.saveQuestionSuccess.bind(this);
+    this.closeQuestionModal = this.closeQuestionModal.bind(this);
+    this.handleSaveQuestionSuccess = this.handleSaveQuestionSuccess.bind(this);
   }
 
   componentWillMount() {
@@ -51,7 +52,7 @@ class FormsEditContainer extends Component {
     this.setState({showQuestionModal: false});
   }
 
-  saveQuestionSuccess(successResponse){
+  handleSaveQuestionSuccess(successResponse){
     this.setState({showQuestionModal: false});
     this.props.fetchQuestion(successResponse.data.id);
     this.props.addQuestion(this.props.form, successResponse.data);
@@ -64,19 +65,22 @@ class FormsEditContainer extends Component {
       );
     }
     return (
-      <div className="container">
+      <div className="form-edit-container">
         <QuestionModalContainer route ={this.props.route}
                                 router={this.props.router}
                                 showModal={this.state.showQuestionModal}
                                 closeQuestionModal ={()=>this.setState({showQuestionModal: false})}
-                                saveQuestionSuccess={this.saveQuestionSuccess} />
+                                handleSaveQuestionSuccess={this.handleSaveQuestionSuccess} />
+        <ResponseSetModal show={this.state.showResponseSetModal}
+                          closeModal={() => this.setState({showResponseSetModal: false})}
+                          saveResponseSetSuccess={() => this.setState({showResponseSetModal: false})} />
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
               <h3 className="panel-title">{_.capitalize(this.props.params.action)} Form </h3>
             </div>
             <div className="panel-body">
-              <div className="col-md-4">
+              <div className="col-md-3">
                 <div className="row add-question">
                   <Button onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
                 </div>
@@ -85,7 +89,7 @@ class FormsEditContainer extends Component {
                                          form ={this.props.form}
                                          reverseSort={true} />
               </div>
-              <FormEdit ref ='form'
+              <FormEdit ref='form'
                     form={this.props.form}
                     action={this.props.params.action || 'new'}
                     route ={this.props.route}
@@ -94,7 +98,8 @@ class FormsEditContainer extends Component {
                     responseSets ={this.props.responseSets}
                     formSubmitter={this.state.selectedFormSaver}
                     removeQuestion ={this.props.removeQuestion}
-                    reorderQuestion={this.props.reorderQuestion} />
+                    reorderQuestion={this.props.reorderQuestion}
+                    showResponseSetModal={() => this.setState({showResponseSetModal: true})} />
             </div>
           </div>
         </div>

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -29,7 +29,7 @@ class FormsEditContainer extends Component {
       this.props.params.formId = 0;
       this.props.params.action = 'new';
     }
-    this.state = {selectedFormSaver: selectedFormSaver, showQuestionModal: false};
+    this.state = {selectedFormSaver: selectedFormSaver, showQuestionModal: false, showResponseSetModal: false};
     this.closeQuestionModal = this.closeQuestionModal.bind(this);
     this.handleSaveQuestionSuccess = this.handleSaveQuestionSuccess.bind(this);
   }
@@ -72,6 +72,7 @@ class FormsEditContainer extends Component {
                                 closeQuestionModal ={()=>this.setState({showQuestionModal: false})}
                                 handleSaveQuestionSuccess={this.handleSaveQuestionSuccess} />
         <ResponseSetModal show={this.state.showResponseSetModal}
+                          router={this.props.router}
                           closeModal={() => this.setState({showResponseSetModal: false})}
                           saveResponseSetSuccess={() => this.setState({showResponseSetModal: false})} />
         <div className="row">
@@ -80,7 +81,7 @@ class FormsEditContainer extends Component {
               <h3 className="panel-title">{_.capitalize(this.props.params.action)} Form </h3>
             </div>
             <div className="panel-body">
-              <div className="col-md-3">
+              <div className="col-md-4">
                 <div className="row add-question">
                   <Button onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
                 </div>

--- a/webpack/containers/QuestionModalContainer.js
+++ b/webpack/containers/QuestionModalContainer.js
@@ -46,10 +46,10 @@ class QuestionModalContainer extends Component {
   }
 
   saveNewQuestion(newQuestion){
-    newQuestion.linkedResponseSets = _.values(this.state.linkedResponseSets).map((r)=> r.id);
+    newQuestion.linkedResponseSets = _.values(this.state.linkedResponseSets).map((r) => r.id);
     this.props.saveQuestion(newQuestion, (successResponse) => {
-      this.setState({showResponseSetWidget:false, linkedResponseSets: {}, errors: null});
-      this.props.saveQuestionSuccess(successResponse);
+      this.setState({showResponseSetWidget: false, linkedResponseSets: {}, errors: null});
+      this.props.handleSaveQuestionSuccess(successResponse);
     }, (failureResponse) => {
       this.setState({errors: failureResponse.response.data});
     });
@@ -64,12 +64,20 @@ class QuestionModalContainer extends Component {
     return (
       <div className={this.state.showResponseSetWidget ? '' : 'hidden'}>
         <Modal.Body bsStyle='response-set'>
+          <div className="row response-set-row">
+            <div className="col-md-6 response-set-label">
+              <label htmlFor="linked_response_sets">Response Sets</label>
+            </div>
+            <div className="col-md-6 response-set-label">
+              <label htmlFor="selected_response_sets">Selected Response Sets</label>
+            </div>
+          </div>
           <ResponseSetDragWidget responseSets={this.props.responseSets}
                                  selectedResponseSets={_.values(this.state.linkedResponseSets)}
                                  handleResponseSetsChange={this.handleResponseSetsChange} />
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={()=>this.setState({showResponseSetWidget:false})} bsStyle="primary">Done</Button>
+          <Button onClick={() => this.setState({showResponseSetWidget:false})} bsStyle="primary">Done</Button>
         </Modal.Footer>
       </div>
     );
@@ -79,14 +87,14 @@ class QuestionModalContainer extends Component {
     if(this.state.showResponseSets){
       return (
         <Modal.Footer>
-        <Button onClick={()=> $('#submit-question-form').click()}>Add Question</Button>
-        <Button onClick={()=> this.setState({showResponseSetWidget:true})} bsStyle="primary">Response Sets</Button>
+          <Button onClick={() => $('#submit-question-form').click()}>Add Question</Button>
+          <Button onClick={() => this.setState({showResponseSetWidget:true})} bsStyle="primary">Response Sets</Button>
         </Modal.Footer>
       );
     } else {
       return (
         <Modal.Footer>
-        <Button onClick={()=> $('#submit-question-form').click()}>Add Question</Button>
+          <Button onClick={() => $('#submit-question-form').click()}>Add Question</Button>
         </Modal.Footer>
       );
     }
@@ -96,12 +104,12 @@ class QuestionModalContainer extends Component {
     var responseSetsDiv = (<div></div>);
     var footer = (
       <Modal.Footer>
-      <Button onClick={()=> $('#submit-question-form').click()}>Add Question</Button>
+        <Button onClick={() => $('#submit-question-form').click()}>Add Question</Button>
       </Modal.Footer>
     );
     if(this.state.showResponseSets){
       responseSetsDiv = (
-        <div className="row selected-response-sets">
+        <div className="row selected_response_sets">
           <label className="input-label" htmlFor="response-set-list">Response Sets</label>
           <div className="col-md-12">
               <div className="panel panel-default">
@@ -114,8 +122,8 @@ class QuestionModalContainer extends Component {
       );
       footer = (
         <Modal.Footer>
-        <Button onClick={()=> $('#submit-question-form').click()}>Add Question</Button>
-        <Button onClick={()=> this.setState({showResponseSetWidget:true})} bsStyle="primary">Response Sets</Button>
+          <Button onClick={() => $('#submit-question-form').click()}>Add Question</Button>
+          <Button onClick={() => this.setState({showResponseSetWidget:true})} bsStyle="primary">Response Sets</Button>
         </Modal.Footer>
       );
     }
@@ -178,7 +186,7 @@ QuestionModalContainer.propTypes = {
   fetchQuestionTypes: PropTypes.func,
   fetchResponseTypes: PropTypes.func,
   closeQuestionModal: PropTypes.func.isRequired,
-  saveQuestionSuccess: PropTypes.func.isRequired
+  handleSaveQuestionSuccess: PropTypes.func.isRequired
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionModalContainer);

--- a/webpack/styles/layouts/_form_edit.scss
+++ b/webpack/styles/layouts/_form_edit.scss
@@ -1,7 +1,13 @@
 .form-edit-container {
+    margin-right: auto;
+    margin-left: auto;
+    padding-left: 15px;
+    padding-right: 15px;
+    width: 1170px;
   .question-group{
     min-height: 500px;
     max-height: 500px;
+    padding-right: 8px;
     overflow-y: auto;
     overflow-x: hidden;
   }
@@ -12,9 +18,25 @@
     }
   }
 
+  .question-result{
+    margin: 0px;
+  }
+
   .response-set-header{
     button {
       float: right;
+    }
+  }
+  .response-set-label{
+    text-align: left;
+    vertical-align: middle;
+    margin-bottom: 0px;
+    span{
+      padding-left: 10px;
+    }
+    span.right{
+      padding-left: 80px;
+      padding-right: 5px;
     }
   }
 }

--- a/webpack/styles/layouts/_form_edit.scss
+++ b/webpack/styles/layouts/_form_edit.scss
@@ -7,5 +7,14 @@
   }
   .add-question{
     padding: 15px;
+    button{
+      margin-right:10px;
+    }
+  }
+
+  .response-set-header{
+    button {
+      float: right;
+    }
   }
 }

--- a/webpack/styles/master.scss
+++ b/webpack/styles/master.scss
@@ -30,7 +30,8 @@
 @import "widgets/recentitems";
 @import "widgets/modal";
 @import "widgets/question_modal";
-@import "layouts/response_set";
+@import "widgets/response_set_modal";
+
 
 //LAYOUTS//
 @import "layouts/body";
@@ -42,6 +43,7 @@
 @import "layouts/contentbox";
 @import "layouts/maincontentarea";
 @import "layouts/form_edit";
+@import "layouts/response_set";
 
 //NAVIGATION//
 @import "navigation/nav";

--- a/webpack/styles/widgets/_questions.scss
+++ b/webpack/styles/widgets/_questions.scss
@@ -11,7 +11,7 @@
   label{
     padding-top: 7px;
   }
-  a{
+  button{
     float:right;
   }
 }

--- a/webpack/styles/widgets/_questions.scss
+++ b/webpack/styles/widgets/_questions.scss
@@ -4,6 +4,21 @@
   margin-bottom: 20px;
 }
 
+.response-set-label {
+  text-align: left;
+  vertical-align: middle;
+  margin-bottom: 0px;
+  label{
+    padding-top: 7px;
+  }
+  a{
+    float:right;
+  }
+}
+
+.selected_response_sets {
+  margin-top: 20px;
+}
 .question-group {
   @extend .panel-group;
   margin-top: 20px;

--- a/webpack/styles/widgets/_response_set_modal.scss
+++ b/webpack/styles/widgets/_response_set_modal.scss
@@ -1,4 +1,4 @@
-.modal-question{
+.modal-response-set{
   width: 60%;
 
   #error_explanation{
@@ -12,14 +12,14 @@
     font-size:16px;
   }
 
-  .modal-header-question{
+  .modal-header-response-set{
     padding-top: 5px;
     padding-bottom: 5px;
     .close {
       margin-top: 0px;
     }
   }
-  .modal-body-question{
+  .modal-body-response-set{
     padding-top:0px;
     padding-bottom: 0px;
 
@@ -50,31 +50,3 @@
   }
 }
 
-.modal-body-response-set{
-  .response-set-group .response-set-container li:first-child {
-      width: unset;
-  }
-}
-.selected_response_sets{
-    .response-set-group:first-child{
-      margin-top: 5px;
-    }
-
-    label{
-      padding-left: 15px;
-      margin-bottom: 0px;
-    }
-    a{
-      padding-left: 10px;
-    }
-    .panel-body{
-      padding-top: 0px;
-      padding-left: 0px;
-      padding-right: 0px;
-    }
-    .panel-default{
-    max-height: 200px;
-    min-height: 30px;
-    overflow-y: auto;
-    }
-  }


### PR DESCRIPTION
Create a new response set from Question form and Form form.
- This should be refactored so QuestionForm isn't responsible for the response set modal, but I've already spent too much time on this and we have other priorities

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
