### PR TITLE
[SDP-419 & SDP-428] Survey on dashboard analytics widget and search results

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -6,9 +6,11 @@ class LandingController < ApplicationController
     response_set_count = ResponseSet.latest_versions.count
     question_count = Question.latest_versions.count
     form_count = Form.latest_versions.count
+    survey_count = Survey.latest_versions.count
 
     render json: { response_set_count: response_set_count,
                    question_count: question_count,
-                   form_count: form_count }
+                   form_count: form_count,
+                   suvey_count: survey_count }
   end
 end

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -11,6 +11,6 @@ class LandingController < ApplicationController
     render json: { response_set_count: response_set_count,
                    question_count: question_count,
                    form_count: form_count,
-                   suvey_count: survey_count }
+                   survey_count: survey_count }
   end
 end

--- a/app/views/surveys/_survey.json.jbuilder
+++ b/app/views/surveys/_survey.json.jbuilder
@@ -1,4 +1,4 @@
-json.extract! survey, :id, :name, :created_at, :updated_at, :survey_forms, \
+json.extract! survey, :id, :name, :description, :created_at, :updated_at, :survey_forms, \
               :version_independent_id, :version, :all_versions, :most_recent, \
               :control_number, :created_by_id
 json.user_id survey.created_by.email if survey.created_by.present?

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -92,13 +92,9 @@ Feature: Manage Response Sets
     And I should not see "Male"
 
   Scenario: Extend Response Set
-    Given I have a Response Set with the name "Gender Full" and the description "Response set description" and the response "Original Response"
+    Given I have a published Response Set with the name "Gender Full" and the description "Response set description" and the response "Original Response"
     And I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
-    When I click on the menu link for the Response Set with the name "Gender Full"
-    And I click on the option to Details the Response Set with the name "Gender Full"
-    And I click on the "Publish" button
-    And I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Extend the Response Set with the name "Gender Full"
     And I fill in the "response_set_name" field with "Gender Partial"

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -1,0 +1,20 @@
+Feature: Manage Surveys
+  As an author
+  I want to create and manage Surveys
+  Scenario: Survey List Details
+    Given I have a Survey with the name "Test Survey"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Surveys
+    Then I should see "Test Survey"
+    When I click on the menu link for the Survey with the name "Test Survey"
+    And I should see the option to Details the Survey with the name "Test Survey"
+    And I should see the option to Edit the Survey with the name "Test Survey"
+
+    Scenario: Show Survey in Detail
+      Given I have a Survey with the name "Test Survey" and the description "Survey description"
+      And I am logged in as test_author@gmail.com
+      When I go to the list of Surveys
+      And I click on the menu link for the Survey with the name "Test Survey"
+      And I click on the option to Details the Survey with the name "Test Survey"
+      Then I should see "Test Survey"
+      Then I should see "Survey description"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -117,6 +117,8 @@ def create_path(object_type, object_id)
     '//div[@id="response_set_id_' + object_id + '"]'
   elsif object_type == 'Form'
     '//div[@id="form_id_' + object_id + '"]'
+  elsif object_type == 'Survey'
+    '//div[@id="survey_id_' + object_id + '"]'
   else
     '//tr[td="id_' + object_id + '"]'
   end
@@ -135,6 +137,8 @@ def attribute_to_id(object_type, attribute, attribute_value)
     obj = QuestionType.find_by(attribute => attribute_value)
   elsif object_type == 'Form'
     obj = Form.find_by(attribute => attribute_value)
+  elsif object_type == 'Survey'
+    obj = Survey.find_by(attribute => attribute_value)
   end
   obj.id.to_s
 end

--- a/features/step_definitions/survey_steps.rb
+++ b/features/step_definitions/survey_steps.rb
@@ -1,0 +1,32 @@
+Given(/^I have a Survey with the name "([^"]*)" and the description "([^"]*)"$/) do |name, description|
+  user = get_user 'test_author@gmail.com'
+  Survey.create!(name: name, description: description, created_by: user)
+end
+
+Given(/^I have a published Survey with the name "([^"]*)" and the description "([^"]*)"$/) do |name, description|
+  user = get_user 'test_author@gmail.com'
+  survey = Survey.create!(name: name, description: description, created_by: user)
+  survey.publish
+end
+
+Given(/^I have a published Survey with the name "([^"]*)"$/) do |name|
+  user = get_user 'test_author@gmail.com'
+  survey = Survey.create!(name: name, created_by: user)
+  survey.publish
+end
+
+Given(/^I have a Survey with the name "([^"]*)"$/) do |name|
+  user = get_user 'test_author@gmail.com'
+  Survey.create!(name: name, created_by: user)
+end
+
+When(/^I go to the list of Surveys$/) do
+  Elastictest.fake_survey_search_results
+  visit '/'
+  page.find('li[id="surveys-analytics-item"]').click
+end
+
+When(/^I click on the menu link for the Survey with the (.+) "([^"]*)"$/) do |attribute, attribute_value|
+  object_id = attribute_to_id('Survey', attribute, attribute_value)
+  page.find("#survey_#{object_id}_menu").click
+end

