### PR TITLE
[SDP-482] Advanced / Prog & sys search filter

### DIFF
--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -1,4 +1,6 @@
 # rubocop:disable Metrics/AbcSize
+# rubocop:disable Metrics/PerceivedComplexity
+# rubocop:disable Metrics/CyclomaticComplexity
 require 'elasticsearch'
 require 'sdp/elastic_search'
 require 'sdp/simple_search'
@@ -10,12 +12,21 @@ class ElasticsearchController < ApplicationController
     page = params[:page] ? params[:page].to_i : 1
     current_user_id  = current_user ? current_user.id : -1
     publisher_search = current_user ? current_user.publisher? : false
+    my_stuff_filter = params[:my_stuff_filter] ? params[:my_stuff_filter] : false
+    program_filter = params[:program_filter] ? params[:program_filter] : []
+    system_filter = params[:system_filter] ? params[:system_filter] : []
     results = if SDP::Elasticsearch.ping
-                SDP::Elasticsearch.search(type, query_string, page, query_size, current_user_id, publisher_search)
+                SDP::Elasticsearch.search(type, query_string, page, query_size,
+                                          current_user_id, publisher_search,
+                                          my_stuff_filter, program_filter,
+                                          system_filter)
               else
-                SDP::SimpleSearch.search(type, query_string, current_user_id, query_size, page, publisher_search).target!
+                SDP::SimpleSearch.search(type, query_string, current_user_id,
+                                         query_size, page, publisher_search).target!
               end
     render json: results
   end
 end
 # rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Metrics/CyclomaticComplexity

--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -13,8 +13,8 @@ class ElasticsearchController < ApplicationController
     current_user_id  = current_user ? current_user.id : -1
     publisher_search = current_user ? current_user.publisher? : false
     my_stuff_filter = params[:my_stuff_filter] ? params[:my_stuff_filter] : false
