### PR TITLE
[SDP-484,485] Refresh on Login, Refresh Usage without refreshing app

### DIFF
--- a/features/session.feature
+++ b/features/session.feature
@@ -61,6 +61,21 @@ Feature: Session Management
     Given I am on the "/" page
     Then I should not see a "Create" link
 
+  Scenario: On login page should update and users should see their My Stuff content
+    Given I am on the "/" page
+    And a user "test_author@gmail.com" exists
+    And I have a Question with the content "What?" and the description "A simple question"
+    And I have a Question with the content "Who?" and the description "Another simple question"
+    # This step should be "should not see my stuff" once landing page is merged / test are written
+    Then I should see "0 Questions"
+    And I should not see "2 Questions"
+    When I click on the "Login" link
+    And I fill in the "email" field with "test_author@gmail.com"
+    And I fill in the "password" field with "password"
+    And I click on the "Log In" button
+    Then I should see "test_author@gmail.com"
+    And I should see "2 Questions"
+
   Scenario: Users should not be able to access restricted pages
     Given I am on the "/#/mystuff" page
     Then I should see "You are not authorized to see this content, please login."

--- a/features/usage.feature
+++ b/features/usage.feature
@@ -1,0 +1,75 @@
+Feature: Manage Usage
+  As an author associated with a program and system
+  I want usage information to display for my questions and response sets
+
+  Scenario: Refresh Question Usage without refreshing application
+    Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC" and the concept "New Concept Name"
+    And I have a Surveillance System with the name "National Violent Death Reporting System"
+    And I have a Surveillance System with the name "National Vital Statistics System"
+    And I have a Surveillance Program with the name "FoodNet"
+    And I am working the program "FoodNet" and system "National Vital Statistics System" logged in as test_author@gmail.com
+    And I have a Question with the content "What is your gender?" linked to Surveillance System "National Violent Death Reporting System"
+    When I go to the list of Questions
+    And I click on the menu link for the Question with the content "What is your gender?"
+    And I click on the option to Details the Question with the content "What is your gender?"
+    Then I should see "Surveillance Programs: 0"
+    And I should see "Surveillance Systems: 1"
+    When I click on the create "Forms" dropdown item
+    And I fill in the "name" field with "Test Form"
+    And I set search filter to "question"
+    And I click on the "search-btn" button
+    And I use the question search to select "What is your gender?"
+    And I click on the "Save" button
+    Then I should see "Test Form"
+    When I click on the "Publish" button
+    And I click on the create "Surveys" dropdown item
+    And I fill in the "name" field with "Test Survey"
+    And I set search filter to "form"
+    And I click on the "search-btn" button
+    And I use the form search to select "Test Form"
+    And I click on the "Save" button
+    Then I should see "Test Survey"
+    When I click on the "Publish" button
+    And I should see "Surveillance Program: FoodNet"
+    And I click on the "CDC Vocabulary Service" link
+    And I click on the menu link for the Question with the content "What is your gender?"
+    And I click on the option to Details the Question with the content "What is your gender?"
+    Then I should see "Surveillance Programs: 1"
+    And I should see "Surveillance Systems: 2"
+
+  Scenario: Refresh Response Set Usage without refreshing application
+    Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC" and the concept "New Concept Name"
+    And I have a Response Set with the name "Gender Full" and the description "Example RS"
+    And I have a Surveillance System with the name "National Violent Death Reporting System"
+    And I have a Surveillance System with the name "National Vital Statistics System"
+    And I have a Surveillance Program with the name "FoodNet"
+    And I am working the program "FoodNet" and system "National Vital Statistics System" logged in as test_author@gmail.com
+    And I have a Response Set with the name "Gender Full" linked to Surveillance System "National Violent Death Reporting System"
+    When I go to the list of Response Sets
+    And I click on the menu link for the Response Set with the name "Gender Full"
+    And I click on the option to Details the Response Set with the name "Gender Full"
+    Then I should see "Surveillance Programs: 0"
+    And I should see "Surveillance Systems: 1"
+    When I click on the create "Forms" dropdown item
+    And I fill in the "name" field with "Test Form"
+    And I set search filter to "question"
+    And I click on the "search-btn" button
+    And I use the question search to select "What is your gender?"
+    And I use the response set search modal to select "Gender Full"
+    And I click on the "Save" button
+    Then I should see "Test Form"
+    When I click on the "Publish" button
+    And I click on the create "Surveys" dropdown item
+    And I fill in the "name" field with "Test Survey"
+    And I set search filter to "form"
+    And I click on the "search-btn" button
+    And I use the form search to select "Test Form"
+    And I click on the "Save" button
+    Then I should see "Test Survey"
+    When I click on the "Publish" button
+    And I should see "Surveillance Program: FoodNet"
+    And I click on the "CDC Vocabulary Service" link
+    And I click on the menu link for the Response Set with the name "Gender Full"
+    And I click on the option to Details the Response Set with the name "Gender Full"
+    Then I should see "Surveillance Programs: 1"
+    And I should see "Surveillance Systems: 2"

--- a/webpack/components/accounts/LogInModal.js
+++ b/webpack/components/accounts/LogInModal.js
@@ -43,8 +43,13 @@ export default class LogInModal extends Component {
     );
   }
 
+  logInSuccess() {
+    this.props.closer();
+    window.location.reload();
+  }
+
   attemptLogIn() {
-    const successHandler = () => this.props.closer();
+    const successHandler = () => this.logInSuccess();
     const failureHandler = () => this.setState({invalidCredentials: true});
     this.props.logIn(this.state, successHandler, failureHandler);
   }

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -14,6 +14,12 @@ class QuestionShowContainer extends Component {
     this.props.fetchQuestion(this.props.params.qId);
   }
 
+  componentDidMount() {
+    if (this.props.question && this.props.question.status === 'published') {
+      this.props.fetchQuestionUsage(this.props.params.qId);
+    }
+  }
+
   componentDidUpdate(prevProps){
     if(prevProps.params.qId !== this.props.params.qId){
       this.props.fetchQuestion(this.props.params.qId);

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -14,6 +14,12 @@ class ResponseSetShowContainer extends Component {
     this.props.fetchResponseSet(this.props.params.rsId);
   }
 
+  componentDidMount() {
+    if (this.props.responseSet && this.props.responseSet.status === 'published') {
+      this.props.fetchResponseSetUsage(this.props.params.rsId);
+    }
+  }
+
   componentDidUpdate(prevProps) {
     if(prevProps.params.rsId != this.props.params.rsId){
       this.props.fetchResponseSet(this.props.params.rsId);


### PR DESCRIPTION
Tests are written to fully test and satisfy the conditions / workflow outlined in the the refresh usage story, cucumber is not using the navigation shortcuts / database shortcuts to lessen the workflow.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
