### PR TITLE
[SDP-385] Show usage count on widgets

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -94,8 +94,8 @@ class QuestionsController < ApplicationController
       render(json: { error: 'Only published Questions provide usage information' }, status: :bad_request)
     else
       response = { id: @question.id }
-      response[:surveillance_programs] = @question.surveillance_programs.map(&:name).uniq
-      response[:surveillance_systems] = @question.surveillance_systems.map(&:name).uniq
+      response[:surveillance_programs] = @question.surveillance_programs.map(&:name)
+      response[:surveillance_systems] = @question.surveillance_systems.map(&:name)
       render json: response
     end
   end

--- a/app/controllers/response_sets_controller.rb
+++ b/app/controllers/response_sets_controller.rb
@@ -28,8 +28,8 @@ class ResponseSetsController < ApplicationController
       render(json: { error: 'Only published Response Sets provide usage information' }, status: :bad_request)
     else
       response = { id: @response_set.id }
-      response[:surveillance_programs] = @response_set.surveillance_programs.map(&:name).uniq
-      response[:surveillance_systems] = @response_set.surveillance_systems.map(&:name).uniq
+      response[:surveillance_programs] = @response_set.surveillance_programs.map(&:name)
+      response[:surveillance_systems] = @response_set.surveillance_systems.map(&:name)
       render json: response
     end
   end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -67,10 +67,12 @@ class Form < ApplicationRecord
   # Get the programs that the form is associated with by the surveys that the
   # form is contained in
   def surveillance_programs
-    SurveillanceProgram.joins(surveys: :survey_forms).where('survey_forms.form_id = ?', id)
+    SurveillanceProgram.joins(surveys: :survey_forms)
+                       .where('survey_forms.form_id = ?', id).select(:id, :name).distinct.to_a
   end
 
   def surveillance_systems
-    SurveillanceSystem.joins(surveys: :survey_forms).where('survey_forms.form_id = ?', id)
+    SurveillanceSystem.joins(surveys: :survey_forms)
+                      .where('survey_forms.form_id = ?', id).select(:id, :name).distinct.to_a
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -63,14 +63,14 @@ class Question < ApplicationRecord
   # form is contained in
   def surveillance_programs
     SurveillanceProgram.joins(surveys: :survey_forms)
-                       .joins('INNER join  form_questions on form_questions.form_id = survey_forms.form_id')
-                       .where('form_questions.question_id = ?', id)
+                       .joins('INNER join form_questions on form_questions.form_id = survey_forms.form_id')
+                       .where('form_questions.question_id = ?', id).select(:id, :name).distinct.to_a
   end
 
   def surveillance_systems
     SurveillanceSystem.joins(surveys: :survey_forms)
-                      .joins('INNER join  form_questions on form_questions.form_id = survey_forms.form_id')
-                      .where('form_questions.question_id = ?', id)
+                      .joins('INNER join form_questions on form_questions.form_id = survey_forms.form_id')
+                      .where('form_questions.question_id = ?', id).select(:id, :name).distinct.to_a
   end
 
   def other_allowed_on_when_choice

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -76,13 +76,13 @@ class ResponseSet < ApplicationRecord
 
   def surveillance_programs
     SurveillanceProgram.joins(surveys: :survey_forms)
-                       .joins('INNER join  form_questions on form_questions.form_id = survey_forms.form_id')
-                       .where('form_questions.response_set_id = ?', id)
+                       .joins('INNER join form_questions on form_questions.form_id = survey_forms.form_id')
+                       .where('form_questions.response_set_id = ?', id).select(:id, :name).distinct.to_a
   end
 
   def surveillance_systems
     SurveillanceSystem.joins(surveys: :survey_forms)
-                      .joins('INNER join  form_questions on form_questions.form_id = survey_forms.form_id')
-                      .where('form_questions.response_set_id = ?', id)
+                      .joins('INNER join form_questions on form_questions.form_id = survey_forms.form_id')
+                      .where('form_questions.response_set_id = ?', id).select(:id, :name).distinct.to_a
   end
 end

--- a/app/serializers/es_form_serializer.rb
+++ b/app/serializers/es_form_serializer.rb
@@ -63,11 +63,7 @@ class ESFormSerializer < ActiveModel::Serializer
     UserSerializer.new(object.created_by).as_json if object.created_by
   end
 
-  def surveillance_programs
-    object.surveillance_programs.collect { |sp| { id: sp.id, name: sp.name } }
-  end
+  delegate :surveillance_programs, to: :object
 
-  def surveillance_systems
-    object.surveillance_systems.collect { |ss| { id: ss.id, name: ss.name } }
-  end
+  delegate :surveillance_systems, to: :object
 end

--- a/app/serializers/es_question_serializer.rb
+++ b/app/serializers/es_question_serializer.rb
@@ -16,6 +16,8 @@ class ESQuestionSerializer < ActiveModel::Serializer
   attribute :response_sets, key: :responseSets
   attribute(:codes) { codes }
   attribute :forms
+  attribute :surveillance_programs
+  attribute :surveillance_systems
 
   def forms
     object.form_questions.collect do |fq|
@@ -57,11 +59,7 @@ class ESQuestionSerializer < ActiveModel::Serializer
     UserSerializer.new(object.created_by).as_json if object.created_by
   end
 
-  def surveillance_programs
-    object.surveillance_programs.collect { |sp| { id: sp.id, name: sp.name } }
-  end
+  delegate :surveillance_programs, to: :object
 
-  def surveillance_systems
-    object.surveillance_systems.collect { |ss| { id: ss.id, name: ss.name } }
-  end
+  delegate :surveillance_systems, to: :object
 end

