### PR TITLE
[SDP- 398, 435, 447, 448] Short bugfixes / tasks

### DIFF
--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 class LandingController < ApplicationController
   def index
   end
@@ -8,9 +9,15 @@ class LandingController < ApplicationController
     form_count = Form.latest_versions.count
     survey_count = Survey.latest_versions.count
 
-    render json: { response_set_count: response_set_count,
-                   question_count: question_count,
-                   form_count: form_count,
-                   survey_count: survey_count }
+    my_response_set_count = current_user ? ResponseSet.where(created_by: current_user.id).latest_versions.count : 0
+    my_question_count = current_user ? Question.where(created_by: current_user.id).latest_versions.count : 0
+    my_form_count = current_user ? Form.where(created_by: current_user.id).latest_versions.count : 0
+    my_survey_count = current_user ? Survey.where(created_by: current_user.id).latest_versions.count : 0
+
+    render json: { response_set_count: response_set_count, question_count: question_count,
+                   form_count: form_count, survey_count: survey_count,
+                   my_response_set_count: my_response_set_count, my_question_count: my_question_count,
+                   my_form_count: my_form_count, my_survey_count: my_survey_count }
   end
 end
+# rubocop:enable Metrics/AbcSize

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -4,15 +4,31 @@
       "number_of_shards": 1,
       "analysis": {
         "analyzer": {
+          "sdp": {
+            "type": "custom",
+            "tokenizer": "sdp",
+            "filter": ["lowercase", "asciifolding", "stop"]
+          },
           "trigram": {
             "type": "custom",
-            "tokenizer": "standard",
+            "tokenizer": "sdp",
             "filter": ["standard", "shingle"]
           },
           "reverse": {
             "type": "custom",
-            "tokenizer": "standard",
+            "tokenizer": "sdp",
             "filter": ["standard", "reverse"]
+          }
+        },
+        "tokenizer": {
+          "sdp": {
+            "type": "edge_ngram",
+            "min_gram": 3,
+            "max_gram": 10,
+            "token_chars": [
+              "letter",
+              "digit"
+            ]
           }
         },
         "filter": {
@@ -48,29 +64,11 @@
         },
         "name": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "description": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "createdAt": {
           "type": "date"
@@ -164,29 +162,11 @@
         },
         "name": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "description": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "createdAt": {
           "type": "date"
@@ -266,29 +246,11 @@
         },
         "name": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "description": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "createdAt": {
           "type": "date"
@@ -368,29 +330,11 @@
         },
         "name": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "description": {
           "type": "string",
-          "fields": {
-            "trigram": {
-              "type": "text",
-              "analyzer": "trigram"
-            },
-            "reverse": {
-              "type": "text",
-              "analyzer": "reverse"
-            }
-          }
+          "analyzer": "sdp"
         },
         "createdAt": {
           "type": "date"

--- a/features/cancel_buttons.feature
+++ b/features/cancel_buttons.feature
@@ -45,7 +45,7 @@ Feature: Cancel buttons
     When I go to the list of Questions
     And I click on the create "Questions" dropdown item
     And I click on the "Cancel" button
-    Then I should see "Recent Items"
+    Then I should see "My Stuff"
     And I should see "Search Results"
 
   # Scenario: Cancel out of creating a new form
@@ -109,7 +109,7 @@ Feature: Cancel buttons
     And I should see "Unsaved Changes"
     When I click on the "Continue Without Saving" button
     Then I should see "Search Results"
-    And I should see "Recent Items"
+    And I should see "My Stuff"
 
   # Scenario: Cancel out of creating a new form with modal warning
   # Given I am logged in as test_author@gmail.com

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -120,7 +120,7 @@ class SurveyEdit extends Component {
     if(this.props.survey && this.props.survey.id) {
       return(<Link className="btn btn-default pull-right" to={`/surveys/${this.props.survey.id}`}>Cancel</Link>);
     }
-    return(<Link className="btn btn-default pull-right" to='/surveys/'>Cancel</Link>);
+    return(<Link className="btn btn-default pull-right" to='/'>Cancel</Link>);
   }
 
   render() {

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -55,6 +55,7 @@ class App extends Component {
     return (
       <div>
         <Header currentUser={this.props.currentUser}
+                location={this.props.location}
                 logInOpener={() => this.openLogInModal()}
                 signUpOpener={() => this.openSignUpModal()}
                 settingsOpener={() => this.openSettingsModal()}/>
@@ -91,6 +92,7 @@ App.propTypes = {
   currentUser: currentUserProps,
   fetchCurrentUser: PropTypes.func,
   logIn: PropTypes.func,
+  location: PropTypes.object,
   signUp: PropTypes.func,
   updateUser: PropTypes.func,
   fetchSurveillanceSystems: PropTypes.func,

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
+import { Link } from 'react-router';
 import { bindActionCreators } from 'redux';
 import { fetchStats } from '../actions/landing';
 import { fetchSearchResults } from '../actions/search_results_actions';
@@ -41,7 +42,7 @@ class DashboardContainer extends Component {
 
           <div className="col-md-4">
             <div className="dashboard-activity">
-              {this.recentItems()}
+              {this.authorStats()}
             </div>
           </div>
         </div>
@@ -116,27 +117,27 @@ class DashboardContainer extends Component {
     </div>);
   }
 
-  recentItems() {
+  authorStats() {
     return (
       <div className="recent-items-panel">
-        <div className="recent-items-heading">Recent Items</div>
+        <div className="recent-items-heading">My Stuff</div>
         <div className="recent-items-body">
           <ul className="list-group">
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-question-circle recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.questionCount} Questions</div>
+              <Link to="/mystuff" className="recent-items-value">{this.props.myQuestionCount} Questions</Link>
             </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.responseSetCount} Response Sets</div>
+              <Link to="/mystuff" className="recent-items-value">{this.props.myResponseSetCount} Response Sets</Link>
             </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-list-alt recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.formCount} Forms</div>
+              <Link to="/mystuff" className="recent-items-value">{this.props.myFormCount} Forms</Link>
             </li>
             <li className="recent-item-list">
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
-              <div className="recent-items-value">{this.props.surveyCount} Surveys</div>
+              <Link to="/mystuff" className="recent-items-value">{this.props.mySurveyCount} Surveys</Link>
             </li>
           </ul>
         </div>
@@ -151,6 +152,10 @@ function mapStateToProps(state) {
     questionCount: state.stats.questionCount,
     responseSetCount: state.stats.responseSetCount,
     surveyCount: state.stats.surveyCount,
+    myFormCount: state.stats.myFormCount,
+    myQuestionCount: state.stats.myQuestionCount,
+    myResponseSetCount: state.stats.myResponseSetCount,
+    mySurveyCount: state.stats.mySurveyCount,
     searchResults: state.searchResults,
     currentUser: state.currentUser
   };
@@ -165,6 +170,10 @@ DashboardContainer.propTypes = {
   questionCount: PropTypes.number,
   responseSetCount: PropTypes.number,
   surveyCount: PropTypes.number,
+  myFormCount: PropTypes.number,
+  myQuestionCount: PropTypes.number,
+  myResponseSetCount: PropTypes.number,
+  mySurveyCount: PropTypes.number,
   fetchStats: PropTypes.func,
   fetchSearchResults: PropTypes.func,
   currentUser: currentUserProps,

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -74,21 +74,23 @@ ContentMenu.propTypes = {
 };
 
 
-let SignedInMenu = ({currentUser, notifications, notificationCount}) => {
+let SignedInMenu = ({currentUser, location, notifications, notificationCount}) => {
   let loggedIn = ! _.isEmpty(currentUser);
   if(loggedIn) {
     return (
       <ul className="cdc-nav cdc-utlt-navbar-nav">
         <li className="active"><a href="#" className="cdc-navbar-item"><i className="fa fa-bar-chart item-navbar-icon" aria-hidden="true"></i>Dashboard</a></li>
-        <li className="dropdown">
-          <a href="#" id = "create-menu" className="dropdown-toggle cdc-navbar-item" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-clipboard item-navbar-icon" aria-hidden="true"></i>Create<span className="caret"></span></a>
-          <ul className="cdc-nav-dropdown">
-            <li className="nav-dropdown-item"><Link to="/questions/new">Questions</Link></li>
-            <li className="nav-dropdown-item"><Link to="/responseSets/new">Response Sets</Link></li>
-            <li className="nav-dropdown-item"><Link to="/forms/new">Forms</Link></li>
-            <li className="nav-dropdown-item"><Link to="/surveys/new">Surveys</Link></li>
-          </ul>
-        </li>
+        {!location.pathname.includes("revise") && !location.pathname.includes("edit") && !location.pathname.includes("extend") &&
+          <li className="dropdown">
+            <a href="#" id = "create-menu" className="dropdown-toggle cdc-navbar-item" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-clipboard item-navbar-icon" aria-hidden="true"></i>Create<span className="caret"></span></a>
+            <ul className="cdc-nav-dropdown">
+              <li className="nav-dropdown-item"><Link to="/questions/new">Questions</Link></li>
+              <li className="nav-dropdown-item"><Link to="/responseSets/new">Response Sets</Link></li>
+              <li className="nav-dropdown-item"><Link to="/forms/new">Forms</Link></li>
+              <li className="nav-dropdown-item"><Link to="/surveys/new">Surveys</Link></li>
+            </ul>
+          </li>
+        }
         <li className="dropdown">
           <NotificationDropdown notifications={notifications} notificationCount={notificationCount} />
           { notificationCount > 0 ? (
@@ -106,6 +108,7 @@ let SignedInMenu = ({currentUser, notifications, notificationCount}) => {
 };
 SignedInMenu.propTypes = {
   currentUser: currentUserProps,
+  location: PropTypes.object,
   notifications: PropTypes.arrayOf(PropTypes.object),
   notificationCount: PropTypes.number
 };
@@ -128,7 +131,7 @@ class Header extends Component {
             </button>
             <Link to="/" className="cdc-brand">CDC Vocabulary Service</Link>
           </div>
-          <SignedInMenu currentUser={this.props.currentUser} notifications={this.props.notifications} notificationCount={this.props.notificationCount} />
+          <SignedInMenu currentUser={this.props.currentUser} location={this.props.location} notifications={this.props.notifications} notificationCount={this.props.notificationCount} />
           <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener}/>
           <ContentMenu currentUser={this.props.currentUser} settingsOpener={this.props.settingsOpener} />
         </div>
@@ -152,6 +155,7 @@ function mapDispatchToProps(dispatch) {
 
 Header.propTypes = {
   currentUser: currentUserProps,
+  location: PropTypes.object,
   notifications: PropTypes.arrayOf(PropTypes.object),
   notificationCount: PropTypes.number,
   fetchNotifications: PropTypes.func,


### PR DESCRIPTION
Implemented the four shorter tasks / bug fixes for this sprint including:
- Changing the placeholder on the right side of the dashboard to match most recent mockups (showing mystuff instead of repeating analytics widget)
- Switched Elasticsearch tokenizer to use edge n-grams and take out the default common stop words
    - *PLEASE NOTE*: In order to test / see this take place I recommend DELETE-ing the /vocabulary index in your local ES, then hooking into the rails console for your app and running: `SDP::Elasticsearch.ensure_index` followed by `SDP::Elasticsearch.sync`, otherwise the app will hang for awhile on the first save while you wait for the ES index to be setup
- Fixed cancel button on the survey edit page to behave the same as the others (redirect to dashboard)
- OBE'd the navigation bug when on edit / revise / extend pages by making it so create menu only shows up on pages where it was needed in the dashboard
Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [n/a] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
