### PR TITLE
[SDP-466,476] Publisher Search on Drafts, updated Current User Serializer

### DIFF
--- a/app/controllers/authentications_controller.rb
+++ b/app/controllers/authentications_controller.rb
@@ -1,8 +1,13 @@
 class AuthenticationsController < ApplicationController
   def index
+    if current_user
+      user_copy = current_user.as_json.clone
+      user_copy[:publisher] = current_user.has_role?(:publisher)
+    end
+
     respond_to do |format|
       format.html { @authentications = current_user.authentications if current_user }
-      format.json { render json: current_user || {} }
+      format.json { render json: user_copy || {} }
     end
   end
 

--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -1,3 +1,4 @@
+# rubocop:disable Metrics/AbcSize
 require 'elasticsearch'
 require 'sdp/elastic_search'
 require 'sdp/simple_search'
@@ -8,7 +9,7 @@ class ElasticsearchController < ApplicationController
     query_size = params[:size] ? params[:size].to_i : 10
     page = params[:page] ? params[:page].to_i : 1
     current_user_id = current_user ? current_user.id : -1
-    publisher_search = current_user.has_role? :publisher
+    publisher_search = current_user ? current_user.has_role?(:publisher) : false
     results = if SDP::Elasticsearch.ping
                 SDP::Elasticsearch.search(type, query_string, page, query_size, current_user_id, publisher_search)
               else
@@ -17,3 +18,4 @@ class ElasticsearchController < ApplicationController
     render json: results
   end
 end
+# rubocop:enable Metrics/AbcSize

--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -8,10 +8,11 @@ class ElasticsearchController < ApplicationController
     query_size = params[:size] ? params[:size].to_i : 10
     page = params[:page] ? params[:page].to_i : 1
     current_user_id = current_user ? current_user.id : -1
+    publisher_search = current_user.has_role? :publisher
     results = if SDP::Elasticsearch.ping
-                SDP::Elasticsearch.search(type, query_string, page, query_size, current_user_id)
+                SDP::Elasticsearch.search(type, query_string, page, query_size, current_user_id, publisher_search)
               else
-                SDP::SimpleSearch.search(type, query_string, current_user_id, query_size, page).target!
+                SDP::SimpleSearch.search(type, query_string, current_user_id, query_size, page, publisher_search).target!
               end
     render json: results
   end

--- a/app/models/concerns/searchable.rb
+++ b/app/models/concerns/searchable.rb
@@ -2,9 +2,13 @@ module Searchable
   extend ActiveSupport::Concern
 
   module ClassMethods
-    def search(search = nil, current_user_id = nil)
+    def search(search = nil, current_user_id = nil, publisher_search = false)
       search_col = has_attribute?(:name) ? 'name' : 'content'
-      if current_user_id && search
+      if search && publisher_search
+        where("#{search_col} ILIKE ?", "%#{search}%")
+      elsif publisher_search
+        all
+      elsif current_user_id && search
         where("(status='published' OR created_by_id= ?) AND (#{search_col} ILIKE ?)", current_user_id, "%#{search}%")
       elsif current_user_id
         where("(status='published' OR created_by_id= ?)", current_user_id)

--- a/lib/sdp/simple_search.rb
+++ b/lib/sdp/simple_search.rb
@@ -1,12 +1,13 @@
+# rubocop:disable Metrics/ParameterLists
 module SDP
   module SimpleSearch
-    def self.search(type, query_string, current_user_id = nil, limit = 10, page = 1)
+    def self.search(type, query_string, current_user_id = nil, limit = 10, page = 1, publisher_search = false)
       current_user_id = current_user_id == -1 ? nil : current_user_id
       types = [type.camelize.constantize] if type
       types ||= [Form, Question, ResponseSet, Survey]
       results = {}
       types.map do |search_type|
-        query = search_type.search(query_string, current_user_id)
+        query = search_type.search(query_string, current_user_id, publisher_search)
         count = query.count()
         results[search_type] = { total: count, hits: query.limit(limit).offset(limit * (page - 1)).to_a }
       end
@@ -53,3 +54,4 @@ module SDP
     end
   end
 end
+# rubocop:enable Metrics/ParameterLists

--- a/test/fixtures/roles.yml
+++ b/test/fixtures/roles.yml
@@ -9,3 +9,5 @@ one: {}
 #
 two: {}
 # column: value
+
+publisher: {}

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,6 +12,14 @@ admin:
   last_system: nids
   last_program: generic
 
+publisher:
+  email: publisher@example.com
+  admin: true
+  first_name: "Awesome"
+  last_name: "Publisher"
+  last_system: nids
+  last_program: generic
+
 not_admin:
   email: not_admin@example.com
   admin: false

