### PR TITLE
[SDP-442,464] Fix Question and RS order on Form Edit & Comments on Surveys

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -131,6 +131,7 @@ class FormsController < ApplicationController
     form_questions = []
     if question_ids
       question_ids.zip(response_set_ids).each do |qid, rsid|
+        rsid = nil if rsid == ''
         form_questions << FormQuestion.new(question_id: qid, response_set_id: rsid)
       end
     end

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -1,5 +1,7 @@
 class Survey < ApplicationRecord
   include Versionable
+  acts_as_commentable
+
   has_many :survey_forms
   belongs_to :created_by, class_name: 'User'
 

--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -52,10 +52,15 @@ Feature: Edit Forms
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
+    And I use the response set search modal to select "Gender Partial"
+    And I set search filter to "question"
+    And I click on the "search-btn" button
     And I use the question search to select "What is your name?"
     And I move the Question "What is your name?" up
     And I click on the "Save" button
     And I should see "What is your gender?"
+    And I should see the question "What is your name?" first
+    And I should see the response set "Gender Partial" second
 
   Scenario: Create New Form from List and Create a Question using New Question Modal
     Given I have a Response Set with the name "Gender Full"

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -30,6 +30,16 @@ When(/^I use the question search to select "([^"]*)"$/) do |name|
   page.find('a', id: "select-#{name}").click
 end
 
+Then(/^I should see the question "([^"]*)" first$/) do |name|
+  page.first('li', class: 'result-name').has_content?(name)
+end
+
+Then(/^I should see the response set "([^"]*)" second$/) do |name|
+  page.all('a', class: 'panel-toggle')[0].click
+  page.all('a', class: 'panel-toggle')[1].click
+  page.all('div', class: 'result-details-content')[1].has_content?(name)
+end
+
 When(/^I click on the menu link for the Form with the (.+) "([^"]*)"$/) do |attribute, attribute_value|
   object_id = attribute_to_id('Form', attribute, attribute_value)
   page.find("#form_#{object_id}_menu").click

--- a/test/frontend/components/form_question_list_test.js
+++ b/test/frontend/components/form_question_list_test.js
@@ -5,14 +5,15 @@ describe('FormQuestionList', () => {
   let component;
 
   beforeEach(() => {
-    const questions = [{1: {id: 1, content: "Is this a question?", questionType: ""}},
-                       {2: {id: 2, content: "Whats your name", questionType: ""}},
-                       {3: {id: 3, content: "What is a question?", questionType: ""}}];
-    component = renderComponent(FormQuestionList, {questions});
+    const questions = [{id: 1, content: "Is this a question?", questionType: ""},
+                       {id: 2, content: "Whats your name", questionType: ""},
+                       {id: 3, content: "What is a question?", questionType: ""}];
+    const responseSets = [{name: 'None'},{name: 'None'},{name: 'None'}];
+    component = renderComponent(FormQuestionList, {questions, responseSets});
   });
 
   it('should create list of questions', () => {
-    expect(component.find("div[class='question-group']").length).to.equal(3);
+    expect(component.find("div[class='u-result-group']").length).to.equal(3);
   });
 
 });

--- a/test/frontend/reducers/test_response_sets.js
+++ b/test/frontend/reducers/test_response_sets.js
@@ -28,6 +28,16 @@ describe('responseSets reducer', () => {
     expect(Object.keys(nextState).length).to.equal(3);
   });
 
