### PR TITLE
[SDP-498] Fix bug breaking redux store shape

### DIFF
--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -12,7 +12,7 @@ class FormQuestionList extends Component {
     return (
       <div className="question-group">
         {this.props.questions.map((q, i) => {
-          let source = q;
+          let source = Object.assign({}, q);
           source.responseSets = [this.props.responseSets[i]];
           return <SearchResult key={i} type='question' result={{Source: source}} currentUser={{id: -1}} />;
         })}


### PR DESCRIPTION
This component was mutating objects passed in as props. Those props were
objects from the redux store. Since they are all references to the same
object, mutating them will mutate the redux store, which is bad.

This change creates a clone of the object before mutating it and passing
it along to another component.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