--- a/app/serializers/es_response_set_serializer.rb
+++ b/app/serializers/es_response_set_serializer.rb
@@ -15,6 +15,8 @@ class ESResponseSetSerializer < ActiveModel::Serializer
   attribute :created_by, key: :createdBy
   attribute :questions
   attribute :codes
+  attribute :surveillance_programs
+  attribute :surveillance_systems
 
   def codes
     object.responses.collect { |c| CodeSerializer.new(c).as_json }
@@ -49,11 +51,7 @@ class ESResponseSetSerializer < ActiveModel::Serializer
     UserSerializer.new(object.created_by).as_json if object.created_by
   end
 
-  def surveillance_programs
-    object.surveillance_programs.collect { |sp| { id: sp.id, name: sp.name } }
-  end
+  delegate :surveillance_programs, to: :object
 
-  def surveillance_systems
-    object.surveillance_systems.collect { |ss| { id: ss.id, name: ss.name } }
-  end
+  delegate :surveillance_systems, to: :object
 end

--- a/test/fixtures/form_questions.yml
+++ b/test/fixtures/form_questions.yml
@@ -8,6 +8,6 @@ one:
 
 two:
   form: one
-  question: one
+  question: two
   response_set: one
   position: 2

--- a/test/fixtures/surveillance_systems.yml
+++ b/test/fixtures/surveillance_systems.yml
@@ -2,3 +2,8 @@ nids:
   name: National Insignificant Digits System
   description: Meaningless digits
   acronym: NIDS
+
+nsms:
+  name: National Spork Monitoring System
+  description: Those things can be dangerous
+  acronym: NSMS

--- a/test/fixtures/survey_forms.yml
+++ b/test/fixtures/survey_forms.yml
@@ -9,3 +9,13 @@ two:
   survey: one
   form: two
   position: 2
+
+three:
+  survey: two
+  form: one
+  position: 1
+
+four:
+  survey: two
+  form: two
+  position: 2

--- a/test/fixtures/surveys.yml
+++ b/test/fixtures/surveys.yml
@@ -13,6 +13,8 @@ two:
   status: published
   version_independent_id: 'S-2'
   control_number: '1234-5678'
+  surveillance_program: generic
+  surveillance_system: nsms
 three:
   name: Search Survey 2
   created_by: admin

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -107,6 +107,21 @@ class QuestionTest < ActiveSupport::TestCase
     assert_equal q1.oid, q7.oid
   end
 
+  test 'surveillance_systems' do
+    q = questions(:one)
+    ss = q.surveillance_systems
+    assert_equal 2, ss.length
+    assert_includes ss.map(&:name), 'National Insignificant Digits System'
+    assert_includes ss.map(&:name), 'National Spork Monitoring System'
+  end
+
+  test 'surveillance_programs' do
+    q = questions(:one)
+    sp = q.surveillance_programs
+    assert_equal 1, sp.length
+    assert_includes sp.map(&:name), 'Generic Surveillance Program'
+  end
+
   test 'only choice response type allows other' do
     blank_rs_question = Question.new(content: 'test', other_allowed: true)
     refute blank_rs_question.valid?

--- a/test/models/response_set_test.rb
+++ b/test/models/response_set_test.rb
@@ -124,12 +124,15 @@ class ResponseSetTest < ActiveSupport::TestCase
   test 'surveillance_systems' do
     rs = response_sets(:one)
     ss = rs.surveillance_systems
-    assert_equal 'National Insignificant Digits System', ss.first.name
+    assert_equal 2, ss.length
+    assert_includes ss.map(&:name), 'National Insignificant Digits System'
+    assert_includes ss.map(&:name), 'National Spork Monitoring System'
   end
 
   test 'surveillance_programs' do
     rs = response_sets(:one)
     sp = rs.surveillance_programs
-    assert_equal 'Generic Surveillance Program', sp.first.name
+    assert_equal 1, sp.length
+    assert_includes sp.map(&:name), 'Generic Surveillance Program'
   end
 end

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -94,7 +94,7 @@ export default class SearchResult extends Component {
   programsInfo(result) {
     return (
       <li className="result-analytics-item">
-        <span className="item-value">{result.programsCount}</span>
+        <span className="item-value">{result.surveillancePrograms.length}</span>
         <p className="item-description">programs</p>
       </li>
     );
@@ -103,7 +103,7 @@ export default class SearchResult extends Component {
   systemsInfo(result) {
     return (
       <li className="result-analytics-item">
-        <span className="item-value">{result.systemsCount}</span>
+        <span className="item-value">{result.surveillanceSystems.length}</span>
         <p className="item-description">systems</p>
       </li>
     );
@@ -244,8 +244,8 @@ export default class SearchResult extends Component {
                   </div>
                   <div className="result-analytics">
                     <ul className="list-inline">
-                      {result.programsCount && this.programsInfo(result)}
-                      {result.systemsCount && this.systemsInfo(result)}
+                      {result.surveillancePrograms && this.programsInfo(result)}
+                      {result.surveillanceSystems && this.systemsInfo(result)}
                       {result.status && this.resultStatus(result.status)}
                       <li className="result-timestamp pull-right"><p>{ moment(result.createdAt,'').format('MMMM Do, YYYY') }</p><p>version {result.version && result.version} | {type}</p></li>
                     </ul>


### PR DESCRIPTION
Also provides some fixes for ES serializers and resulting clean up in
other places.

This doesn't really add any new functionality. Just hooks up to what was already there.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
