### PR TITLE
[SDP-392] Boosted query

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,5 +1,3 @@
-require_relative '../../test/elastic_helpers'
-
 # Given clauses
 Given(/^I am logged in as (.+)$/) do |user_name|
   user = User.create_with(password: 'password').find_or_create_by(email: user_name)

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -1,5 +1,3 @@
-require_relative '../../test/elastic_helpers'
-
 Given(/^I have a Form with the name "([^"]*)" and the description "([^"]*)"$/) do |name, description|
   user = get_user 'test_author@gmail.com'
   Form.create!(name: name, description: description, created_by: user)

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -1,5 +1,3 @@
-require_relative '../../test/elastic_helpers'
-
 Given(/^I have a Question with the content "([^"]*)" and the description "([^"]*)" and the type "([^"]*)"\
  and the concept "([^"]*)"$/) do |content, description, type, concept|
   user  = get_user('test_author@gmail.com')

--- a/features/step_definitions/response_set_steps.rb
+++ b/features/step_definitions/response_set_steps.rb
@@ -1,5 +1,3 @@
-require_relative '../../test/elastic_helpers'
-
 Given(/^I have a Response Set with the name "([^"]*)" and the description "([^"]*)" and\
  the response "([^"]*)"$/) do |set_name, desc, response|
   user = get_user 'test_author@gmail.com'

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -10,6 +10,7 @@ require 'capybara/cucumber'
 require 'capybara/accessible'
 
 require 'axe/cucumber/step_definitions'
+require_relative '../../test/elastic_helpers'
 
 FakeWeb.register_uri(:any, %r{http://concept-manager\..*\.xip\.io}, body: '{}')
 

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -1,4 +1,5 @@
 # rubocop:disable Metrics/ModuleLength
+# rubocop:disable Metrics/MethodLength
 module SDP
   module Elasticsearch
     def self.with_client
@@ -15,7 +16,15 @@ module SDP
               { match: { status: 'published' } }
             ] } },
             should: [
-              { match: { name: query_string } }, { match: { description: query_string } }
+              { match: { name: { query: query_string, boost: 9 } } },
+              { match: { description: { query: query_string, boost: 8 } } },
+              { match: { 'codes.code': { query: query_string, boost: 7 } } },
+              { match: { 'codes.codeSystem': { query: query_string, boost: 7 } } },
+              { match: { 'codes.displayName': { query: query_string, boost: 7 } } },
+              { match: { category: { query: query_string } } },
+              { match: { 'createdBy.email': { query: query_string } } },
+              { match: { 'createdBy.name': { query: query_string } } },
+              { match: { status: { query: query_string } } }
             ]
           }
         },
@@ -37,8 +46,15 @@ module SDP
               { match: { status: 'published' } }
             ] } },
             should: [
-              { match: { name: query_string } },
-              { match: { description: query_string } }
+              { match: { name: { query: query_string, boost: 9 } } },
+              { match: { description: { query: query_string, boost: 8 } } },
+              { match: { 'codes.code': { query: query_string, boost: 7 } } },
+              { match: { 'codes.codeSystem': { query: query_string, boost: 7 } } },
+              { match: { 'codes.displayName': { query: query_string, boost: 7 } } },
+              { match: { category: { query: query_string } } },
+              { match: { 'createdBy.email': { query: query_string } } },
+              { match: { 'createdBy.name': { query: query_string } } },
+              { match: { status: { query: query_string } } }
             ]
           }
         },
@@ -137,3 +153,4 @@ module SDP
   end
 end
 # rubocop:enable Metrics/ModuleLength
+# rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
Implemented according to latest discussion encapsulated here:
Ammu Irivinti added a comment - 13/Mar/17 10:15 AM - edited
3/13 Sprint Planning:
Defining relevance for now as:
1. search term appears in content title
2. search term appears in associated concepts
Including the associated response sets / response codes may dilute the actual relevant search result.
Deferring usage (programs & systems using content) as prioritization metric, because this is not currently implemented in the system. Wrote a separate story to handle this in a later Sprint.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
