### PR TITLE
[SDP-490] Program and system import

### DIFF
--- a/lib/sdp/importers/cdc.rb
+++ b/lib/sdp/importers/cdc.rb
@@ -1,6 +1,12 @@
 module SDP
   module Importers
     module CDC
+      SYSTEM_NAME_INDEX = 2
+      STATUS_INDEX = 9
+      SUPPORT_TYPE_INDEX = 17
+      ABBREVIATION_INDEX = 95
+      PROGRAM_INDEX = 128
+
       def self.import_programs(program_csv_file)
         CSV.foreach(program_csv_file, headers: :first_row) do |row|
           SurveillanceProgram.find_or_create_by!(row.to_hash)
@@ -10,6 +16,26 @@ module SDP
       def self.import_systems(system_csv_file)
         CSV.foreach(system_csv_file, headers: :first_row) do |row|
           SurveillanceSystem.find_or_create_by!(row.to_hash)
+        end
+      end
+
+      def self.import_enterprise_data_spreadsheet(excelx_file)
+        programs = []
+        xlsx = Roo::Spreadsheet.open(excelx_file)
+        sheet = xlsx.sheet(0)
+        (sheet.first_row + 2).upto(sheet.last_row) do |i|
+          next unless sheet.row(i)[STATUS_INDEX] == 'Active' && sheet.row(i)[SUPPORT_TYPE_INDEX] == 'Mission Support'
+          SurveillanceSystem.find_or_create_by!(name: sheet.row(i)[SYSTEM_NAME_INDEX], acronym: sheet.row(i)[ABBREVIATION_INDEX])
+          if !programs.include?(sheet.row(i)[PROGRAM_INDEX]) && sheet.row(i)[PROGRAM_INDEX].respond_to?(:strip)
+            programs << sheet.row(i)[PROGRAM_INDEX]
+          end
+        end
+        write_out_programs(programs)
+      end
+
+      def self.write_out_programs(programs)
+        programs.compact.each do |p|
+          SurveillanceProgram.find_or_create_by!(name: p.strip)
         end
       end
     end

--- a/lib/sdp/importers/cdc.rb
+++ b/lib/sdp/importers/cdc.rb
@@ -35,7 +35,16 @@ module SDP
 
       def self.write_out_programs(programs)
         programs.compact.each do |p|
-          SurveillanceProgram.find_or_create_by!(name: p.strip)
+          program_name = p.strip
+          acronym = nil
+          # If the program name has the acronym in parens, then pull out the
+          # acronym and strip it from the name
+          md = program_name.match(/\((\w+)\)/)
+          if md
+            acronym = md[1]
+            program_name = program_name.split('(')[0].strip
+          end
+          SurveillanceProgram.create!(name: program_name, acronym: acronym) unless SurveillanceProgram.find_by(name: program_name)
         end
       end
     end

--- a/lib/sdp/importers/jupiter.rb
+++ b/lib/sdp/importers/jupiter.rb
@@ -1,0 +1,18 @@
+module SDP
+  module Importers
+    module Jupiter
+      def self.request(url)
+        items = []
+        response = HTTParty.get(url)
+        response['nodedataarr'].each do |ss|
+          name = ss['name']
+          description = nil
+          purpose = ss['attributes'].find { |a| a['key'] == 'purpose' }
+          description = purpose['value'] if purpose && purpose['value'].present? && purpose['value'] != 'N/A'
+          items << { name: name, description: description }
+        end
+        items
+      end
+    end
+  end
+end

--- a/lib/tasks/programs_and_systems.rake
+++ b/lib/tasks/programs_and_systems.rake
@@ -9,4 +9,9 @@ namespace :cdc do
   task :import_systems, [:file] => :environment do |_t, args|
     SDP::Importers::CDC.import_systems(args.file)
   end
+
+  desc 'Import Programs and Systems from the Enterprise Data Excel File'
+  task :import_excel, [:file] => :environment do |_t, args|
+    SDP::Importers::CDC.import_enterprise_data_spreadsheet(args.file)
+  end
 end

--- a/lib/tasks/programs_and_systems.rake
+++ b/lib/tasks/programs_and_systems.rake
@@ -1,4 +1,5 @@
 require 'sdp/importers/cdc'
