### PR TITLE
[SDP-438] Profile edits w/o systems or programs in DB

### DIFF
--- a/features/session.feature
+++ b/features/session.feature
@@ -39,6 +39,19 @@ Feature: Session Management
     And I click on the "Settings" link
     Then I should see "Account Details"
 
+  Scenario: Edit an existing account without programs
+    Given I am logged in as test_author@gmail.com
+    And I am on the "/" page
+    When I click on the "account-dropdown" link
+    And I click on the "Settings" link
+    Then I should see "Account Details"
+    And I should see "No surveillance programs loaded in the database"
+    And I fill in the "firstName" field with "Brett"
+    And I fill in the "lastName" field with "Bretterson"
+    And I click on the "Update" button
+    Then I should see "test_author@gmail.com"
+    And I should not see "Account Details"
+
   Scenario: Login via OpenID Connect
     Given I am on the "/" page
     When I click on the "Login" link

--- a/webpack/components/accounts/ProfileEditor.js
+++ b/webpack/components/accounts/ProfileEditor.js
@@ -1,0 +1,115 @@
+import React, { Component, PropTypes } from 'react';
+import { Modal } from 'react-bootstrap';
+import _ from 'lodash';
+
+import Errors from '../Errors.js';
+
+import { surveillanceSystemsProps }from '../../prop-types/surveillance_system_props';
+import { surveillanceProgramsProps } from '../../prop-types/surveillance_program_props';
+
+// This is an abstract class that is never intended to
+// be used directly.
+export default class ProfileEditor extends Component {
+  render() {
+    return (
+      <Modal show={this.props.show}>
+        <Modal.Header closeButton>
+          <Modal.Title>{this.title()}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <form>
+            <Errors errors={this.state.errors} />
+            <div className="control-group">
+              <label className="control-label" htmlFor="email">E-mail</label>
+              <div className="controls">
+                <input autoFocus="autofocus" placeholder="" className="form-control input-lg" type="email"
+                       value={this.state.email} name="email" id="email" onChange={this.handleChange('email')} />
+                <p className="help-block">Please provide your E-mail</p>
+              </div>
+            </div>
+            <div className="field">
+              <label className="control-label" htmlFor="firstName">First name</label>
+              <input className="form-control input-lg" type="text" name="firstName" id="firstName"
+                     value={this.state.firstName} onChange={this.handleChange('firstName')}/>
+            </div>
+            <div className="field">
+              <label className="control-label" htmlFor="lastName">Last name</label>
+              <input className="form-control input-lg" type="text" name="lastName" id="lastName"
+                     value={this.state.lastName} onChange={this.handleChange('lastName')}/>
+            </div>
+
+            {this.extraContent()}
+
+            <div className="field">
+              {this.surveillanceProgramsField()}
+            </div>
+            <div className="field">
+              {this.surveillanceSystemsField()}
+            </div>
+          </form>
+        </Modal.Body>
+        <Modal.Footer>
+          <button type="button" className="btn btn-default" onClick={this.props.closer}>Close</button>
+          {this.actionButton()}
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+
+  surveillanceProgramsField() {
+    if (_.isEmpty(this.props.surveillancePrograms)) {
+      return <p>No surveillance programs loaded in the database</p>;
+    } else {
+      return (<div>
+          <label className="control-label" htmlFor="lastProgramId">Surveillance Program</label>
+          <select className="form-control" name="lastProgramId" id="lastProgramId" defaultValue={this.state.lastProgramId} onChange={this.handleChange('lastProgramId')} >
+          {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
+            return <option key={sp.id} value={sp.id}>{sp.name}</option>;
+          })}
+          </select>
+        </div>);
+    }
+  }
+
+  surveillanceSystemsField() {
+    if (_.isEmpty(this.props.surveillanceSystems)) {
+      return <p>No surveillance systems loaded in the database</p>;
+    } else {
+      return (<div>
+          <label className="control-label" htmlFor="lastSystemId">Surveillance System</label>
+          <select className="form-control" name="lastSystemId" id="lastSystemId" defaultValue={this.state.lastSystemId} onChange={this.handleChange('lastSystemId')} >
+          {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
+            return <option key={ss.id} value={ss.id}>{ss.name}</option>;
+          })}
+          </select>
+        </div>);
+    }
+  }
+
+  profileInformation() {
+    let profileInformation = _.clone(this.state);
+    delete profileInformation.errors;
+    if (profileInformation.lastSystemId === -1) {
+      delete profileInformation.lastSystemId;
+    }
+    if (profileInformation.lastProgramId === -1) {
+      delete profileInformation.lastProgramId;
+    }
+    return profileInformation;
+  }
+
+  handleChange(field) {
+    return (event) => {
+      let newState = {};
+      newState[field] = event.target.value;
+      this.setState(newState);
+    };
+  }
+}
+
+ProfileEditor.propTypes = {
+  closer: PropTypes.func.isRequired,
+  show: PropTypes.bool.isRequired,
+  surveillanceSystems: surveillanceSystemsProps,
+  surveillancePrograms: surveillanceProgramsProps
+};