-    program_filter = params[:program_filter] ? params[:program_filter] : []
-    system_filter = params[:system_filter] ? params[:system_filter] : []
+    program_filter = params[:programs] ? params[:programs] : []
+    system_filter = params[:systems] ? params[:systems] : []
     results = if SDP::Elasticsearch.ping
                 SDP::Elasticsearch.search(type, query_string, page, query_size,
                                           current_user_id, publisher_search,

--- a/webpack/actions/search_results_actions.js
+++ b/webpack/actions/search_results_actions.js
@@ -5,22 +5,22 @@ import {
   FETCH_MORE_SEARCH_RESULTS
 } from './types';
 
-export function fetchSearchResults(searchTerms=null, type=null) {
+export function fetchSearchResults(searchTerms=null, type=null, programFilter=[], systemFilter=[]) {
   return {
     type: FETCH_SEARCH_RESULTS,
     payload: axios.get(routes.elasticsearchPath(), {
       headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'},
-      params: { type: type, search: searchTerms }
+      params: { type: type, search: searchTerms, programs: programFilter, systems: systemFilter }
     })
   };
 }
 
-export function fetchMoreSearchResults(searchTerms=null, type=null, page) {
+export function fetchMoreSearchResults(searchTerms=null, type=null, page, programFilter=[], systemFilter=[]) {
   return {
     type: FETCH_MORE_SEARCH_RESULTS,
     payload: axios.get(routes.elasticsearchPath(), {
       headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'},
-      params: { type: type, search: searchTerms, page: page }
+      params: { type: type, search: searchTerms, page: page, programs: programFilter, systems: systemFilter }
     })
   };
 }

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -43,7 +43,7 @@ class DashboardSearch extends Component {
   }
 
   selectFilters(e, filterType) {
-    let newState = {}
+    let newState = {};
     newState[filterType] = _.values(e.target.selectedOptions).map((opt) => opt.value);
     this.props.setFiltersParent(newState);
     return this.setState(newState);

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -32,6 +32,10 @@ class DashboardSearch extends Component {
   }
 
   clearAdvSearch() {
+    this.props.setFiltersParent({
+      progFilters: [],
+      sysFilters: []
+    });
     this.setState({
       progFilters: [],
       sysFilters: []
@@ -39,13 +43,10 @@ class DashboardSearch extends Component {
   }
 
   selectFilters(e, filterType) {
-    let progIds = [];
-    // _.values(e.target.selectedOptions).map((opt) => progIds.push(opt.value));
     let newState = {}
     newState[filterType] = _.values(e.target.selectedOptions).map((opt) => opt.value);
-    //let newState = {'progFilters' : progIds};
+    this.props.setFiltersParent(newState);
     return this.setState(newState);
-    // return this.setState({`${filterType}`: progIds});
   }
 
   surveillanceProgramsSelect() {
@@ -112,7 +113,7 @@ class DashboardSearch extends Component {
 
   onFormSubmit(event){
     event.preventDefault();
-    this.props.search(this.state.searchTerms);
+    this.props.search(this.state.searchTerms, this.state.progFilters, this.state.sysFilters);
   }
 
   render() {
@@ -142,7 +143,8 @@ class DashboardSearch extends Component {
 DashboardSearch.propTypes = {
   search: PropTypes.func.isRequired,
   surveillanceSystems: surveillanceSystemsProps,
-  surveillancePrograms: surveillanceProgramsProps
+  surveillancePrograms: surveillanceProgramsProps,
+  setFiltersParent: PropTypes.func
 };
 
 export default DashboardSearch;

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -129,10 +129,26 @@ class DashboardSearch extends Component {
               <button id="search-btn" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
             </span>
           </div>
-          <a className="pull-right" title="Advanced Search" href="#" onClick={(e) => {
+          {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" className="adv-search-link pull-right" onClick={(e) => {
+            e.preventDefault();
+            this.clearAdvSearch();
+          }}>Clear Filters</a>}
+          <a className="adv-search-link pull-right" title="Advanced Search" href="#" onClick={(e) => {
             e.preventDefault();
             this.showAdvSearch();
           }}>Advanced</a>
+          {this.state.progFilters.length > 0 &&
+            <div className="adv-filter-list">Program Filters: {this.state.progFilters.map((id, i) => {
+              return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillancePrograms[id].name}</row>;
+            })}
+            </div>
+          }
+          {this.state.sysFilters.length > 0 &&
+            <div className="adv-filter-list">System Filters: {this.state.sysFilters.map((id, i) => {
+              return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillanceSystems[id].name}</row>;
+            })}
+            </div>
+          }<br/>
         </div>
       </div>
     </form>

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -129,26 +129,30 @@ class DashboardSearch extends Component {
               <button id="search-btn" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
             </span>
           </div>
-          {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" className="adv-search-link pull-right" onClick={(e) => {
-            e.preventDefault();
-            this.clearAdvSearch();
-          }}>Clear Filters</a>}
-          <a className="adv-search-link pull-right" title="Advanced Search" href="#" onClick={(e) => {
-            e.preventDefault();
-            this.showAdvSearch();
-          }}>Advanced</a>
-          {this.state.progFilters.length > 0 &&
-            <div className="adv-filter-list">Program Filters: {this.state.progFilters.map((id, i) => {
-              return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillancePrograms[id].name}</row>;
-            })}
+          {this.props.searchSource === 'simple_search' ? (<text className="adv-filter-list">Could not connect to elasticsearch, advanced searching disabled.</text>) : (
+            <div>
+              {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" className="adv-search-link pull-right" onClick={(e) => {
+                e.preventDefault();
+                this.clearAdvSearch();
+              }}>Clear Filters</a>}
+              <a className="adv-search-link pull-right" title="Advanced Search" href="#" onClick={(e) => {
+                e.preventDefault();
+                this.showAdvSearch();
+              }}>Advanced</a>
+              {this.state.progFilters.length > 0 &&
+                <div className="adv-filter-list">Program Filters: {this.state.progFilters.map((id, i) => {
+                  return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillancePrograms[id].name}</row>;
+                })}
+                </div>
+              }
+              {this.state.sysFilters.length > 0 &&
+                <div className="adv-filter-list">System Filters: {this.state.sysFilters.map((id, i) => {
+                  return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillanceSystems[id].name}</row>;
+                })}
+                </div>
+              }
             </div>
-          }
-          {this.state.sysFilters.length > 0 &&
-            <div className="adv-filter-list">System Filters: {this.state.sysFilters.map((id, i) => {
-              return <row key={i} className="adv-filter-list-item col-md-12">{this.props.surveillanceSystems[id].name}</row>;
-            })}
-            </div>
-          }<br/>
+          )}<br/>
         </div>
       </div>
     </form>
@@ -160,7 +164,8 @@ DashboardSearch.propTypes = {
   search: PropTypes.func.isRequired,
   surveillanceSystems: surveillanceSystemsProps,
   surveillancePrograms: surveillanceProgramsProps,
-  setFiltersParent: PropTypes.func
+  setFiltersParent: PropTypes.func,
+  searchSource: PropTypes.string
 };
 
 export default DashboardSearch;

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -1,12 +1,109 @@
 import React, { Component, PropTypes } from 'react';
+import { Modal, Button } from 'react-bootstrap';
+import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
+import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
+import _ from 'lodash';
 
 class DashboardSearch extends Component {
-
   constructor(props){
     super(props);
-    this.state={searchTerms: ''};
+    this.state={
+      searchTerms: '',
+      progFilters: [],
+      sysFilters: [],
+      showAdvSearchModal: false
+    };
+    this.showAdvSearch = this.showAdvSearch.bind(this);
+    this.hideAdvSearch = this.hideAdvSearch.bind(this);
+    this.clearAdvSearch = this.clearAdvSearch.bind(this);
     this.onInputChange = this.onInputChange.bind(this);
+    this.selectFilters = this.selectFilters.bind(this);
     this.onFormSubmit  = this.onFormSubmit.bind(this);
+    this.surveillanceProgramsSelect = this.surveillanceProgramsSelect.bind(this);
+    this.surveillanceSystemsSelect = this.surveillanceSystemsSelect.bind(this);
+  }
+
+  showAdvSearch() {
+    this.setState({ showAdvSearchModal: true });
+  }
+
+  hideAdvSearch() {
+    this.setState({ showAdvSearchModal: false });
+  }
+
+  clearAdvSearch() {
+    this.setState({
+      progFilters: [],
+      sysFilters: []
+    });
+  }
+
+  selectFilters(e, filterType) {
+    let progIds = [];
+    // _.values(e.target.selectedOptions).map((opt) => progIds.push(opt.value));
+    let newState = {}
+    newState[filterType] = _.values(e.target.selectedOptions).map((opt) => opt.value);
+    //let newState = {'progFilters' : progIds};
+    return this.setState(newState);
+    // return this.setState({`${filterType}`: progIds});
+  }
+
+  surveillanceProgramsSelect() {
+    if (_.isEmpty(this.props.surveillancePrograms)) {
+      return <p>No surveillance programs loaded in the database</p>;
+    } else {
+      return (
+        <div className="form-group">
+          <label>Select Programs:</label>
+          <select multiple className="form-control" id="select-prog" value={this.state.progFilters} onChange={(e) => this.selectFilters(e, 'progFilters')}>
+            {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
+              return <option key={sp.id} value={sp.id}>{sp.name}</option>;
+            })}
+          </select>
+        </div>
+      );
+    }
+  }
+
+  surveillanceSystemsSelect() {
+    if (_.isEmpty(this.props.surveillanceSystems)) {
+      return <p>No surveillance systems loaded in the database</p>;
+    } else {
+      return (
+        <div className="form-group">
+          <label>Select Systems:</label>
+          <select multiple className="form-control" id="select-sys" value={this.state.sysFilters} onChange={(e) => this.selectFilters(e, 'sysFilters')}>
+            {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
+              return <option key={ss.id} value={ss.id}>{ss.name}</option>;
+            })}
+          </select>
+        </div>
+      );
+    }
+  }
+
+  advSearchModal() {
+    return (
+      <Modal show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch}>
+        <Modal.Header closeButton bsStyle='search'>
+          <Modal.Title>Advanced Search Filters</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <div className="adv-filter-modal-body">
+            <div className="col-md-6">
+              {this.surveillanceProgramsSelect()}
+            </div>
+            <div className="col-md-6">
+              {this.surveillanceSystemsSelect()}
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={this.clearAdvSearch} bsStyle="primary">Clear Filters</Button>
+          <Button onClick={this.hideAdvSearch} bsStyle="primary">Close</Button>
+        </Modal.Footer>
+      </Modal>
+    );
   }
 
   onInputChange(event){
@@ -21,6 +118,7 @@ class DashboardSearch extends Component {
   render() {
     return (
       <form onSubmit={this.onFormSubmit}>
+      {this.advSearchModal()}
       <div className="row">
         <div className="col-md-12">
           <div className="input-group search-group">
@@ -30,6 +128,10 @@ class DashboardSearch extends Component {
               <button id="search-btn" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
             </span>
           </div>
+          <a className="pull-right" title="Advanced Search" href="#" onClick={(e) => {
+            e.preventDefault();
+            this.showAdvSearch();
+          }}>Advanced</a>
         </div>
       </div>
     </form>
@@ -38,7 +140,9 @@ class DashboardSearch extends Component {
 }
 
 DashboardSearch.propTypes = {
-  search: PropTypes.func.isRequired
+  search: PropTypes.func.isRequired,
+  surveillanceSystems: surveillanceSystemsProps,
+  surveillancePrograms: surveillanceProgramsProps
 };
 
 export default DashboardSearch;

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -83,7 +83,10 @@ class QuestionItem extends Component {
           <Modal.Title>Search Response Sets</Modal.Title>
         </Modal.Header>
         <Modal.Body bsStyle='search'>
-          <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
+          <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems}
+                           surveillancePrograms={this.props.surveillancePrograms}
+                           setFiltersParent={this.setFiltersParent}
+                           searchSource={this.props.searchResults.Source} />
           <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} handleSelectSearchResult={this.handleSelectSearchResult} />
         </Modal.Body>
         <Modal.Footer>

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -33,7 +33,7 @@ class QuestionItem extends Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    if(prevState != this.state) {
+    if(prevState != this.state && prevState.page === this.state.page) {
       let searchTerms = this.state.searchTerms;
       if(searchTerms === ''){
         searchTerms = null;

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -4,6 +4,8 @@ import { bindActionCreators } from 'redux';
 import { questionProps } from "../prop-types/question_props";
 import { responseSetProps } from "../prop-types/response_set_props";
 import currentUserProps from '../prop-types/current_user_props';
+import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
+import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 import { fetchSearchResults } from '../actions/search_results_actions';
 import SearchResult from './SearchResult';
 import DashboardSearch from './DashboardSearch';
@@ -18,13 +20,26 @@ class QuestionItem extends Component {
       programVar: this.props.programVar,
       showSearchModal: false,
       showProgramVarModal: false,
+      progFilters: [],
+      sysFilters: []
     };
+    this.setFiltersParent = this.setFiltersParent.bind(this);
     this.showResponseSetSearch = this.showResponseSetSearch.bind(this);
     this.hideResponseSetSearch = this.hideResponseSetSearch.bind(this);
     this.showProgramVarModal = this.showProgramVarModal.bind(this);
     this.hideProgramVarModal = this.hideProgramVarModal.bind(this);
     this.handleSelectSearchResult = this.handleSelectSearchResult.bind(this);
     this.search = this.search.bind(this);
+  }
+
+  componentDidUpdate(_prevProps, prevState) {
+    if(prevState != this.state) {
+      let searchTerms = this.state.searchTerms;
+      if(searchTerms === ''){
+        searchTerms = null;
+      }
+      this.props.fetchSearchResults(searchTerms, 'response_set', this.state.progFilters, this.state.sysFilters);
+    }
   }
 
   showResponseSetSearch() {
@@ -48,13 +63,17 @@ class QuestionItem extends Component {
     this.setState({ showSearchModal: false });
   }
 
-  search(searchTerms) {
+  setFiltersParent(newState) {
+    this.setState(newState);
+  }
+
+  search(searchTerms, progFilters, sysFilters) {
     let searchType = 'response_set';
     if(searchTerms === ''){
       searchTerms = null;
     }
-    this.setState({searchTerms: searchTerms});
-    this.props.fetchSearchResults(searchTerms, searchType);
+    this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
+    this.props.fetchSearchResults(searchTerms, searchType, progFilters, sysFilters);
   }
 
   searchModal() {
@@ -64,7 +83,7 @@ class QuestionItem extends Component {
           <Modal.Title>Search Response Sets</Modal.Title>
         </Modal.Header>
         <Modal.Body bsStyle='search'>
-          <DashboardSearch search={this.search} />
+          <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
           <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} handleSelectSearchResult={this.handleSelectSearchResult} />
         </Modal.Body>
         <Modal.Footer>
@@ -141,6 +160,8 @@ class QuestionItem extends Component {
 function mapStateToProps(state) {
   return {
     searchResults: state.searchResults,
+    surveillanceSystems: state.surveillanceSystems,
+    surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser
   };
 }
@@ -161,7 +182,9 @@ QuestionItem.propTypes = {
   responseSetId: PropTypes.number,
   programVar: PropTypes.string,
   searchResults: PropTypes.object,
-  currentUser: currentUserProps
+  currentUser: currentUserProps,
+  surveillanceSystems: surveillanceSystemsProps,
+  surveillancePrograms: surveillanceProgramsProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionItem);

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -32,7 +32,7 @@ class DashboardContainer extends Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    if(prevState != this.state) {
+    if(prevState != this.state && prevState.page === this.state.page) {
       let searchType = this.state.searchType;
       let searchTerms = this.state.searchTerms;
       if(searchType === '') {

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -14,11 +14,14 @@ class DashboardContainer extends Component {
   constructor(props){
     super(props);
     this.search = this.search.bind(this);
+    this.setFiltersParent = this.setFiltersParent.bind(this);
     this.selectType = this.selectType.bind(this);
     this.loadMore = this.loadMore.bind(this);
     this.state = {
       searchType: '',
       searchTerms: '',
+      progFilters: [],
+      sysFilters: [],
       page: 1
     };
   }
@@ -28,6 +31,20 @@ class DashboardContainer extends Component {
     this.search('');
   }
 
+  componentDidUpdate(_prevProps, prevState) {
+    if(prevState != this.state) {
+      let searchType = this.state.searchType;
+      let searchTerms = this.state.searchTerms;
+      if(searchType === '') {
+        searchType = null;
+      }
+      if(searchTerms === ''){
+        searchTerms = null;
+      }
+      this.props.fetchSearchResults(searchTerms, searchType, this.state.progFilters, this.state.sysFilters);
+    }
+  }
+
   render() {
     const searchResults = this.props.searchResults;
     return (
@@ -35,7 +52,7 @@ class DashboardContainer extends Component {
         <div className="row dashboard">
           <div className="col-md-8">
             <div className="dashboard-details">
-              <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} />
+              <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
               <div className="row">
                 <div className="col-md-12">
                   {this.analyticsGroup(this.state.searchType)}
@@ -69,11 +86,17 @@ class DashboardContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState);
+    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState,
+                                      this.state.progFilters,
+                                      this.state.sysFilters);
     this.setState({page: tempState});
   }
 
-  search(searchTerms) {
+  setFiltersParent(newState) {
+    this.setState(newState);
+  }
+
+  search(searchTerms, progFilters, sysFilters) {
     let searchType = null;
     if(this.state.searchType === '') {
       searchType = null;
@@ -83,8 +106,8 @@ class DashboardContainer extends Component {
     if(searchTerms === ''){
       searchTerms = null;
     }
-    this.setState({searchTerms: searchTerms});
-    this.props.fetchSearchResults(searchTerms, searchType);
+    this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
+    this.props.fetchSearchResults(searchTerms, searchType, progFilters, sysFilters);
   }
 
   selectType(searchType) {
@@ -100,7 +123,7 @@ class DashboardContainer extends Component {
     } else {
       this.setState({searchType: searchType, page: 1});
     }
-    this.props.fetchSearchResults(searchTerms, searchType);
+    this.props.fetchSearchResults(searchTerms, searchType, this.state.progFilters, this.state.sysFilters);
   }
 
   analyticsGroup(searchType) {
@@ -136,7 +159,7 @@ class DashboardContainer extends Component {
           </div>
           </li>
       </ul>
-      {searchType != '' && <a href="#" onClick={() => this.selectType(searchType)}>Clear Filter</a>}
+      {searchType != '' && <a href="#" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
     </div>);
   }
 

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -6,6 +6,8 @@ import { fetchStats } from '../actions/landing';
 import { fetchSearchResults, fetchMoreSearchResults } from '../actions/search_results_actions';
 import DashboardSearch from '../components/DashboardSearch';
 import SearchResultList from '../components/SearchResultList';
+import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
+import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 import currentUserProps from '../prop-types/current_user_props';
 
 class DashboardContainer extends Component {
@@ -33,7 +35,7 @@ class DashboardContainer extends Component {
         <div className="row dashboard">
           <div className="col-md-8">
             <div className="dashboard-details">
-              <DashboardSearch search={this.search} />
+              <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} />
               <div className="row">
                 <div className="col-md-12">
                   {this.analyticsGroup(this.state.searchType)}
@@ -178,6 +180,8 @@ function mapStateToProps(state) {
     myResponseSetCount: state.stats.myResponseSetCount,
     mySurveyCount: state.stats.mySurveyCount,
     searchResults: state.searchResults,
+    surveillanceSystems: state.surveillanceSystems,
+    surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser
   };
 }
@@ -199,7 +203,9 @@ DashboardContainer.propTypes = {
   fetchSearchResults: PropTypes.func,
   fetchMoreSearchResults: PropTypes.func,
   currentUser: currentUserProps,
-  searchResults: PropTypes.object
+  searchResults: PropTypes.object,
+  surveillanceSystems: surveillanceSystemsProps,
+  surveillancePrograms: surveillanceProgramsProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(DashboardContainer);

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -52,7 +52,10 @@ class DashboardContainer extends Component {
         <div className="row dashboard">
           <div className="col-md-8">
             <div className="dashboard-details">
-              <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
+              <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems}
+                               surveillancePrograms={this.props.surveillancePrograms}
+                               setFiltersParent={this.setFiltersParent}
+                               searchSource={this.props.searchResults.Source} />
               <div className="row">
                 <div className="col-md-12">
                   {this.analyticsGroup(this.state.searchType)}

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -79,7 +79,10 @@ class FormSearchContainer extends Component {
     const searchResults = this.props.searchResults;
     return (
       <div>
-        <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
+        <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems}
+                         surveillancePrograms={this.props.surveillancePrograms}
+                         setFiltersParent={this.setFiltersParent}
+                         searchSource={this.props.searchResults.Source} />
         <div className="load-more-search">
           {searchResults.hits && searchResults.hits.hits.map((f, i) => {
             return (

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -69,7 +69,7 @@ class FormSearchContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState,
+    this.props.fetchMoreSearchResults(searchTerms, 'form', tempState,
                                       this.state.progFilters,
                                       this.state.sysFilters);
     this.setState({page: tempState});

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -38,7 +38,7 @@ class FormSearchContainer extends Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    if(prevState != this.state) {
+    if(prevState != this.state && prevState.page === this.state.page) {
       let searchType = this.state.searchType;
       let searchTerms = this.state.searchTerms;
       if(searchType === '') {

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -8,14 +8,19 @@ import { fetchSearchResults, fetchMoreSearchResults } from '../actions/search_re
 import SearchResult from '../components/SearchResult';
 import DashboardSearch from '../components/DashboardSearch';
 import currentUserProps from "../prop-types/current_user_props";
+import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
+import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 
 class QuestionSearchContainer extends Component {
   constructor(props) {
     super(props);
     this.search = this.search.bind(this);
     this.loadMore = this.loadMore.bind(this);
+    this.setFiltersParent = this.setFiltersParent.bind(this);
     this.state = {
       searchTerms: '',
+      progFilters: [],
+      sysFilters: [],
       page: 1
     };
   }
@@ -24,12 +29,30 @@ class QuestionSearchContainer extends Component {
     this.search('');
   }
 
-  search(searchTerms) {
+  componentDidUpdate(_prevProps, prevState) {
+    if(prevState != this.state) {
+      let searchType = this.state.searchType;
+      let searchTerms = this.state.searchTerms;
+      if(searchType === '') {
+        searchType = null;
+      }
+      if(searchTerms === ''){
+        searchTerms = null;
+      }
+      this.props.fetchSearchResults(searchTerms, 'question', this.state.progFilters, this.state.sysFilters);
+    }
+  }
+
+  setFiltersParent(newState) {
+    this.setState(newState);
+  }
+
+  search(searchTerms, progFilters, sysFilters) {
     if(searchTerms === ''){
       searchTerms = null;
     }
-    this.setState({searchTerms: searchTerms});
-    this.props.fetchSearchResults(searchTerms, 'question');
+    this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
+    this.props.fetchSearchResults(searchTerms, 'question', progFilters, sysFilters);
   }
 
   loadMore() {
@@ -38,7 +61,9 @@ class QuestionSearchContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, 'question', tempState);
+    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState,
+                                      this.state.progFilters,
+                                      this.state.sysFilters);
     this.setState({page: tempState});
   }
 
@@ -46,7 +71,7 @@ class QuestionSearchContainer extends Component {
     const searchResults = this.props.searchResults;
     return (
       <div>
-        <DashboardSearch search={this.search} />
+        <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
         <div className="load-more-search">
           {searchResults.hits && searchResults.hits.hits.map((q, i) => {
             return (
@@ -68,6 +93,8 @@ class QuestionSearchContainer extends Component {
 function mapStateToProps(state) {
   return {
     searchResults: state.searchResults,
+    surveillanceSystems: state.surveillanceSystems,
+    surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser
   };
 }
@@ -82,7 +109,9 @@ QuestionSearchContainer.propTypes = {
   fetchSearchResults: PropTypes.func,
   fetchMoreSearchResults: PropTypes.func,
   currentUser: currentUserProps,
-  searchResults: PropTypes.object
+  searchResults: PropTypes.object,
+  surveillanceSystems: surveillanceSystemsProps,
+  surveillancePrograms: surveillanceProgramsProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionSearchContainer);

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -61,7 +61,7 @@ class QuestionSearchContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState,
+    this.props.fetchMoreSearchResults(searchTerms, 'question', tempState,
                                       this.state.progFilters,
                                       this.state.sysFilters);
     this.setState({page: tempState});

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -30,7 +30,7 @@ class QuestionSearchContainer extends Component {
   }
 
   componentDidUpdate(_prevProps, prevState) {
-    if(prevState != this.state) {
+    if(prevState != this.state && prevState.page === this.state.page) {
       let searchType = this.state.searchType;
       let searchTerms = this.state.searchTerms;
       if(searchType === '') {

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -71,7 +71,10 @@ class QuestionSearchContainer extends Component {
     const searchResults = this.props.searchResults;
     return (
       <div>
-        <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems} surveillancePrograms={this.props.surveillancePrograms} setFiltersParent={this.setFiltersParent}/>
+        <DashboardSearch search={this.search} surveillanceSystems={this.props.surveillanceSystems}
+                         surveillancePrograms={this.props.surveillancePrograms}
+                         setFiltersParent={this.setFiltersParent}
+                         searchSource={this.props.searchResults.Source} />
         <div className="load-more-search">
           {searchResults.hits && searchResults.hits.hits.map((q, i) => {
             return (

--- a/webpack/styles/widgets/_search.scss
+++ b/webpack/styles/widgets/_search.scss
@@ -1,7 +1,7 @@
 .search-group {
   @extend .input-group;
   margin-top: 14px;
-  margin-bottom: 14px;
+  margin-bottom: 8px;
   margin-left: 20px;
   margin-right: 20px;
 }
@@ -115,4 +115,24 @@
 
 .adv-filter-modal-body {
   min-height: 160px;
+}
+
+.adv-search-link {
+  margin-right: 25px;
+  font-size: 14px;
+  font-weight: bold;
+}
+
+.adv-filter-list {
+  padding-left: 20px;
+  margin-bottom: 10px;
+  font-size: 14px;
+  font-weight: bold;
+  color: $dark-gray;
+
+  .adv-filter-list-item {
+    font-size: 13px;
+    font-weight: normal;
+    color: $dark-gray;
+  }
 }

--- a/webpack/styles/widgets/_search.scss
+++ b/webpack/styles/widgets/_search.scss
@@ -112,3 +112,7 @@
   @extend .btn-default;
   border: 1px solid $cdc-blue;
 }
+
+.adv-filter-modal-body {
+  min-height: 160px;
+}


### PR DESCRIPTION
Adds advanced search to applicable search bars, when applying a new filter it updates the results with the filter applied. If elastic search is down it displays a message letting the user know it is down.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [n/a] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [ ] Added cucumber tests for any new functionality - can't really test since elasticsearch is fake 'up' but filtering won't do anything without substantial test framework changes.
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [n/a] If any database changes were made, run `rake generate_erd` to update the README.md
- [n/a] If any changes were made to config/routes.rb run `rake jsroutes:generate`
