### PR TITLE
[SDP-506] Ensure ES is updated for child objects of survey

### DIFF
--- a/app/models/survey_form.rb
+++ b/app/models/survey_form.rb
@@ -5,6 +5,16 @@ class SurveyForm < ApplicationRecord
   after_commit :reindex, on: [:create, :update, :destroy]
 
   def reindex
-    UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json) if form
+    if form
+      UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
+      unique_response_sets = []
+      form.form_questions.each do |fq|
+        UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question).as_json)
+        unique_response_sets << fq.response_set if fq.response_set && !unique_response_sets.include?(fq.response_set)
+      end
+      unique_response_sets.each do |rs|
+        UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(rs).as_json)
+      end
+    end
   end
 end

--- a/test/controllers/survey_controller_test.rb
+++ b/test/controllers/survey_controller_test.rb
@@ -23,7 +23,7 @@ class SurveysControllerTest < ActionDispatch::IntegrationTest
     assert_difference('Survey.count') do
       post surveys_url params: { survey: { linked_forms: [forms(:one).id], name: 'Test' } }
     end
-    assert_enqueued_jobs 2 # one for the survey one for the form update
+    assert_enqueued_jobs 5 # 1 for the survey, 1 for the form update, 2 for questions, 1 for response set
     assert_response :success
     assert_equal 1, Survey.last.forms.length
     assert_equal 'GSP', Survey.last.surveillance_program.acronym


### PR DESCRIPTION
- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