--- a/webpack/components/accounts/SettingsModal.js
+++ b/webpack/components/accounts/SettingsModal.js
@@ -1,22 +1,18 @@
-import React, { Component, PropTypes } from 'react';
-import { Modal } from 'react-bootstrap';
-import _ from 'lodash';
+import React, { PropTypes } from 'react';
 
-import Errors from '../Errors.js';
+import ProfileEditor from './ProfileEditor';
 
 import currentUserProps from '../../prop-types/current_user_props';
-import { surveillanceSystemsProps }from '../../prop-types/surveillance_system_props';
-import { surveillanceProgramsProps } from '../../prop-types/surveillance_program_props';
 
-export default class SettingsModal extends Component {
+export default class SettingsModal extends ProfileEditor {
   constructor(props) {
     super(props);
     this.state = {email: this.props.currentUser.email,
       id: this.props.currentUser.id,
       firstName: this.props.currentUser.firstName || '',
       lastName: this.props.currentUser.lastName || '',
-      lastProgramId: this.props.currentUser.lastProgramId || 1,
-      lastSystemId: this.props.currentUser.lastSystemId || 1, errors: {}};
+      lastProgramId: this.props.currentUser.lastProgramId || -1,
+      lastSystemId: this.props.currentUser.lastSystemId || -1, errors: {}};
   }
 
   componentWillReceiveProps(nextProps) {
@@ -25,85 +21,31 @@ export default class SettingsModal extends Component {
         id: nextProps.currentUser.id,
         firstName: nextProps.currentUser.firstName || '',
         lastName: nextProps.currentUser.lastName || '',
-        lastProgramId: this.props.currentUser.lastProgramId || 1,
-        lastSystemId: this.props.currentUser.lastSystemId || 1});
+        lastProgramId: this.props.currentUser.lastProgramId || -1,
+        lastSystemId: this.props.currentUser.lastSystemId || -1});
     }
   }
 
