### PR TITLE
[SDP-445] Prevent middleware overwriting with child objects

### DIFF
--- a/test/frontend/middleware/test_questions_from_forms.js
+++ b/test/frontend/middleware/test_questions_from_forms.js
@@ -5,7 +5,7 @@ import questionsFromForms from '../../../webpack/middleware/questions_from_forms
 
 import {
   FETCH_FORMS_FULFILLED,
-  FETCH_QUESTIONS_FULFILLED
+  FETCH_QUESTION_FULFILLED
 } from '../../../webpack/actions/types';
 
 describe('questionsFromForms middleware', () => {
@@ -17,7 +17,7 @@ describe('questionsFromForms middleware', () => {
   const twoForms = [
                     {id: 1, name: "Red Form",  userId: "testAuthor@gmail.com", questions: twoQuestions},
                     {id: 3, name: "Blue Form", userId: "testAuthor@gmail.com", questions: twoQuestions}
-                   ];
+  ];
 
   const next = () => {
     1 + 1; //do nothing
@@ -27,15 +27,15 @@ describe('questionsFromForms middleware', () => {
     store = new MockStore();
     action = {
       type: FETCH_FORMS_FULFILLED,
-      payload: {data: twoForms} 
+      payload: {data: twoForms}
     };
   });
 
   it('will dispatch actions for questions in forms', () => {
     questionsFromForms(store)(next)(action);
-    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_QUESTIONS_FULFILLED);
+    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_QUESTION_FULFILLED);
     expect(dispatchedAction).to.exist;
-    expect(dispatchedAction.payload.data[0].content).to.equal('M?');
+    expect(dispatchedAction.payload.data.content).to.equal('M?');
   });
 
   it('will transform the form payload', () => {

--- a/test/frontend/middleware/test_response_sets_from_questions.js
+++ b/test/frontend/middleware/test_response_sets_from_questions.js
@@ -5,7 +5,7 @@ import responseSetsFromQuestions from '../../../webpack/middleware/response_sets
 
 import {
   FETCH_QUESTIONS_FULFILLED,
-  FETCH_RESPONSE_SETS_FULFILLED
+  FETCH_RESPONSE_SET_FULFILLED
 } from '../../../webpack/actions/types';
 
 describe('responseSetsFromQuestions middleware', () => {
@@ -27,12 +27,13 @@ describe('responseSetsFromQuestions middleware', () => {
     };
   });
 
-  it('will dispatch actions for questions in response sets', () => {
+  it('will dispatch actions for response sets in questions', () => {
     responseSetsFromQuestions(store)(next)(action);
-    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_RESPONSE_SETS_FULFILLED);
+    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_RESPONSE_SET_FULFILLED);
     expect(dispatchedAction).to.exist;
-    expect(dispatchedAction.payload.data[0].name).to.equal('Response Set 1');
+    expect(dispatchedAction.payload.data.name).to.equal('Response Set 1');
   });
+
   it('will transform the question payload', () => {
     responseSetsFromQuestions(store)(next)(action);
     const qs = action.payload.data[0];

--- a/webpack/middleware/parent_from_questions.js
+++ b/webpack/middleware/parent_from_questions.js
@@ -3,6 +3,8 @@ import {
   FETCH_QUESTION_FULFILLED
 } from '../actions/types';
 
+import dispatchIfNotPresent from './store_helper';
+
 const parentFromQuestions = store => next => action => {
   if(store == null) return;
   switch (action.type) {
@@ -10,15 +12,16 @@ const parentFromQuestions = store => next => action => {
       const questions = action.payload.data;
       questions.forEach((q) => {
         if(q.parent){
-          //store.dispatch({type: FETCH_QUESTION_FULFILLED, payload: {data: q.parent}});
+          dispatchIfNotPresent(store, 'questions', q.parent, FETCH_QUESTION_FULFILLED);
           q.parent = ({id: q.parent.id, name: q.parent.content});
         }
       });
       break;
     case FETCH_QUESTION_FULFILLED:
-      if(action.payload.data.parent){
-        //store.dispatch({type: FETCH_QUESTION_FULFILLED, payload: {data: action.payload.data.parent}});
-        action.payload.data.parent = ({id: action.payload.data.parent.id, name: action.payload.data.parent.content});
+      if(action.payload.data.parent) {
+        const parent = action.payload.data.parent;
+        dispatchIfNotPresent(store, 'questions', parent, FETCH_QUESTION_FULFILLED);
+        action.payload.data.parent = ({id: parent.id, name: parent.content});
       }
   }
 

--- a/webpack/middleware/parent_from_response_sets.js
+++ b/webpack/middleware/parent_from_response_sets.js
@@ -3,21 +3,23 @@ import {
   FETCH_RESPONSE_SET_FULFILLED
 } from '../actions/types';
 
+import dispatchIfNotPresent from './store_helper';
+
 const parentFromResponseSets = store => next => action => {
-  if(store == null) return;
+  if (store == null) return;
   switch (action.type) {
     case FETCH_RESPONSE_SETS_FULFILLED:
       const responseSets = action.payload.data;
       responseSets.forEach((rs) => {
-        if(rs.parent){
-          //store.dispatch({type: FETCH_RESPONSE_SET_FULFILLED, payload: {data: rs.parent}});
+        if (rs.parent) {
+          dispatchIfNotPresent(store, 'responseSets', rs.parent, FETCH_RESPONSE_SET_FULFILLED);
           rs.parent = ({id: rs.parent.id, name: rs.parent.name});
         }
       });
       break;
     case FETCH_RESPONSE_SET_FULFILLED:
       if(action.payload.data.parent){
-        //store.dispatch({type: FETCH_RESPONSE_SET_FULFILLED, payload: {data: action.payload.data.parent}});
+        dispatchIfNotPresent(store, 'responseSets', action.payload.data.parent, FETCH_RESPONSE_SET_FULFILLED);
         action.payload.data.parent = ({id: action.payload.data.parent.id, name: action.payload.data.parent.name});
       }
   }

--- a/webpack/middleware/question_types_from_questions.js
+++ b/webpack/middleware/question_types_from_questions.js
@@ -5,21 +5,23 @@ import {
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
+import dispatchIfNotPresent from './store_helper';
+
 const questionTypesFromQuestions = store => next => action => {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
       const questions = action.payload.data;
       questions.forEach((q) => {
-        if(q.questionType){
-          store.dispatch({type: FETCH_QUESTION_TYPE_FULFILLED, payload: {data: q.questionType}});
+        if (q.questionType) {
+          dispatchIfNotPresent(store, 'questionTypes', q.questionType, FETCH_QUESTION_TYPE_FULFILLED);
           q.questionTypeId = q.questionType.id;
         }
       });
       break;
     case FETCH_QUESTION_FULFILLED:
     case SAVE_QUESTION_FULFILLED:
-      if(action.payload.data.questionType){
-        store.dispatch({type: FETCH_QUESTION_TYPE_FULFILLED, payload: {data: action.payload.data.questionType}});
+      if (action.payload.data.questionType) {
+        dispatchIfNotPresent(store, 'questionTypes', action.payload.data.questionType, FETCH_QUESTION_TYPE_FULFILLED);
         action.payload.data.questionTypeId = action.payload.data.questionType.id;
       }
   }

--- a/webpack/middleware/questions_from_forms.js
+++ b/webpack/middleware/questions_from_forms.js
@@ -1,28 +1,32 @@
 import {
   FETCH_FORM_FULFILLED,
   FETCH_FORMS_FULFILLED,
-  FETCH_QUESTIONS_FULFILLED
+  FETCH_QUESTION_FULFILLED
 } from '../actions/types';
+
+import dispatchIfNotPresent from './store_helper';
 
 const questionsFromForms = store => next => action => {
   switch (action.type) {
     case FETCH_FORMS_FULFILLED:
       const forms = action.payload.data;
       forms.forEach((f) => {
-        store.dispatch({
-          type: FETCH_QUESTIONS_FULFILLED,
-          payload: {data: f.questions}
-        });
+        if (f.questions) {
+          f.questions.forEach((q) => {
+            dispatchIfNotPresent(store, 'questions', q, FETCH_QUESTION_FULFILLED);
+          });
+        }
         f.questions = f.questions.map((q) => {
           return ({id: q.id, content: q.content });
         });
       });
       break;
     case FETCH_FORM_FULFILLED:
-      store.dispatch({
-        type: FETCH_QUESTIONS_FULFILLED,
-        payload: {data: action.payload.data.questions}
-      });
+      if (action.payload.data.questions) {
+        action.payload.data.questions.forEach((q) => {
+          dispatchIfNotPresent(store, 'questions', q, FETCH_QUESTION_FULFILLED);
+        });
+      }
       action.payload.data.questions = action.payload.data.questions.map((q) => {
         return ({id: q.id, content: q.content });
       });

--- a/webpack/middleware/questions_from_response_sets.js
+++ b/webpack/middleware/questions_from_response_sets.js
@@ -1,7 +1,10 @@
 import {
   FETCH_RESPONSE_SETS_FULFILLED,
-  FETCH_RESPONSE_SET_FULFILLED
+  FETCH_RESPONSE_SET_FULFILLED,
+  FETCH_QUESTION_FULFILLED
 } from '../actions/types';
+
+import dispatchIfNotPresent from './store_helper';
 
 const questionsFromResponseSets = store => next => action => {
   if(store == null) return;
@@ -10,14 +13,18 @@ const questionsFromResponseSets = store => next => action => {
       const responseSets = action.payload.data;
       responseSets.forEach((rs) => {
         if(rs.questions){
-          //store.dispatch({type: FETCH_QUESTIONS_FULFILLED, payload: {data: rs.questions}});
+          rs.questions.forEach((q) => {
+            dispatchIfNotPresent(store, 'questions', q, FETCH_QUESTION_FULFILLED);
+          });
           rs.questions = rs.questions.map((q) => q.id);
         }
       });
       break;
     case FETCH_RESPONSE_SET_FULFILLED:
       if(action.payload.data.questions){
-        //store.dispatch({type: FETCH_QUESTIONS_FULFILLED, payload: {data: action.payload.data.questions}});
+        action.payload.data.questions.forEach((q) => {
+          dispatchIfNotPresent(store, 'questions', q, FETCH_QUESTION_FULFILLED);
+        });
         action.payload.data.questions = action.payload.data.questions.map((q) => q.id);
       }
   }

--- a/webpack/middleware/response_sets_from_questions.js
+++ b/webpack/middleware/response_sets_from_questions.js
@@ -1,17 +1,21 @@
 import {
-  FETCH_RESPONSE_SETS_FULFILLED,
+  FETCH_RESPONSE_SET_FULFILLED,
   SAVE_QUESTION_FULFILLED,
   FETCH_QUESTION_FULFILLED,
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
+
+import dispatchIfNotPresent from './store_helper';
 
 const responseSetsFromQuestions = store => next => action => {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
       const questions = action.payload.data;
       questions.forEach((q, i) => {
-        if(q.responseSets){
-          store.dispatch({type: FETCH_RESPONSE_SETS_FULFILLED, payload: {data: q.responseSets}});
+        if (q.responseSets) {
+          q.responseSets.forEach((rs) => {
+            dispatchIfNotPresent(store, 'responseSets', rs, FETCH_RESPONSE_SET_FULFILLED);
+          });
           action.payload.data[i].responseSets = q.responseSets.map((rs) => rs.id);
         }
       });
@@ -19,7 +23,9 @@ const responseSetsFromQuestions = store => next => action => {
     case FETCH_QUESTION_FULFILLED:
     case SAVE_QUESTION_FULFILLED:
       if(action.payload.data.responseSets){
-        store.dispatch({type: FETCH_RESPONSE_SETS_FULFILLED, payload: {data: action.payload.data.responseSets}});
+        action.payload.data.responseSets.forEach((rs) => {
+          dispatchIfNotPresent(store, 'responseSets', rs, FETCH_RESPONSE_SET_FULFILLED);
+        });
         action.payload.data.responseSets = action.payload.data.responseSets.map((rs) => rs.id);
       }
   }

--- a/webpack/middleware/response_types_from_questions.js
+++ b/webpack/middleware/response_types_from_questions.js
@@ -5,21 +5,23 @@ import {
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
+import dispatchIfNotPresent from './store_helper';
+
 const responseTypesFromQuestions = store => next => action => {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
       const questions = action.payload.data;
       questions.forEach((q) => {
-        if(q.responseType){
-          store.dispatch({type: FETCH_RESPONSE_TYPE_FULFILLED, payload: {data: q.responseType}});
+        if (q.responseType) {
+          dispatchIfNotPresent(store, 'responseTypes', q.responseType, FETCH_RESPONSE_TYPE_FULFILLED);
           q.responseTypeId = q.responseType.id;
         }
       });
       break;
     case FETCH_QUESTION_FULFILLED:
     case SAVE_QUESTION_FULFILLED:
-      if(action.payload.data.responseType){
-        store.dispatch({type: FETCH_RESPONSE_TYPE_FULFILLED, payload: {data: action.payload.data.responseType}});
+      if (action.payload.data.responseType) {
+        dispatchIfNotPresent(store, 'responseTypes', action.payload.data.responseType, FETCH_RESPONSE_TYPE_FULFILLED);
         action.payload.data.responseTypeId = action.payload.data.responseType.id;
       }
   }

--- a/webpack/middleware/store_helper.js
+++ b/webpack/middleware/store_helper.js
@@ -1,0 +1,8 @@
+const dispatchIfNotPresent = (store, type, obj, dispatchAction) => {
+  if (store.getState()[type] === undefined ||
+      store.getState()[type][obj.id] === undefined) {
+    store.dispatch({type: dispatchAction, payload: {data: obj}});
+  }
+};
+
+export default dispatchIfNotPresent;


### PR DESCRIPTION
The middleware in the application will look through nested objects that are returned by fetch actions. It will then try to put those objects into the store in the correct location. The problem is that sometimes the child object contains less information than if it were fetched directly. Previous behavior would allow these child objects to overwrite existing objects in the store, causing information loss on the client side.

This PR changes the middleware behavior so that it will check to see if the child object is present in the store before dispatching an action to update the store with the child object. If there is already an object in the store with the same id, the child object is ignored and the code moves on.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop

