### PR TITLE
[SDP-379,469] ES on Question Edit and New Response Set Association Method 

### DIFF
--- a/features/draft_questions.feature
+++ b/features/draft_questions.feature
@@ -5,7 +5,7 @@ Feature: Draft, Publish, and Revise Questions
     Given I have a Response Set with the name "Gender Full"
     And I have a Question Type with the name "Multiple Choice"
     And I am logged in as test_author@gmail.com
-    When I go to the list of Questions
+    When I go to the dashboard
     And I click on the create "Questions" dropdown item
     And I fill in the "Question" field with "What is your favorite color?"
     And I fill in the "Description" field with "This is a description"

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -47,7 +47,7 @@ Feature: Manage Questions
     And I have a Response Set with the name "Gender Partial"
     And I have a Response Type with the name "Response Set"
     And I am logged in as test_author@gmail.com
-    When I go to the list of Questions
+    When I go to the dashboard
     And I click on the menu link for the Question with the content "What is your gender?"
     And I click on the option to Revise the Question with the content "What is your gender?"
     And I fill in the "Question" field with "What is your favorite color?"
@@ -81,14 +81,14 @@ Feature: Manage Questions
     And I should see "This is an extended description"
     And I should not see "This is a question"
 
-  Scenario: Create New Question from List and Create a Response Set using New Response Set Modal
+  Scenario: Create New Question from List, test rs add button, and Create a Response Set using New Response Set Modal
     Given I have a Response Set with the name "Gender Full"
     And I am logged in as test_author@gmail.com
-    When I go to the list of Questions
+    When I go to the dashboard
     And I click on the create "Questions" dropdown item
     And I fill in the "Question" field with "What is your favorite color?"
     And I fill in the "Description" field with "This is a description"
-    And I drag the "Gender Full" option to the "Selected Response Sets" list
+    And I click on the "select-Gender Full" link
     Then I click on the "Add New Response Set" button
     Then I fill in the "response_set_name" field with "New Response Set"
     And I click on the "Add Response Set" button
@@ -102,7 +102,7 @@ Feature: Manage Questions
     And I have a Question Type with the name "Multiple Choice"
     And I have a Response Type with the name "Integer"
     And I am logged in as test_author@gmail.com
-    When I go to the list of Questions
+    When I go to the dashboard
     And I click on the create "Questions" dropdown item
     And I fill in the "Question" field with "What is your favorite animal?"
     And I drag the "Gender Full" option to the "Selected Response Sets" list
@@ -123,7 +123,7 @@ Feature: Manage Questions
     And I have a Question Type with the name "Multiple Choice"
     And I have a Response Type with the name "Integer"
     And I am logged in as test_author@gmail.com
-    When I go to the list of Questions
+    When I go to the dashboard
     And I click on the create "Questions" dropdown item
     And I fill in the "Question" field with "What is your favorite animal?"
     And I drag the "Gender Full" option to the "Selected Response Sets" list