-  render() {
-    return (
-      <Modal show={this.props.show}>
-        <Modal.Header closeButton>
-          <Modal.Title>Account Details</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <form>
-            <Errors errors={this.state.errors} />
-            <div className="control-group">
-              <label className="control-label" htmlFor="email">E-mail</label>
-              <div className="controls">
-                <input autoFocus="autofocus" placeholder="" className="form-control input-lg" type="email"
-                       value={this.state.email} name="email" id="email" onChange={this.handleChange('email')} />
-                <p className="help-block">Please provide your E-mail</p>
-              </div>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="firstName">First name</label>
-              <input className="form-control input-lg" type="text" name="firstName" id="firstName"
-                     value={this.state.firstName} onChange={this.handleChange('firstName')}/>
-            </div>
+  title() {
+    return "Account Details";
+  }
 
-            <div className="field">
-              <label className="control-label" htmlFor="lastName">Last name</label>
-              <input className="form-control input-lg" type="text" name="lastName" id="lastName"
-                     value={this.state.lastName} onChange={this.handleChange('lastName')}/>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="lastProgramId">Surveillance Program</label>
-                <select className="form-control" name="lastProgramId" id="lastProgramId" defaultValue={this.state.lastProgramId} onChange={this.handleChange('lastProgramId')} >
-                {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
-                  return <option key={sp.id} value={sp.id}>{sp.name}</option>;
-                })}
-                </select>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="lastSystemId">Surveillance System</label>
-                <select className="form-control" name="lastSystemId" id="lastSystemId" defaultValue={this.state.lastSystemId} onChange={this.handleChange('lastSystemId')} >
-                {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
-                  return <option key={ss.id} value={ss.id}>{ss.name}</option>;
-                })}
-                </select>
-            </div>
-          </form>
-        </Modal.Body>
-        <Modal.Footer>
-          <button type="button" className="btn btn-default" onClick={this.props.closer}>Close</button>
-          <button type="button" className="btn btn-primary" onClick={() => this.attemptUpdate() }>Update</button>
-        </Modal.Footer>
-      </Modal>
-    );
+  actionButton() {
+    return <button type="button" className="btn btn-primary" onClick={() => this.attemptUpdate() }>Update</button>;
+  }
+
+  extraContent() {
+    return ''; // None needed
   }
 
   attemptUpdate() {
     const successHandler = () => this.props.closer();
     const failureHandler = (failureResponse) => this.setState({errors: failureResponse.response.data.errors});
-    this.props.update(this.state, successHandler, failureHandler);
-  }
-
-  handleChange(field) {
-    return (event) => {
-      let newState = {};
-      newState[field] = event.target.value;
-      this.setState(newState);
-    };
+    this.props.update(this.profileInformation(), successHandler, failureHandler);
   }
 }
 
 SettingsModal.propTypes = {
   currentUser: currentUserProps,
-  update: PropTypes.func.isRequired,
-  closer: PropTypes.func.isRequired,
-  show: PropTypes.bool.isRequired,
-  surveillanceSystems: surveillanceSystemsProps,
-  surveillancePrograms: surveillanceProgramsProps
+  update: PropTypes.func.isRequired
 };

--- a/webpack/components/accounts/SignUpModal.js
+++ b/webpack/components/accounts/SignUpModal.js
@@ -1,94 +1,49 @@
-import React, { Component, PropTypes } from 'react';
-import { Modal } from 'react-bootstrap';
-import _ from 'lodash';
+import React, { PropTypes } from 'react';
 
-import Errors from '../Errors.js';
+import ProfileEditor from './ProfileEditor';
 