+  it('should fetch response sets, even if some already exist', () => {
+    const responseSetData = {data: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
+                                 {id: 2, name: "People", description: "A list of people", oid: "2.16.840.1.113883.3.1502.3.2"},
+                                 {id: 3, name: "Things", description: "A list of things", oid: "2.16.840.1.113883.3.1502.3.3"}]};
+    const action = {type: FETCH_RESPONSE_SETS_FULFILLED, payload: responseSetData};
+    const startState = {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}};
+    const nextState = responseSets(startState, action);
+    expect(Object.keys(nextState).length).to.equal(3);
+  });
+
   it('should not overwrite response sets already in store', () => {
     const responseSetData = {data: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
                                  {id: 3, name: "Things", description: "A list of things", oid: "2.16.840.1.113883.3.1502.3.3"}]};

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -87,8 +87,7 @@ class FormEdit extends Component {
     return (this.unsavedState || null);
   }
 
-  handleResponseSetChange(questionIndex, event) {
-    var responseSetId = parseInt(event.target.value);
+  handleResponseSetChange(questionIndex, responseSetId) {
     if(isNaN(responseSetId)){
       responseSetId = '';
     }
@@ -170,7 +169,7 @@ class FormEdit extends Component {
                               selectedResponseSet={q.responseSetId}
                               removeQuestion ={this.props.removeQuestion}
                               reorderQuestion={this.props.reorderQuestion}
-                              handleResponseSetChange ={(responseSet) => this.handleResponseSetChange(i, responseSet)}
+                              handleResponseSetChange ={(event) => this.handleResponseSetChange(i, parseInt(event.target.value))}
                               handleSelectSearchResult={(responseSet) => {
                                 this.addLinkedResponseSet(i, responseSet);
                                 this.handleResponseSetChange(i, responseSet.id);

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -87,7 +87,11 @@ class FormEdit extends Component {
     return (this.unsavedState || null);
   }
 
-  handleResponseSetChange(questionIndex, responseSetId) {
+  handleResponseSetChange(questionIndex, event) {
+    var responseSetId = parseInt(event.target.value);
+    if(isNaN(responseSetId)){
+      responseSetId = '';
+    }
     let newState = Object.assign({}, this.state);
     newState.formQuestions[questionIndex].responseSetId = responseSetId;
     this.setState(newState);

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -89,7 +89,7 @@ class FormEdit extends Component {
 
   handleResponseSetChange(questionIndex, responseSetId) {
     if(isNaN(responseSetId)){
-      responseSetId = '';
+      responseSetId = null;
     }
     let newState = Object.assign({}, this.state);
     newState.formQuestions[questionIndex].responseSetId = responseSetId;
@@ -111,7 +111,7 @@ class FormEdit extends Component {
     // Because of the way we have to pass the current questions in we have to manually sync props and state for submit
     let form = Object.assign({}, this.state);
     form.linkedQuestions = this.state.formQuestions.map((q) => q.questionId);
-    form.linkedResponseSets = this.state.formQuestions.map((q) => q.responseSetId);
+    form.linkedResponseSets = this.state.formQuestions.map((q) => q.responseSetId || '');
     this.props.formSubmitter(form, (response) => {
       this.unsavedState = false;
       this.props.router.push(`/forms/${response.data.id}`);

--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -4,6 +4,11 @@ import QuestionWidget from './QuestionWidget';
 
 class FormQuestionList extends Component {
   render() {
+    if(!this.props.questions){
+      return (
+        <div>Loading...</div>
+      );
+    }
     return (
       <div className="question-group">
         {this.props.questions.map((q, i) => {

--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { questionProps } from "../prop-types/question_props";
-import QuestionWidget from './QuestionWidget';
+import SearchResult from './SearchResult';
 
 class FormQuestionList extends Component {
   render() {
@@ -12,7 +12,9 @@ class FormQuestionList extends Component {
     return (
       <div className="question-group">
         {this.props.questions.map((q, i) => {
-          return <QuestionWidget key={i} question={q} />;
+          let source = q;
+          //source.responseSets = this.props.responseSets;
+          return <SearchResult key={i} type='question' result={{Source: source}} currentUser={{id: -1}} />;
         })}
       </div>
     );
@@ -20,7 +22,8 @@ class FormQuestionList extends Component {
 }
 
 FormQuestionList.propTypes = {
-  questions: PropTypes.arrayOf(questionProps)
+  questions: PropTypes.arrayOf(questionProps),
+  responseSets: PropTypes.array
 };
 
 export default FormQuestionList;

--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -13,7 +13,7 @@ class FormQuestionList extends Component {
       <div className="question-group">
         {this.props.questions.map((q, i) => {
           let source = q;
-          //source.responseSets = this.props.responseSets;
+          source.responseSets = [this.props.responseSets[i]];
           return <SearchResult key={i} type='question' result={{Source: source}} currentUser={{id: -1}} />;
         })}
       </div>

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -89,7 +89,9 @@ class FormShow extends Component {
               {form.description}
             </div>
           </div>
-          <FormQuestionList questions={form.questions} routes={Routes} />
+          {this.props.formQuestions && this.props.formQuestions.length > 0 &&
+            <FormQuestionList questions={this.props.formQuestions} responseSets={this.props.formResponseSets} />
+          }
         </div>
       </div>
     );
@@ -98,6 +100,8 @@ class FormShow extends Component {
 
 FormShow.propTypes = {
   form: formProps,
+  formQuestions: PropTypes.array,
+  formResponseSets: PropTypes.array,
   router: PropTypes.object,
   currentUser: currentUserProps,
   publishForm: PropTypes.func,

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -14,8 +14,6 @@ class QuestionItem extends Component {
     super(props);
     this.state = {
       showSearchModal: false,
-      selectedSearchResult: false,
-      selectedResponseSet: {},
       searchTerms: ''
     };
     this.showResponseSetSearch = this.showResponseSetSearch.bind(this);
@@ -33,7 +31,8 @@ class QuestionItem extends Component {
   }
 
   handleSelectSearchResult(rs) {
-    this.setState({ selectedSearchResult: true, selectedResponseSet: rs, showSearchModal: false });
+    this.props.handleSelectSearchResult(rs);
+    this.setState({ showSearchModal: false });
   }
 
   search(searchTerms) {
@@ -56,7 +55,7 @@ class QuestionItem extends Component {
           <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} handleSelectSearchResult={this.handleSelectSearchResult} />
         </Modal.Body>
         <Modal.Footer>
-          <Button onClick={() => this.hideResponseSetSearch()} bsStyle="primary">Cancel</Button>
+          <Button onClick={this.hideResponseSetSearch} bsStyle="primary">Cancel</Button>
         </Modal.Footer>
       </Modal>
     );
@@ -64,7 +63,7 @@ class QuestionItem extends Component {
 
   render() {
     if (!this.props.question) {
-      return (<div>"Loading..."</div>);
+      return (<div>Loading...</div>);
     }
     return (
       <div className='question-item'>
@@ -73,15 +72,12 @@ class QuestionItem extends Component {
         <div className="col-md-3">
           <div className="form-group">
             <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.question.id}/>
-            <select className="col-md-12" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.responseSetId} onChange={this.props.handleResponseSetChange(this.props.index)}>
+            <select className="col-md-12" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSet || ''} onChange={(e)=>this.props.handleResponseSetChange(parseInt(e.target.value))}>
               {this.props.responseSets.length > 0 && this.props.responseSets.map((r, i) => {
                 return (
                   <option value={r.id} key={`${r.id}-${i}`}>{r.name} </option>
                 );
               })}
-              {this.state.selectedSearchResult &&
-                <option value={this.state.selectedResponseSet.id} selected>{this.state.selectedResponseSet.name}</option>
-              }
               <option aria-label=' '></option>
             </select>
             <a title="Search Response Sets" href="#" onClick={(e) => {
@@ -109,9 +105,11 @@ function mapDispatchToProps(dispatch) {
 
 QuestionItem.propTypes = {
   question: questionProps,
-  responseSets: PropTypes.object,
+  responseSets: PropTypes.array,
+  selectedResponseSet: PropTypes.number,
   index: PropTypes.number.isRequired,
   handleResponseSetChange: PropTypes.func,
+  handleSelectSearchResult: PropTypes.func,
   fetchSearchResults: PropTypes.func,
   responseSetId: PropTypes.number,
   searchResults: PropTypes.object,

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -72,7 +72,7 @@ class QuestionItem extends Component {
         <div className="col-md-3">
           <div className="form-group">
             <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.question.id}/>
-            <select className="col-md-12" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSet || ''} onChange={(e)=>this.props.handleResponseSetChange(parseInt(e.target.value))}>
+            <select className="col-md-12" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSet || ''} onChange={(e)=>this.props.handleResponseSetChange(e)}>
               {this.props.responseSets.length > 0 && this.props.responseSets.map((r, i) => {
                 return (
                   <option value={r.id} key={`${r.id}-${i}`}>{r.name} </option>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -124,7 +124,11 @@ export default class SearchResult extends Component {
       case 'question':
         return (
           <ul className="list-inline result-linked-number result-linked-item associated__responseset">
-            {result.responseSets && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>}
+            {result.responseSets && result.responseSets.length === 1 ? (
+              <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Set</a></li>
+            ) : (
+              <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>
+            )}
           </ul>
         );
       case 'response_set':
@@ -158,7 +162,7 @@ export default class SearchResult extends Component {
                 result.responseSets.map((rs, i) => {
                   return(
                     <div key={`response-set-${rs.id}-${i}`} className="result-details-content">
-                      <Link to={`/responseSets/${rs.id}`}>{rs.name}</Link>
+                      {rs.name === 'None' ? <text>No Associated Response Set.</text> : <Link to={`/responseSets/${rs.id}`}>{rs.name}</Link>}
                     </div>
                   );
                 })

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -145,7 +145,7 @@ class DashboardContainer extends Component {
         <div className="recent-items-body">
           <ul className="list-group">
             <li className="recent-item-list">
-              <div className="recent-items-icon"><i className="fa fa-question-circle recent-items-icon" aria-hidden="true"></i></div>
+              <div className="recent-items-icon"><i className="fa fa-tasks recent-items-icon" aria-hidden="true"></i></div>
               <Link to="/mystuff" className="recent-items-value">{this.props.myQuestionCount} Questions</Link>
             </li>
             <li className="recent-item-list">

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -56,11 +56,21 @@ function mapStateToProps(state, ownProps) {
   props.form = state.forms[ownProps.params.formId];
   if (props.form && props.form.formQuestions && props.form.formQuestions.length > 0) {
     props.formQuestions = props.form.formQuestions.map((fq) => state.questions[fq.questionId]);
-    // props.formResponseSets = props.form.formQuestions.map((fq) => {
-    //   let rs = fq.responseSetId ? state.responseSets[fq.responseSetId] : {name: 'No Associated Response Set'};
-    //   return rs;
-    // });
+    props.formResponseSets = props.form.formQuestions.map((fq) => {
+      let rs;
+      if (fq.responseSetId) {
+        if(state.responseSets[fq.responseSetId]) {
+          rs = state.responseSets[fq.responseSetId];
+        } else {
+          rs = {name: 'Loading...'};
+        }
+      } else {
+        rs = {name: 'None'};
+      }
+      return rs;
+    });
   }
+  console.log(props.formResponseSets);
   return props;
 }
 

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -46,7 +46,7 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.currentUser = state.currentUser;
   props.form = state.forms[ownProps.params.formId];
-  if (props.form) {
+  if (props.form && props.form.questions) {
     props.questions = props.form.questions.map((qId) => state.questions[qId]);
   }
   return props;

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -2,6 +2,8 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchForm, publishForm, deleteForm } from '../actions/form_actions';
+import { fetchQuestions } from '../actions/questions_actions';
+import { fetchResponseSets } from '../actions/response_set_actions';
 import FormShow from '../components/FormShow';
 import { formProps } from '../prop-types/form_props';
 import CommentList from '../containers/CommentList';
@@ -10,11 +12,15 @@ import currentUserProps from '../prop-types/current_user_props';
 class FormShowContainer extends Component {
   componentWillMount() {
     this.props.fetchForm(this.props.params.formId);
+    this.props.fetchQuestions();
+    this.props.fetchResponseSets();
   }
 
   componentDidUpdate(prevProps) {
     if(prevProps.params.formId != this.props.params.formId){
       this.props.fetchForm(this.props.params.formId);
+      this.props.fetchQuestions();
+      this.props.fetchResponseSets();
     }
   }
 
@@ -29,6 +35,8 @@ class FormShowContainer extends Component {
         <div className="row basic-bg">
           <div className="col-md-12">
             <FormShow form={this.props.form}
+                      formQuestions={this.props.formQuestions}
+                      formResponseSets={this.props.formResponseSets}
                       router={this.props.router}
                       currentUser={this.props.currentUser}
                       publishForm={this.props.publishForm}
@@ -46,14 +54,18 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.currentUser = state.currentUser;
   props.form = state.forms[ownProps.params.formId];
-  if (props.form && props.form.questions) {
-    props.questions = props.form.questions.map((qId) => state.questions[qId]);
+  if (props.form && props.form.formQuestions && props.form.formQuestions.length > 0) {
+    props.formQuestions = props.form.formQuestions.map((fq) => state.questions[fq.questionId]);
+    // props.formResponseSets = props.form.formQuestions.map((fq) => {
+    //   let rs = fq.responseSetId ? state.responseSets[fq.responseSetId] : {name: 'No Associated Response Set'};
+    //   return rs;
+    // });
   }
   return props;
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({fetchForm, publishForm, deleteForm}, dispatch);
+  return bindActionCreators({fetchForm, fetchQuestions, fetchResponseSets, publishForm, deleteForm}, dispatch);
 }
 
 FormShowContainer.propTypes = {
@@ -62,6 +74,10 @@ FormShowContainer.propTypes = {
   router: PropTypes.object.isRequired,
   currentUser: currentUserProps,
   fetchForm:  PropTypes.func,
+  fetchQuestions:  PropTypes.func,
+  fetchResponseSets: PropTypes.func,
+  formQuestions: PropTypes.array,
+  formResponseSets: PropTypes.array,
   deleteForm: PropTypes.func,
   publishForm: PropTypes.func
 };

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -70,7 +70,6 @@ function mapStateToProps(state, ownProps) {
       return rs;
     });
   }
-  console.log(props.formResponseSets);
   return props;
 }
 

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -9,8 +9,8 @@ import { fetchResponseSets }   from '../actions/response_set_actions';
 import QuestionModalContainer  from './QuestionModalContainer';
 import QuestionSearchContainer from './QuestionSearchContainer';
 import { formProps } from '../prop-types/form_props';
-import { questionProps } from '../prop-types/question_props';
-import { responseSetProps } from '../prop-types/response_set_props';
+import { questionsProps } from '../prop-types/question_props';
+import { responseSetsProps } from '../prop-types/response_set_props';
 import {Button} from 'react-bootstrap';
 import _ from 'lodash';
 
@@ -85,19 +85,19 @@ class FormsEditContainer extends Component {
                 <div className="row add-question">
                   <Button onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
                 </div>
-                <QuestionSearchContainer form ={this.props.form} />
+                <QuestionSearchContainer form={this.props.form} />
               </div>
-              <FormEdit ref='form'
-                    form={this.props.form}
-                    action={this.props.params.action || 'new'}
-                    route ={this.props.route}
-                    router={this.props.router}
-                    questions={this.props.questions}
-                    responseSets ={this.props.responseSets}
-                    formSubmitter={this.state.selectedFormSaver}
-                    removeQuestion ={this.props.removeQuestion}
-                    reorderQuestion={this.props.reorderQuestion}
-                    showResponseSetModal={() => this.setState({showResponseSetModal: true})} />
+              <FormEdit ref ='form'
+                        form={this.props.form}
+                        route ={this.props.route}
+                        router={this.props.router}
+                        action={this.props.params.action || 'new'}
+                        questions={this.props.questions}
+                        responseSets ={this.props.responseSets}
+                        formSubmitter={this.state.selectedFormSaver}
+                        removeQuestion ={this.props.removeQuestion}
+                        reorderQuestion={this.props.reorderQuestion}
+                        showResponseSetModal={() => this.setState({showResponseSetModal: true})} />
             </div>
           </div>
         </div>
@@ -115,8 +115,8 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
   return {
     form: state.forms[ownProps.params.formId||0],
-    questions: _.values(state.questions),
-    responseSets: _.values(state.responseSets)
+    questions: state.questions,
+    responseSets: state.responseSets
   };
 }
 
@@ -125,8 +125,8 @@ FormsEditContainer.propTypes = {
   route: PropTypes.object.isRequired,
   router: PropTypes.object.isRequired,
   params: PropTypes.object.isRequired,
-  questions: PropTypes.arrayOf(questionProps),
-  responseSets: PropTypes.arrayOf(responseSetProps),
+  questions: questionsProps,
+  responseSets: responseSetsProps,
   newForm:  PropTypes.func,
   saveForm: PropTypes.func,
   fetchForm: PropTypes.func,

--- a/webpack/containers/surveys/ShowContainer.js
+++ b/webpack/containers/surveys/ShowContainer.js
@@ -7,7 +7,7 @@ import { fetchQuestions } from '../../actions/questions_actions';
 import SurveyShow from '../../components/surveys/Show';
 import { surveyProps } from '../../prop-types/survey_props';
 import { formProps } from '../../prop-types/form_props';
-// import CommentList from '../../containers/CommentList';
+import CommentList from '../../containers/CommentList';
 import currentUserProps from '../../prop-types/current_user_props';
 
 class SurveyShowContainer extends Component {
@@ -42,6 +42,7 @@ class SurveyShowContainer extends Component {
                         forms ={this.props.forms}
                         deleteSurvey={this.props.deleteSurvey} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
+            <CommentList commentableType='Survey' commentableId={this.props.survey.id} />
           </div>
         </div>
       </div>

--- a/webpack/reducers/forms_reducer.js
+++ b/webpack/reducers/forms_reducer.js
@@ -13,7 +13,7 @@ import {
 import _ from 'lodash';
 
 export default function forms(state = {}, action) {
-  let form , index, newState, newForm, direction, question;
+  let form , index, newState, newForm, direction, question, responseSetId;
   switch (action.type) {
     case FETCH_FORMS_FULFILLED:
       return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
@@ -30,7 +30,12 @@ export default function forms(state = {}, action) {
     case ADD_QUESTION:
       question = action.payload.question;
       form = action.payload.form;
-      let newFormQuestion = Object.assign({}, {questionId: question.id, formId: form.id, responseSetId: question.responseSets && question.responseSets[0]});
+      if(question.responseSets && question.responseSets[0]){
+        responseSetId = question.responseSets[0].id || question.responseSets[0];
+      } else {
+        responseSetId = null;
+      }
+      let newFormQuestion = Object.assign({}, {questionId: question.id, formId: form.id, responseSetId: responseSetId});
       newForm = Object.assign({}, form);
       newForm.formQuestions.push(newFormQuestion);
       newState = Object.assign({}, state);

--- a/webpack/reducers/forms_reducer.js
+++ b/webpack/reducers/forms_reducer.js
@@ -30,14 +30,14 @@ export default function forms(state = {}, action) {
     case ADD_QUESTION:
       question = action.payload.question;
       form = action.payload.form;
-      let newFormQuestion = Object.assign({}, {questionId: question.id, formId: form.id});
+      let newFormQuestion = Object.assign({}, {questionId: question.id, formId: form.id, responseSetId: question.responseSets && question.responseSets[0]});
       newForm = Object.assign({}, form);
       newForm.formQuestions.push(newFormQuestion);
       newState = Object.assign({}, state);
       newState[form.id] = newForm;
       return newState;
     case REMOVE_QUESTION:
-      form = action.payload.form;
+      form  = action.payload.form;
       index = action.payload.index;
       newForm = Object.assign({}, form);
       newForm.formQuestions.splice(index, 1);

--- a/webpack/reducers/response_sets_reducer.js
+++ b/webpack/reducers/response_sets_reducer.js
@@ -13,7 +13,8 @@ export default function responseSets(state = {}, action) {
   let responseSetClone;
   switch (action.type) {
     case FETCH_RESPONSE_SETS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
+      responseSetClone = Object.assign({}, state);
+      return _.assign(responseSetClone, _.keyBy(action.payload.data, 'id'));
     case FETCH_RESPONSE_SET_FULFILLED:
     case SAVE_DRAFT_RESPONSE_SET_FULFILLED:
     case PUBLISH_RESPONSE_SET_FULFILLED:


### PR DESCRIPTION
This PR:
- Makes it so reordering a question on form edit keeps the response set associated with it
- Uses the updated widget design on form details page and edits the widget to handle FormQuestions when passed in
- adds comments to surveys

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
