### PR TITLE
[SDP-456] Fix warning modal

### DIFF
--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -111,6 +111,19 @@ Feature: Edit Forms
     Then I should see "Test Form"
     And I should see "What is your gender?"
 
+  Scenario: Show warning modal after adding question
+    Given I have a Response Set with the name "Gender Full"
+    And I have a Question with the content "What is your gender?" and the type "MC"
+    And I am logged in as test_author@gmail.com
+    When I go to the dashboard
+    And I click on the create "Forms" dropdown item
+    And I fill in the "search" field with "What"
+    And I set search filter to "question"
+    And I click on the "search-btn" button
+    And I use the question search to select "What is your gender?"
+    When I click on the "CDC Vocabulary Service" link
+    Then I should see "Unsaved Changes"
+
   Scenario: Create New Form from List with warning modal
     Given I have a Response Set with the name "Gender Full"
     And I have a Question with the content "What is your gender?" and the type "MC"

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -45,6 +45,7 @@ class FormEdit extends Component {
         this.state = this.stateForRevise({});
     }
     this.unsavedState = false;
+    this.lastQuestionCount = this.state.formQuestions.length;
     this.addedResponseSets = _.compact(this.state.formQuestions.map((fq) => fq.responseSetId));
   }
 
@@ -56,6 +57,13 @@ class FormEdit extends Component {
   componentWillUnmount() {
     this.unsavedState = false;
     this.unbindHook();
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if(this.lastQuestionCount !== prevState.formQuestions.length) {
+      this.unsavedState = true;
+      this.lastQuestionCount = prevState.formQuestions.length;
+    }
   }
 
   routerWillLeave(nextLocation) {

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -53,11 +53,19 @@ class SurveyEdit extends Component {
         this.state = this.stateForNew();
     }
     this.unsavedState = false;
+    this.lastFormCount = this.state.surveyForms.length;
   }
 
   componentDidMount() {
     this.unbindHook = this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave.bind(this));
     window.onbeforeunload = this.windowWillUnload.bind(this);
+  }
+
+  componentDidUpdate(prevProps, prevState) {
+    if(this.lastFormCount !== prevState.surveyForms.length) {
+      this.unsavedState  = true;
+      this.lastFormCount = prevState.surveyForms.length;
+    }
   }
 
   componentWillUnmount() {

--- a/webpack/reducers/forms_reducer.js
+++ b/webpack/reducers/forms_reducer.js
@@ -44,6 +44,7 @@ export default function forms(state = {}, action) {
     case REMOVE_QUESTION:
       form  = action.payload.form;
       index = action.payload.index;
+      form.id = form.id || 0;
       newForm = Object.assign({}, form);
       newForm.formQuestions.splice(index, 1);
       newState = Object.assign({}, state);


### PR DESCRIPTION
Make warning modal appear when you try to leave edit page, if all you did was change questions / forms

- [na] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na ] If any changes were made to config/routes.rb run `rake jsroutes:generate`