-import { surveillanceSystemsProps }from '../../prop-types/surveillance_system_props';
-import { surveillanceProgramsProps } from '../../prop-types/surveillance_program_props';
-
-export default class SignUpModal extends Component {
+export default class SignUpModal extends ProfileEditor {
   constructor(props) {
     super(props);
     this.state = {email: '', firstName: '', lastName: '', password: '',
-      passwordConfirmation: '', lastProgramId: 1, lastSystemId: 1, errors: {}};
+      passwordConfirmation: '', lastProgramId: -1, lastSystemId: -1, errors: {}};
   }
 
-  render() {
-    return (
-      <Modal show={this.props.show}>
-        <Modal.Header closeButton>
-          <Modal.Title>Sign Up</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <form>
-            <Errors errors={this.state.errors} />
-            <div className="control-group">
-              <label className="control-label" htmlFor="email">E-mail</label>
-              <div className="controls">
-                <input autoFocus="autofocus" placeholder="" className="form-control input-lg" type="email"
-                       value={this.state.email} name="email" id="email" onChange={this.handleChange('email')} />
-                <p className="help-block">Please provide your E-mail</p>
-              </div>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="firstName">First name</label>
-              <input className="form-control input-lg" type="text" name="firstName" id="firstName" onChange={this.handleChange('firstName')}/>
-            </div>
+  title() {
+    return "Sign Up";
+  }
 
-            <div className="field">
-              <label className="control-label" htmlFor="lastName">Last name</label>
-              <input className="form-control input-lg" type="text" name="lastName" id="lastName" onChange={this.handleChange('lastName')}/>
-            </div>
+  actionButton() {
+    return <button type="button" className="btn btn-primary" onClick={() => this.attemptSignUp() }>Sign Up</button>;
+  }
 
-            <div className="control-group">
-              <label className="control-label" htmlFor="password">Password</label>
-              <div className="controls">
-                <input autoComplete="off" placeholder="" className="form-control input-lg" type="password" name="password" id="password" onChange={this.handleChange('password')}/>
-                <p className="help-block">Password should be at least
-                  6
-                  characters</p>
-              </div>
-            </div>
+  extraContent() {
+    return (<div>
+      <div className="control-group">
+        <label className="control-label" htmlFor="password">Password</label>
+        <div className="controls">
+          <input autoComplete="off" placeholder="" className="form-control input-lg" type="password" name="password" id="password" onChange={this.handleChange('password')}/>
+          <p className="help-block">Password should be at least
+            6
+            characters</p>
+        </div>
+      </div>
 
-            <div className="control-group">
-              <label className="control-label" htmlFor="passwordConfirmation">Password (Confirm)</label>
-              <div className="controls">
-                <input autoComplete="off" placeholder="" className="form-control input-lg" type="password"
-                       name="passwordConfirmation" id="passwordConfirmation" onChange={this.handleChange('passwordConfirmation')}/>
-                <p className="help-block">Please confirm password</p>
-              </div>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="lastProgramId">Surveillance Program</label>
-                <select className="form-control" name="lastProgramId" id="lastProgramId" defaultValue={this.state.lastProgramId} onChange={this.handleChange('lastProgramId')} >
-                {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
-                  return <option key={sp.id} value={sp.id}>{sp.name}</option>;
-                })}
-                </select>
-            </div>
-            <div className="field">
-              <label className="control-label" htmlFor="lastSystemId">Surveillance System</label>
-                <select className="form-control" name="lastSystemId" id="lastSystemId" defaultValue={this.state.lastSystemId} onChange={this.handleChange('lastSystemId')} >
-                {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
-                  return <option key={ss.id} value={ss.id}>{ss.name}</option>;
-                })}
-                </select>
-            </div>
-          </form>
-        </Modal.Body>
-        <Modal.Footer>
-          <button type="button" className="btn btn-default" onClick={this.props.closer}>Close</button>
-          <button type="button" className="btn btn-primary" onClick={() => this.attemptSignUp() }>Sign Up</button>
-        </Modal.Footer>
-      </Modal>
-    );
+      <div className="control-group">
+        <label className="control-label" htmlFor="passwordConfirmation">Password (Confirm)</label>
+        <div className="controls">
+          <input autoComplete="off" placeholder="" className="form-control input-lg" type="password"
+                 name="passwordConfirmation" id="passwordConfirmation" onChange={this.handleChange('passwordConfirmation')}/>
+          <p className="help-block">Please confirm password</p>
+        </div>
+      </div>
+    </div>);
   }
 
   attemptSignUp() {
     const successHandler = () => this.props.closer();
     const failureHandler = (failureResponse) => this.setState({errors: failureResponse.response.data.errors});
-    this.props.signUp(this.state, successHandler, failureHandler);
+    this.props.signUp(this.profileInformation(), successHandler, failureHandler);
   }
 
   handleChange(field) {
@@ -101,9 +56,5 @@ export default class SignUpModal extends Component {
 }
 
 SignUpModal.propTypes = {
-  signUp: PropTypes.func.isRequired,
-  closer: PropTypes.func.isRequired,
-  show: PropTypes.bool.isRequired,
-  surveillanceSystems: surveillanceSystemsProps,
-  surveillancePrograms: surveillanceProgramsProps
+  signUp: PropTypes.func.isRequired
 };


### PR DESCRIPTION
If there are no surveillance systems or programs in the database, the
UI will say that. Makes sure that there are no programs or systems sent
to the server when submitting the request.

This commit also extracts common functionality between the SettingsModal
and the SignUpModal into the new ProfileEditor component.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