--- a/test/frontend/components/response_set_drag_widget_test.js
+++ b/test/frontend/components/response_set_drag_widget_test.js
@@ -8,9 +8,8 @@ describe('ResponseSetDragWidget', () => {
 
   beforeEach(() => {
     props = { handleResponseSetsChange: ()=>{},
-              responseSets: {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}, 
-                             2: {id: 2, name: "test", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.2"}},
-              selectedResponseSets: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}]};
+              selectedResponseSets: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
+                                     {id: 2, name: "test", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.2"}]};
 
     component = renderComponent(ResponseSetDragWidget, props);
     inputNode = component.find("div[name='row response-set-row']")[0]
@@ -19,7 +18,7 @@ describe('ResponseSetDragWidget', () => {
   it('should create response set drag widget', () => {
     expect(component.find("div[name='linked_response_sets']").length).to.exist;
     expect(component.find("div[class='selected_response_sets']").length).to.exist;
-    expect(component.find("div[id='response_set_id_1']").length).to.equal(2);
+    expect(component.find("div[id='response_set_id_1']").length).to.equal(1);
     expect(component.find("div[id='response_set_id_2']").length).to.equal(1);
   });
 

--- a/webpack/components/Draggable.js
+++ b/webpack/components/Draggable.js
@@ -23,7 +23,7 @@ let Draggable = (ComposedComponent, setData=function(){}, dragStop=function(){})
     let { dragging = false } = this.state;
     let dragProps = {draggable: true, onDragStart:_dragStart, onDragEnd:_dragStop};
     return (
-        <div  {...dragProps}>
+        <div className="draggable" {...dragProps}>
           <ComposedComponent isDragging={dragging} {...this.props}/>
         </div>
     );

--- a/webpack/components/NestedSearchBar.js
+++ b/webpack/components/NestedSearchBar.js
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+
+class NestedSearchBar extends Component {
+  constructor(props){
+    super(props);
+    this.state = { term: '' };
+  }
+
+  render() {
+    return (
+      <div className="search-bar">
+        <input
+            className="input-format"
+            placeholder={`Search ${this.props.modelName}s...`}
+            value={this.state.term}
+            onChange={event => this.onInputChange(event.target.value)}
+            onKeyPress={event => this.onEnter(event)} />
+      </div>
+    );
+  }
+
+  onEnter(e) {
+    if(e.key === 'Enter') {
+      e.preventDefault();
+      this.props.onSearchTermChange(this.state.term);
+    }
+  }
+
+  onInputChange(term) {
+    this.setState({term});
+  }
+}
+
+
+NestedSearchBar.propTypes = {
+  modelName: React.PropTypes.string,
+  onSearchTermChange: React.PropTypes.func
+};
+
+export default NestedSearchBar;

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -2,16 +2,14 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Draggable, Droppable } from './Draggable';
-import ResponseSetWidget from './ResponseSetWidget';
 import SearchResult from './SearchResult';
 import DashboardSearch from '../components/DashboardSearch';
 import currentUserProps from '../prop-types/current_user_props';
 import { fetchSearchResults, fetchMoreSearchResults } from '../actions/search_results_actions';
 import { responseSetsProps } from '../prop-types/response_set_props';
-import _ from 'lodash';
 
 let setData = function(){
-  return {"json/responseSet": JSON.stringify(this.props.responseSet)};
+  return {"json/responseSet": JSON.stringify(this.props.result.Source)};
 };
 
 let DraggableResponseSet = Draggable(SearchResult, setData);
@@ -104,7 +102,8 @@ class ResponseSetDragWidget extends Component {
           <div className="fixed-height-list" name="linked_response_sets">
             {searchResults.hits && searchResults.hits.hits.map((rs, i) => {
               return <DraggableResponseSet key={i} type={rs.Type} result={rs}
-                      currentUser={this.props.currentUser} />;
+                      currentUser={this.props.currentUser}
+                      handleSelectSearchResult={() => this.props.handleResponseSetsChange(this.props.selectedResponseSets.concat([rs.Source]))} />;
             })}
           </div>
         </div>

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -1,6 +1,12 @@
 import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 import { Draggable, Droppable } from './Draggable';
 import ResponseSetWidget from './ResponseSetWidget';
+import SearchResult from './SearchResult';
+import DashboardSearch from '../components/DashboardSearch';
+import currentUserProps from '../prop-types/current_user_props';
+import { fetchSearchResults, fetchMoreSearchResults } from '../actions/search_results_actions';
 import { responseSetsProps } from '../prop-types/response_set_props';
 import _ from 'lodash';
 
@@ -8,7 +14,7 @@ let setData = function(){
   return {"json/responseSet": JSON.stringify(this.props.responseSet)};
 };
 
-let DraggableResponseSet = Draggable(ResponseSetWidget, setData);
+let DraggableResponseSet = Draggable(SearchResult, setData);
 
 let onDrop = (evt, self) => {
   let rs = JSON.parse(evt.dataTransfer.getData("json/responseSet"));
@@ -30,12 +36,12 @@ class DropTarget extends Component {
     };
 
     return (
-      <div style={{minHeight: '40px', backgroundColor:isValidDrop?'green':'grey'}}>
+      <div style={{minHeight: '440px', backgroundColor:isValidDrop?'green':'grey'}}>
         {selectedResponseSets.map((rs, i) => {
           return (
           <div key={i}>
           <i className='pull-right fa fa-close' onClick={() => removeResponseSet(rs.id)}/>
-          <DraggableResponseSet responseSet={rs}/>
+          <DraggableResponseSet type='response_set' result={{Source: rs}} currentUser={{id: -1}} />
           </div>);
         })}
         <select readOnly={true} value={selectedResponseSets.map((rs) => rs.id )} name="linked_response_sets[]" id="linked_response_sets" size="5" multiple="multiple" className="form-control"  style={{display: 'none'}}>
@@ -56,32 +62,79 @@ DropTarget.propTypes = {
 
 let DroppableTarget = Droppable(DropTarget, onDrop);
 
-class ResponseSetDragWidget extends Component{
-  render(){
-    if(!this.props.responseSets){
-      return (<div>Loading....</div>);
+class ResponseSetDragWidget extends Component {
+  constructor(props){
+    super(props);
+    this.search = this.search.bind(this);
+    this.loadMore = this.loadMore.bind(this);
+    this.state = {
+      searchTerms: '',
+      page: 1
+    };
+  }
+
+  componentWillMount() {
+    this.search('');
+  }
+
+  search(searchTerms) {
+    if(searchTerms === ''){
+      searchTerms = null;
     }
+    this.setState({searchTerms: searchTerms});
+    this.props.fetchSearchResults(searchTerms, 'response_set');
+  }
+
+  loadMore() {
+    let searchTerms = this.state.searchTerms;
+    let tempState = this.state.page + 1;
+    if(this.state.searchTerms === '') {
+      searchTerms = null;
+    }
+    this.props.fetchMoreSearchResults(searchTerms, 'response_set', tempState);
+    this.setState({page: tempState});
+  }
+
+  render(){
+    const searchResults = this.props.searchResults;
     return (
       <div className="row response-set-row">
-          <div className="col-md-6 question-form-group">
-              <div className="fixed-height-list" name="linked_response_sets">
-                {this.props.responseSets && _.values(this.props.responseSets).map((rs, i) => {
-                  return <DraggableResponseSet key={i} responseSet={rs}/>;
-                })}
-              </div>
+        <div className="col-md-6 question-form-group">
+          <DashboardSearch search={this.search} />
+          <div className="fixed-height-list" name="linked_response_sets">
+            {searchResults.hits && searchResults.hits.hits.map((rs, i) => {
+              return <DraggableResponseSet key={i} type={rs.Type} result={rs}
+                      currentUser={this.props.currentUser} />;
+            })}
           </div>
-          <div className="col-md-6 drop-target selected_response_sets" name="selected_response_sets">
-            <DroppableTarget handleResponseSetsChange={this.props.handleResponseSetsChange} selectedResponseSets={this.props.selectedResponseSets} />
-          </div>
+        </div>
+        <div className="col-md-6 drop-target selected_response_sets" name="selected_response_sets">
+          <DroppableTarget handleResponseSetsChange={this.props.handleResponseSetsChange} selectedResponseSets={this.props.selectedResponseSets} />
+        </div>
       </div>
     );
   }
 }
 
+function mapStateToProps(state) {
+  return {
+    searchResults: state.searchResults,
+    currentUser: state.currentUser
+  };
+}
+
+function mapDispatchToProps(dispatch) {
+  return bindActionCreators({fetchSearchResults, fetchMoreSearchResults}, dispatch);
+}
+
 ResponseSetDragWidget.propTypes = {
   responseSets: responseSetsProps.isRequired,
   selectedResponseSets: PropTypes.array,
+  fetchSearchResults: PropTypes.func,
+  fetchMoreSearchResults: PropTypes.func,
+  currentUser: currentUserProps,
+  searchResults: PropTypes.object,
   handleResponseSetsChange: PropTypes.func.isRequired
 };
 
-export default ResponseSetDragWidget;
+export default connect(mapStateToProps, mapDispatchToProps)(ResponseSetDragWidget);

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Draggable, Droppable } from './Draggable';
 import SearchResult from './SearchResult';
-import DashboardSearch from '../components/DashboardSearch';
+import NestedSearchBar from '../components/NestedSearchBar';
 import currentUserProps from '../prop-types/current_user_props';
 import { fetchSearchResults, fetchMoreSearchResults } from '../actions/search_results_actions';
 import { responseSetsProps } from '../prop-types/response_set_props';
@@ -98,13 +98,16 @@ class ResponseSetDragWidget extends Component {
     return (
       <div className="row response-set-row">
         <div className="col-md-6 question-form-group">
-          <DashboardSearch search={this.search} />
+          <NestedSearchBar onSearchTermChange={this.search} modelName="Response Set" /><br/>
           <div className="fixed-height-list" name="linked_response_sets">
             {searchResults.hits && searchResults.hits.hits.map((rs, i) => {
               return <DraggableResponseSet key={i} type={rs.Type} result={rs}
                       currentUser={this.props.currentUser}
                       handleSelectSearchResult={() => this.props.handleResponseSetsChange(this.props.selectedResponseSets.concat([rs.Source]))} />;
             })}
+            {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+              <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
+            }
           </div>
         </div>
         <div className="col-md-6 drop-target selected_response_sets" name="selected_response_sets">

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -114,7 +114,7 @@ export default class SearchResult extends Component {
       case 'response_set':
         return (
           <ul className="list-inline result-linked-number result-linked-item associated__question">
-            <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-rs`}><i className="fa fa-bars" aria-hidden="true"></i>Responses: {result.codes && result.codes.length}</a></li>
+            {result.codes && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-rs`}><i className="fa fa-bars" aria-hidden="true"></i>Responses: {result.codes && result.codes.length}</a></li>}
           </ul>
         );
       case 'form':

--- a/webpack/styles/widgets/_responseset.scss
+++ b/webpack/styles/widgets/_responseset.scss
@@ -1,11 +1,11 @@
 .response-set-group {
   @extend .panel-group;
-  border-left: 6px solid $cdc-blue; 
+  border-left: 6px solid $cdc-blue;
   margin-top: 20px;
   text-align: left;
   margin-bottom: 20px;
   .response-set-name {
-    @extend .panel; 
+    @extend .panel;
     border-radius: 0px;
     border: 1px solid $light-gray;
   }
@@ -53,5 +53,9 @@
         padding: 0px 10px 0px 0px;
       }
     }
-  }       
+  }
+}
+
+.draggable {
+  cursor:-webkit-grab;
 }


### PR DESCRIPTION
This PR does the following (behavior should be tested / checked):
- The drag and drop objects on the question edit page now turn the cursor into a grab hand to make that function more apparent
- The question edit page now has a search and uses elastic search and load more functionality to populate available response sets for association
- Question edit page now uses the updated widget
- Question edit response set association can now be done through the + button in the bottom right of the widget instead of solely by drag and drop


Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
