### PR TITLE
[SDP-453] Disable details link

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -130,7 +130,7 @@ Then(/^debugger$/) do
 end
 
 When(/^I drag the "([^"]*)" option to the "([^"]*)" list$/) do |option, target|
-  drag = find('a', text: option)
+  drag = find('li', class: 'result-name', text: option)
   target = '.' + target.downcase.tr(' ', '_')
   drop = find(target)
   drag.drag_to(drop)

--- a/webpack/components/Draggable.js
+++ b/webpack/components/Draggable.js
@@ -24,7 +24,7 @@ let Draggable = (ComposedComponent, setData=function(){}, dragStop=function(){})
     let dragProps = {draggable: true, onDragStart:_dragStart, onDragEnd:_dragStop};
     return (
         <div className="draggable" {...dragProps}>
-          <ComposedComponent isDragging={dragging} {...this.props}/>
+          <ComposedComponent isEditPage={true} isDragging={dragging} {...this.props}/>
         </div>
     );
   }

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -43,6 +43,7 @@ let AddedQuestions = ({form, reorderQuestion, removeQuestion, responseSets, hand
                           responseSets={linkedResponseSets(q, questionsLookup, rsLookup)}
                           removeQuestion={removeQuestion}
                           reorderQuestion={reorderQuestion}
+                          isEditPage={true}
                           handleResponseSetChange={handleResponseSetChange}
                           responseSetId={q.responseSetId}
                           />

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -69,8 +69,8 @@ class QuestionItem extends Component {
     return (
       <div className='question-item'>
         {this.searchModal()}
-        <div className="col-md-9"><SearchResult type='question' result={{Source:this.props.question}} currentUser={{id: -1}} /></div>
-        <div className="col-md-3" >
+        <div className="col-md-9"><SearchResult type='question' result={{Source:this.props.question}} currentUser={{id: -1}} isEditPage={true} /></div>
+        <div className="col-md-3">
           <div className="form-group">
             <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.question.id}/>
             <select className="col-md-12" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.responseSetId} onChange={this.props.handleResponseSetChange(this.props.index)}>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -12,6 +12,7 @@ export default class SearchResult extends Component {
                             this.props.result.Source,
                             this.props.result.highlight,
                             this.props.handleSelectSearchResult,
+                            this.props.isEditPage,
                             this.props.extraActionName,
                             this.props.extraAction));
   }
@@ -72,6 +73,21 @@ export default class SearchResult extends Component {
           <span className="fa fa-pencil fa-lg item-status-draft" aria-hidden="true"></span>
           <p className="item-description">draft</p>
         </li>
+      );
+    }
+  }
+
+  resultName(result, type, isEditPage){
+    const highlight = result.highlight;
+    const name = result.content ? result.content: result.name;
+    const innerHTML = highlight && highlight.name ? <text dangerouslySetInnerHTML={{__html: highlight.name[0]}} /> : name;
+    if(isEditPage){
+      return innerHTML;
+    }else{
+      return (
+        <Link to={`/${type.replace('_s','S')}s/${result.id}`}>
+          {innerHTML}
+        </Link>
       );
     }
   }
@@ -203,9 +219,8 @@ export default class SearchResult extends Component {
     }
   }
 
-  baseResult(type, result, highlight, handleSelectSearchResult, actionName, action) {
+  baseResult(type, result, highlight, handleSelectSearchResult, isEditPage, actionName, action) {
     const iconMap = {'response_set': 'fa-list', 'question': 'fa-tasks', 'form': 'fa-clipboard', 'survey': 'fa-clipboard'};
-    const name = result.content ? result.content : result.name;
     return (
       <div className="u-result-group">
         <div className="u-result" id={`${type}_id_${result.id}`}>
@@ -217,9 +232,7 @@ export default class SearchResult extends Component {
                     <ul className="list-inline result-type-wrapper">
                       <li className="result-type-icon"><span className={`fa ${iconMap[type]} fa-2x`} aria-hidden="true"></span></li>
                       <li className="result-name">
-                        <Link to={`/${type.replace('_s','S')}s/${result.id}`}>
-                          {highlight && highlight.name ? <text dangerouslySetInnerHTML={{__html: highlight.name[0]}} /> : name}
-                        </Link>
+                        {this.resultName(result, type, isEditPage)}
                       </li>
                     </ul>
                   </div>
@@ -240,7 +253,6 @@ export default class SearchResult extends Component {
                 </div>
               </li>
               <li className="u-result-content-item result-nav">
-                <div className="result-nav-item"><i className="fa fa-signal fa-lg" aria-hidden="true"></i></div>
                 <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i></Link></div>
                 <div className="result-nav-item">
                   {handleSelectSearchResult ? (
@@ -269,6 +281,7 @@ SearchResult.propTypes = {
   type: PropTypes.string,
   currentUser: currentUserProps,
   result: PropTypes.object.isRequired,
+  isEditPage: PropTypes.bool,
   handleSelectSearchResult: PropTypes.func,
   extraActionName: PropTypes.string,
   extraAction: PropTypes.func

--- a/webpack/components/SearchResultList.js
+++ b/webpack/components/SearchResultList.js
@@ -17,7 +17,9 @@ export default class SearchResultList extends Component {
             <SearchResult key={`${sr.Source.versionIndependentId}-${sr.Source.updatedAt}-${i}`}
                           type={sr.Type} result={sr} currentUser={this.props.currentUser}
                           handleSelectSearchResult={this.props.handleSelectSearchResult}
-                          extraAction={this.props.extraAction} extraActionName={this.props.extraActionName}/>
+                          extraAction={this.props.extraAction} extraActionName={this.props.extraActionName}
+                          isEditPage={this.props.isEditPage}
+                          />
           );
         })}
       </div>
@@ -28,6 +30,7 @@ export default class SearchResultList extends Component {
 SearchResultList.propTypes = {
   searchResults: PropTypes.object.isRequired,
   currentUser: currentUserProps,
+  isEditPage: PropTypes.bool,
   handleSelectSearchResult: PropTypes.func,
   extraActionName: PropTypes.string,
   extraAction: PropTypes.func

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -40,7 +40,7 @@ class DashboardContainer extends Component {
                 </div>
               </div>
               <div className="load-more-search">
-                <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} />
+                <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} isEditPage={false} />
                 {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
                   <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
                 }

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -60,7 +60,8 @@ class FormSearchContainer extends Component {
             return (
               <SearchResult key={`${f.Source.versionIndependentId}-${f.Source.updatedAt}-${i}`}
               type={f.Type} result={f} currentUser={this.props.currentUser}
-              handleSelectSearchResult={() => this.props.addForm(this.props.survey, f.Source)}/>
+              handleSelectSearchResult={() => this.props.addForm(this.props.survey, f.Source)}
+              isEditPage={true}/>
             );
           })}
           {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -52,7 +52,8 @@ class QuestionSearchContainer extends Component {
             return (
               <SearchResult key={`${q.Source.versionIndependentId}-${q.Source.updatedAt}-${i}`}
               type={q.Type} result={q} currentUser={this.props.currentUser}
-              handleSelectSearchResult={() => this.props.addQuestion(this.props.form, q.Source)}/>
+              handleSelectSearchResult={() => this.props.addQuestion(this.props.form, q.Source)}
+              isEditPage={true}/>
             );
           })}
           {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&


### PR DESCRIPTION
Making it harder to get to details page from edit pages. 

- na Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- na Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- na If any database changes were made, run `rake generate_erd` to update the README.md
- na If any changes were made to config/routes.rb run `rake jsroutes:generate`
