### PR TITLE
[SDP-None] Mid sprint fixing a few visual

### DIFF
--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -36,7 +36,7 @@ module SDP
               { term: { 'createdBy.id': current_user_id } },
               { match: { status: 'published' } }
             ] } },
-            should: [
+            must: { dis_max: { queries: [
               { match: { name: { query: query_string, boost: 9 } } },
               { match: { description: { query: query_string, boost: 8 } } },
               { match: { 'codes.code': { query: query_string, boost: 7 } } },
@@ -46,7 +46,7 @@ module SDP
               { match: { 'createdBy.email': { query: query_string } } },
               { match: { 'createdBy.name': { query: query_string } } },
               { match: { status: { query: query_string } } }
-            ]
+            ] } }
           }
         },
         highlight: {
@@ -69,7 +69,7 @@ module SDP
               { term: { 'createdBy.id': current_user_id } },
               { match: { status: 'published' } }
             ] } },
-            should: [
+            must: { dis_max: { queries: [
               { match: { name: { query: query_string, boost: 9 } } },
               { match: { description: { query: query_string, boost: 8 } } },
               { match: { 'codes.code': { query: query_string, boost: 7 } } },
@@ -79,7 +79,7 @@ module SDP
               { match: { 'createdBy.email': { query: query_string } } },
               { match: { 'createdBy.name': { query: query_string } } },
               { match: { status: { query: query_string } } }
-            ]
+            ] } }
           }
         },
         highlight: {

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -77,8 +77,7 @@ export default class SearchResult extends Component {
     }
   }
 
-  resultName(result, type, isEditPage){
-    const highlight = result.highlight;
+  resultName(result, highlight, type, isEditPage) {
     const name = result.content ? result.content: result.name;
     const innerHTML = highlight && highlight.name ? <text dangerouslySetInnerHTML={{__html: highlight.name[0]}} /> : name;
     if(isEditPage){
@@ -236,7 +235,7 @@ export default class SearchResult extends Component {
                     <ul className="list-inline result-type-wrapper">
                       <li className="result-type-icon"><span className={`fa ${iconMap[type]} fa-2x`} aria-hidden="true"></span></li>
                       <li className="result-name">
-                        {this.resultName(result, type, isEditPage)}
+                        {this.resultName(result, highlight, type, isEditPage)}
                       </li>
                     </ul>
                   </div>

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -41,7 +41,7 @@ class DashboardContainer extends Component {
               </div>
               <div className="load-more-search">
                 <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} isEditPage={false} />
-                {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+                {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
                   <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
                 }
               </div>


### PR DESCRIPTION
I made three small changes based on bugs I noticed that weren't addressed and things that came up in sprint review:
1) When backup search is used and there are 0 search results returned there was a 0 displaying floating in the middle of page (noticed on dev server)
2) Elastic search was returning all queries that met the filters and sorting them based on the query made, now when you query with a search term it only returns results that match that term in one of the fields
3) Fixed a highlighting bug that was introduced by a rebase yesterday, name of items should now properly highlight when partial word was matched.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [n/a] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [x] If any changes were made to config/routes.rb run `rake jsroutes:generate`