--- a/test/elastic_helpers.rb
+++ b/test/elastic_helpers.rb
@@ -88,5 +88,22 @@ module Elastictest
 
     FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
   end
+
+  def self.fake_survey_search_results
+    # Craft Response
+    surveys = Survey.all
+    fake_body = <<-EOS
+    {"took":1,"timed_out":false,"_shards":{"total":#{surveys.size},"successful":5,"failed":0},
+    "hits":{"total":2,"max_score":2.7132807,"hits":[
+    EOS
+    surveys.each_with_index do |survey, index|
+      fake_body += "{\"_index\":\"vocabulary\",\"_type\":\"survey\",\"_id\":\"#{survey.id}\",\"_score\":2.1132807,\"_source\":"
+      fake_body += ESSurveySerializer.new(survey).to_json
+      fake_body += index != surveys.size - 1 ? '},' : ''
+    end
+    fake_body += surveys.any? ? '}]}}' : ']}}'
+
+    FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
+  end
 end
 # rubocop:enable Metrics/MethodLength

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -25,6 +25,12 @@ export default class SearchResult extends Component {
             {this.formResult(this.props.result.Source, this.props.result.highlight)}
           </div>
         );
+      case 'survey':
+        return (
+          <div>
+            {this.surveyResult(this.props.result.Source, this.props.result.highlight)}
+          </div>
+        );
     }
   }
 
@@ -169,6 +175,34 @@ export default class SearchResult extends Component {
                 <span className="fa fa-ellipsis-h"></span>
               </a>
               {this.resultDropdownMenu(result, 'form')}
+            </div>
+          </div>
+        </div>
+        <div className="search-result-description">
+          {highlight && highlight.description ? <text dangerouslySetInnerHTML={{__html: highlight.description[0]}} /> : result.description}
+        </div>
+        <div className="search-result-stats">
+          <hr/>
+        </div>
+        <hr/>
+      </div>
+    );
+  }
+
+  surveyResult(result, highlight) {
+    return (
+      <div className="search-result" id={`survey_id_${result.id}`}>
+        <div className="search-result-name">
+          <text className="search-result-type">Survey: </text>
+          <Link to={`/surveys/${result.id}`}>
+            {highlight && highlight.name ? <text dangerouslySetInnerHTML={{__html: highlight.name[0]}} /> : result.name}
+          </Link>
+          <div className="pull-right survey-menu">
+            <div className="dropdown">
+              <a id={`survey_${result.id}_menu`} className="dropdown-toggle" type="" data-toggle="dropdown">
+                <span className="fa fa-ellipsis-h"></span>
+              </a>
+              {this.resultDropdownMenu(result, 'survey')}
             </div>
           </div>
         </div>

--- a/webpack/components/SearchResultList.js
+++ b/webpack/components/SearchResultList.js
@@ -8,7 +8,7 @@ export default class SearchResultList extends Component {
       <div className="search-result-list">
         {this.props.searchResults.hits &&
           <row className="search-result-heading">
-            <div>Search Results ({this.props.searchResults.hits.hits.length})</div>
+            <div>Search Results ({this.props.searchResults.hits && this.props.searchResults.hits.total && this.props.searchResults.hits.total})</div>
             <hr/>
           </row>
         }

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -30,6 +30,14 @@ class SurveyShow extends Component{
         <div className="maincontent-details">
           <h3 className="maincontent-item-name"><strong>Name:</strong> {survey.name} </h3>
           <p className="maincontent-item-info">Version: {survey.version} - Author: {survey.userId} </p>
+          <div className="basic-c-box panel-default">
+            <div className="panel-heading">
+              <h3 className="panel-title">Description</h3>
+            </div>
+            <div className="box-content">
+              {survey.description}
+            </div>
+          </div>
           {forms.map((f,i ) =>
             <div  key={i} className="basic-c-box panel-default survey-form">
               <div className="panel-heading">

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -104,10 +104,10 @@ class DashboardContainer extends Component {
             <h2 className="item-title">Forms</h2>
           </div>
           </li>
-        <li id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
+        <li id="surveys-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
           <div>
             <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
-            <p className="item-value">{this.props.formCount}</p>
+            <p className="item-value">{this.props.surveyCount}</p>
             <h2 className="item-title">Surveys</h2>
           </div>
           </li>
@@ -136,7 +136,7 @@ class DashboardContainer extends Component {
             </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.formCount} Suveys</div>
+              <div className="recent-items-value">{this.props.surveyCount} Suveys</div>
             </li>
           </ul>
         </div>
@@ -150,6 +150,7 @@ function mapStateToProps(state) {
     formCount: state.stats.formCount,
     questionCount: state.stats.questionCount,
     responseSetCount: state.stats.responseSetCount,
+    surveyCount: state.stats.surveryCount,
     searchResults: state.searchResults,
     currentUser: state.currentUser
   };
@@ -163,6 +164,7 @@ DashboardContainer.propTypes = {
   formCount: PropTypes.number,
   questionCount: PropTypes.number,
   responseSetCount: PropTypes.number,
+  surveyCount: PropTypes.number,
   fetchStats: PropTypes.func,
   fetchSearchResults: PropTypes.func,
   currentUser: currentUserProps,

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -136,7 +136,7 @@ class DashboardContainer extends Component {
             </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.surveyCount} Suveys</div>
+              <div className="recent-items-value">{this.props.surveyCount} Surveys</div>
             </li>
           </ul>
         </div>
@@ -146,11 +146,12 @@ class DashboardContainer extends Component {
 }
 
 function mapStateToProps(state) {
+  console.log(state.stats.surveyCount);
   return {
     formCount: state.stats.formCount,
     questionCount: state.stats.questionCount,
     responseSetCount: state.stats.responseSetCount,
-    surveyCount: state.stats.surveryCount,
+    surveyCount: state.stats.surveyCount,
     searchResults: state.searchResults,
     currentUser: state.currentUser
   };

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -146,7 +146,6 @@ class DashboardContainer extends Component {
 }
 
 function mapStateToProps(state) {
-  console.log(state.stats.surveyCount);
   return {
     formCount: state.stats.formCount,
     questionCount: state.stats.questionCount,

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -99,9 +99,16 @@ class DashboardContainer extends Component {
           </li>
         <li id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
           <div>
-            <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
+            <i className="fa fa-list-alt fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value">{this.props.formCount}</p>
             <h2 className="item-title">Forms</h2>
+          </div>
+          </li>
+        <li id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
+          <div>
+            <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
+            <p className="item-value">{this.props.formCount}</p>
+            <h2 className="item-title">Surveys</h2>
           </div>
           </li>
       </ul>
@@ -116,18 +123,20 @@ class DashboardContainer extends Component {
         <div className="recent-items-body">
           <ul className="list-group">
             <li className="recent-item-list">
-              <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.responseSetCount} Response Sets</div>
-            </li>
-
-            <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-question-circle recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.questionCount} Questions</div>
             </li>
-
+            <li className="recent-item-list">
+              <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
+              <div className="recent-items-value">{this.props.responseSetCount} Response Sets</div>
+            </li>
+            <li className="recent-item-list">
+              <div className="recent-items-icon"><i className="fa fa-list-alt recent-items-icon" aria-hidden="true"></i></div>
+              <div className="recent-items-value">{this.props.formCount} Forms</div>
+            </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.formCount} Forms</div>
+              <div className="recent-items-value">{this.props.formCount} Suveys</div>
             </li>
           </ul>
         </div>

--- a/webpack/prop-types/survey_props.js
+++ b/webpack/prop-types/survey_props.js
@@ -3,6 +3,7 @@ import { PropTypes } from 'react';
 const surveyProps = PropTypes.shape({
   id:      PropTypes.number,
   name:    PropTypes.string,
+  description: PropTypes.string,
   userId:  PropTypes.string
 });
 

--- a/webpack/styles/widgets/_analytics.scss
+++ b/webpack/styles/widgets/_analytics.scss
@@ -19,7 +19,7 @@
 .analytics-list-item {
   @extend .list-group-item;
   display: table-cell;
-  width: 30%;
+  width: 23%;
   color: $cdc-blue;
   border: none;
   border-left: solid 1px $light-gray;


### PR DESCRIPTION
This adds Surveys to the dashboard and hooks them into search result widget using elastic search.
I also added some of the cucumber rules and simple tests for the index page and details page to start until the creation and editing workflow is in.

Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [ ] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