--- a/test/unit/lib/elastic_search_test.rb
+++ b/test/unit/lib/elastic_search_test.rb
@@ -14,7 +14,7 @@ class ElasticSearchTest < ActiveSupport::TestCase
     SDP::Elasticsearch.search(nil, 'Hello', 1)
     req = FakeWeb.last_request
     assert_equal 'GET', req.method
-    assert_equal '/vocabulary/form/_search', req.path
+    assert_equal '/vocabulary/_search', req.path
   end
 
   def test_search_on_type

--- a/test/unit/lib/elastic_search_test.rb
+++ b/test/unit/lib/elastic_search_test.rb
@@ -11,30 +11,24 @@ class ElasticSearchTest < ActiveSupport::TestCase
   end
 
   def test_search_on_string
-    SDP::Elasticsearch.with_client do |client|
-      SDP::Elasticsearch.search_on_string(client, 10, 1, 'form', 'Hello', '1')
-      req = FakeWeb.last_request
-      assert_equal 'GET', req.method
-      assert_equal '/vocabulary/form/_search', req.path
-    end
+    SDP::Elasticsearch.search(nil, 'Hello', 1)
+    req = FakeWeb.last_request
+    assert_equal 'GET', req.method
+    assert_equal '/vocabulary/form/_search', req.path
   end
 
   def test_search_on_type
-    SDP::Elasticsearch.with_client do |client|
-      SDP::Elasticsearch.search_on_type(client, 10, 1, 'form', '1')
-      req = FakeWeb.last_request
-      assert_equal 'GET', req.method
-      assert_equal '/vocabulary/form/_search', req.path
-    end
+    SDP::Elasticsearch.search('form', 'Hello', 1)
+    req = FakeWeb.last_request
+    assert_equal 'GET', req.method
+    assert_equal '/vocabulary/form/_search', req.path
   end
 
   def test_search_all
-    SDP::Elasticsearch.with_client do |client|
-      SDP::Elasticsearch.search_all(client, 10, 1, '1')
-      req = FakeWeb.last_request
-      assert_equal 'GET', req.method
-      assert_equal '/vocabulary/_search', req.path
-    end
+    SDP::Elasticsearch.search(nil, nil, 1, 10, -1, true)
+    req = FakeWeb.last_request
+    assert_equal 'GET', req.method
+    assert_equal '/vocabulary/_search', req.path
   end
 
   def test_delete_all

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -213,7 +213,7 @@ class FormEdit extends Component {
       );
     }
     return (
-      <div className="col-md-8">
+      <div className="col-md-7">
       <div className="" id='form-div'>
       <ModalDialog show ={this.state.showWarningModal}
                    title="Warning"

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -105,7 +105,7 @@ class ResponseSetDragWidget extends Component {
                       currentUser={this.props.currentUser}
                       handleSelectSearchResult={() => this.props.handleResponseSetsChange(this.props.selectedResponseSets.concat([rs.Source]))} />;
             })}
-            {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+            {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
               <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
             }
           </div>

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -136,7 +136,7 @@ class SurveyEdit extends Component {
       return ('Loading');
     }
     return (
-      <div className="col-md-8">
+      <div className="col-md-7">
       <div className="" id='survey-div'>
       <ModalDialog  show ={this.state.showModal}
                     title="Warning"

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -64,7 +64,7 @@ class FormSearchContainer extends Component {
               isEditPage={true}/>
             );
           })}
-          {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
             <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
           }
         </div>

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -81,7 +81,7 @@ class FormsEditContainer extends Component {
               <h3 className="panel-title">{_.capitalize(this.props.params.action)} Form </h3>
             </div>
             <div className="panel-body">
-              <div className="col-md-4">
+              <div className="col-md-5">
                 <div className="row add-question">
                   <Button onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
                 </div>

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -56,7 +56,7 @@ class QuestionSearchContainer extends Component {
               isEditPage={true}/>
             );
           })}
-          {searchResults.hits && searchResults.hits.total && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
             <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
           }
         </div>

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -56,7 +56,7 @@ class SurveyEditContainer extends Component {
               <h3 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h3>
             </div>
             <div className="panel-body">
-              <div className="col-md-4">
+              <div className="col-md-5">
                 <FormSearchContainer survey  ={this.props.survey}
                                      allForms={_.values(this.props.forms)}
                                      currentUser={this.props.currentUser} />


### PR DESCRIPTION
Current User in the store now has a `publisher` key that stores a `true` if the current_user.has_role? :publisher unblocking UI conditional rendering stories @schreiaj 

The backup search and elastic search now take into account wether the current_user is a publisher as well and return 

A lot of refactoring was done to the ES module to reduce redundancy and accommodate the new changes.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