+require 'sdp/importers/jupiter'
 namespace :cdc do
   desc 'Import Surveillance Programs from a CSV File'
   task :import_programs, [:file] => :environment do |_t, args|
@@ -13,5 +14,18 @@ namespace :cdc do
   desc 'Import Programs and Systems from the Enterprise Data Excel File'
   task :import_excel, [:file] => :environment do |_t, args|
     SDP::Importers::CDC.import_enterprise_data_spreadsheet(args.file)
+  end
+
+  desc 'Import Programs and Systems from Jupiter'
+  task :import_jupiter, [:url] => :environment do |_t, args|
+    base_url = args.url || 'http://jupiter.phiresearchlab.org/api/node/search/label/'
+    systems = SDP::Importers::Jupiter.request(base_url + 'SurveillanceSystem')
+    programs = SDP::Importers::Jupiter.request(base_url + 'Program')
+    systems.each do |ss|
+      SurveillanceSystem.find_or_create_by!(ss) unless SurveillanceSystem.find_by(name: ss[:name])
+    end
+    programs.each do |sp|
+      SurveillanceProgram.find_or_create_by!(sp) unless SurveillanceProgram.find_by(name: sp[:name])
+    end
   end
 end

--- a/test/fixtures/files/jupiter_response.json
+++ b/test/fixtures/files/jupiter_response.json
@@ -1,0 +1,43 @@
+{
+  "nodedataarr": [
+    {
+      "name": "Arctic Investigations Program",
+      "id": "P1",
+      "labels": "Program",
+      "relCount": 9,
+      "status": "Fully Operational and Implemented",
+      "attributes": [
+        {
+          "key": "purpose",
+          "value": "The mission of the Arctic Investigations Program (AIP) is prevention of infectious diseases in peoples of the Arctic and Subarctic with special emphasis on diseases of high incidence and concern among Alaska Natives and American Indians. Priority activities include prevention of diseases caused by Streptococcus pneumoniae, Haemophilus influenzae type b, Helicobacter pylori, methicillin-resistant staphylococcus aureus, and respiratory syncytial..."
+        }
+      ]
+    },
+    {
+      "name": "Biosecurity Engagement Program",
+      "id": "P2",
+      "labels": "Program",
+      "relCount": 6,
+      "status": "Fully Operational and Implemented",
+      "attributes": [
+        {
+          "key": "purpose",
+          "value": "The Biosecurity Engagement Program (BEP) is a portfolio of security-related overseas projects supported by the U.S. Department of State Bureau of International Security and Nonproliferation. Projects include those initiated in the former Soviet Union as the Biotechnology Engagement Program (BTEP) implemented through the International Science and Technology Center in Russia and the Science and Technology Center in Ukraine. BEP supports a broad ..."
+        }
+      ]
+    },
+    {
+      "name": "Program with N/A description",
+      "id": "P3",
+      "labels": "Program",
+      "relCount": 6,
+      "status": "Fully Operational and Implemented",
+      "attributes": [
+        {
+          "key": "purpose",
+          "value": "N/A"
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/lib/jupiter_test.rb
+++ b/test/unit/lib/jupiter_test.rb
@@ -1,0 +1,15 @@
+require 'test_helper'
+require 'sdp/importers/jupiter'
+
+class JupiterTest < ActiveSupport::TestCase
+  test 'request' do
+    FakeWeb.register_uri(:get, 'http://jupiter-example.com/test1',
+                         body: File.read('test/fixtures/files/jupiter_response.json'),
+                         content_type: 'application/json')
+    programs = SDP::Importers::Jupiter.request('http://jupiter-example.com/test1')
+    assert_equal 3, programs.length
+    assert_equal 'Arctic Investigations Program', programs[0][:name]
+    assert programs[0][:description].include?('The mission of the Arctic Investigations Program')
+    assert_nil programs[2][:description]
+  end
+end


### PR DESCRIPTION
Contains rake tasks to import surveillance programs and systems from two things:
* An internally generated CDC excel file
* Jupiter - http://jupiter.phiresearchlab.org/

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
