### PR TITLE
[SDP-474] Publisher lookup

### DIFF
--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -19,6 +19,18 @@ Feature: Manage Forms
     Then I should see "Test Form"
     Then I should see "Form description"
 
+  Scenario: Send a Draft Form to a Publisher
+    Given I have a Form with the name "Test Form" and the description "Form description"
+    And I have a publisher "johnny@test.org" with the first name "Johnny" and last name "Test"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Forms
+    And I click on the menu link for the Form with the name "Test Form"
+    And I click on the option to Details the Form with the name "Test Form"
+    Then I should see "Test Form"
+    And I should see "Send to publisher"
+    When I click on the "Send to publisher" button
+    And I should see "Johnny Test <johnny@test.org>"
+
   Scenario: Delete Form
     Given I have a Form with the name "Test Form" and the description "Form description"
     And I am logged in as test_author@gmail.com

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -25,6 +25,18 @@ Feature: Manage Questions
     And I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
 
+  Scenario: Send a Draft Question to a Publisher
+    Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC" and the concept "New Concept Name"
+    And I have a publisher "johnny@test.org" with the first name "Johnny" and last name "Test"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Questions
+    When I click on the menu link for the Question with the content "What is your gender?"
+    And I click on the option to Details the Question with the content "What is your gender?"
+    Then I should see "Name: What is your gender?"
+    And I should see "Send to publisher"
+    When I click on the "Send to publisher" button
+    And I should see "Johnny Test <johnny@test.org>"
+
   Scenario: Show Question in Detail No Concepts
     Given I have a Question with the content "What is your gender?" and the description "This is a question" and the type "MC"
     And I am logged in as test_author@gmail.com

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -50,6 +50,17 @@ Feature: Manage Response Sets
     And I should see "M / F"
     And I should not see "Publish"
 
+  Scenario: Send a Draft Response Set to a Publisher
+    Given I have a Response Set with the name "Gender Full" and the description "Response set description" and the response "Original Response"
+    And I am logged in as test_author@gmail.com
+    And I have a publisher "johnny@test.org" with the first name "Johnny" and last name "Test"
+    When I go to the list of Response Sets
+    When I click on the menu link for the Response Set with the name "Gender Full"
+    And I click on the option to Details the Response Set with the name "Gender Full"
+    Then I should see "Send to publisher"
+    When I click on the "Send to publisher" button
+    And I should see "Johnny Test <johnny@test.org>"
+
    Scenario: Delete a draft Response Set
     Given I have a Response Set with the name "Test Response Set" and the description "Response Set description"
     And I am logged in as test_author@gmail.com

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -19,6 +19,18 @@ Feature: Manage Surveys
     Then I should see "Test Survey"
     Then I should see "Survey description"
 
+  Scenario: Send a Draft Survey to a Publisher
+    Given I have a Survey with the name "Test Survey" and the description "Survey description"
+    And I have a publisher "johnny@test.org" with the first name "Johnny" and last name "Test"
+    And I am logged in as test_author@gmail.com
+    When I go to the list of Surveys
+    And I click on the menu link for the Survey with the name "Test Survey"
+    And I click on the option to Details the Survey with the name "Test Survey"
+    Then I should see "Test Survey"
+    And I should see "Send to publisher"
+    When I click on the "Send to publisher" button
+    And I should see "Johnny Test <johnny@test.org>"
+
  Scenario: Revise Survey
    Given I have a published Survey with the name "Test Survey" and the description "Survey description"
    Given I have a published Form with the name "Test Gender Form" and the description "Form description"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -15,6 +15,13 @@ Given(/^I am the publisher (.+)$/) do |user_name|
   login_as(user, scope: :user)
 end
 
+Given(/^I have a publisher "(.+)" with the first name "(.+)" and last name "(.+)"$/) do |user_name, first_name, last_name|
+  user = User.create_with(password: 'password').find_or_create_by(email: user_name, first_name: first_name, last_name: last_name)
+  Ability.new(user)
+  user.add_role :publisher
+  user.save
+end
+
 Given(/^I am working the program "(.+)" and system "(.+)" logged in as (.+)$/) do |program_name, system_name, user_name|
   user = User.create_with(password: 'password').find_or_create_by(email: user_name)
   Ability.new(user)

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "resolve-url-loader": "^1.6.0",
     "sass-loader": "^4.0.2",
     "stats-webpack-plugin": "^0.2.1",
+    "strict-uri-encode": "^2.0.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.9.11",

--- a/webpack/actions/publisher_actions.js
+++ b/webpack/actions/publisher_actions.js
@@ -1,0 +1,14 @@
+import axios from 'axios';
+import routes from '../routes';
+import {
+  FETCH_PUBLISHERS
+} from './types';
+
+export function fetchPublishers() {
+  return {
+    type: FETCH_PUBLISHERS,
+    payload: axios.get(routes.publishersPath(), {
+      headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'}
+    })
+  };
+}

--- a/webpack/actions/types.js
+++ b/webpack/actions/types.js
@@ -126,3 +126,7 @@ export const CREATE_SURVEY = 'CREATE_SURVEY';
 
 // Current User
 export const LOG_OUT = 'LOG_OUT';
+
+// Publisher types
+export const FETCH_PUBLISHERS = 'FETCH_PUBLISHERS';
+export const FETCH_PUBLISHERS_FULFILLED = 'FETCH_PUBLISHERS_FULFILLED';

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -1,10 +1,14 @@
 import React, { Component, PropTypes } from 'react';
-import {formProps} from '../prop-types/form_props';
+import { hashHistory, Link } from 'react-router';
+
 import FormQuestionList from './FormQuestionList';
 import Routes from '../routes';
 import VersionInfo from './VersionInfo';
-import { hashHistory, Link } from 'react-router';
+import PublisherLookUp from "./shared_show/PublisherLookUp";
+
+import { formProps } from '../prop-types/form_props';
 import currentUserProps from '../prop-types/current_user_props';
+import { publishersProps } from "../prop-types/publisher_props";
 import { isEditable, isRevisable, isPublishable, isExtendable } from '../utilities/componentHelpers';
 
 class FormShow extends Component {
@@ -47,6 +51,10 @@ class FormShow extends Component {
     return (
       <div className="col-md-9 nopadding maincontent">
         <div className="action_bar no-print">
+          {isEditable(form, this.props.currentUser) &&
+            <PublisherLookUp publishers={this.props.publishers}
+                           itemType="Form" />
+          }
           {isPublishable(form, this.props.currentUser) &&
               <a className="btn btn-default" href="#" onClick={(e) => {
                 e.preventDefault();
@@ -118,7 +126,8 @@ FormShow.propTypes = {
   router: PropTypes.object,
   currentUser: currentUserProps,
   publishForm: PropTypes.func,
-  deleteForm:  PropTypes.func.isRequired
+  deleteForm:  PropTypes.func.isRequired,
+  publishers: publishersProps
 };
 
 export default FormShow;

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -1,13 +1,18 @@
 import React, { Component, PropTypes } from 'react';
-import { questionProps } from "../prop-types/question_props";
+import moment from 'moment';
+import _ from 'lodash';
+import { hashHistory, Link } from 'react-router';
+
 import VersionInfo from "./VersionInfo";
 import ResponseSetList from "./ResponseSetList";
 import CodedSetTable from "./CodedSetTable";
 import ProgramsAndSystems from "./shared_show/ProgramsAndSystems";
-import moment from 'moment';
-import _ from 'lodash';
-import { hashHistory, Link } from 'react-router';
+import PublisherLookUp from "./shared_show/PublisherLookUp";
+
+import { questionProps } from "../prop-types/question_props";
 import currentUserProps from "../prop-types/current_user_props";
+import { publishersProps } from "../prop-types/publisher_props";
+
 import { isEditable, isRevisable, isPublishable, isExtendable } from '../utilities/componentHelpers';
 
 export default class QuestionDetails extends Component {
@@ -84,6 +89,10 @@ export default class QuestionDetails extends Component {
       <div className="col-md-9 nopadding maincontent">
         {this.props.currentUser && this.props.currentUser.id && question.mostRecent == question.version &&
           <div className="action_bar no-print">
+            {isEditable(question, this.props.currentUser) &&
+              <PublisherLookUp publishers={this.props.publishers}
+                             itemType="Question" />
+            }
             {isRevisable(question, this.props.currentUser) &&
               <Link className="btn btn-primary" to={`/questions/${this.props.question.id}/revise`}>Revise</Link>
             }
@@ -200,5 +209,6 @@ QuestionDetails.propTypes = {
   router: PropTypes.object,
   responseSets: PropTypes.array,
   handlePublish:  PropTypes.func,
-  deleteQuestion: PropTypes.func
+  deleteQuestion: PropTypes.func,
+  publishers: publishersProps
 };

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -9,7 +9,9 @@ import { hashHistory } from 'react-router';
 import QuestionList  from './QuestionList';
 import CodedSetTable from "./CodedSetTable";
 import ProgramsAndSystems from "./shared_show/ProgramsAndSystems";
+import PublisherLookUp from "./shared_show/PublisherLookUp";
 import currentUserProps from "../prop-types/current_user_props";
+import { publishersProps } from "../prop-types/publisher_props";
 import { isEditable, isRevisable, isPublishable, isExtendable } from '../utilities/componentHelpers';
 import _ from 'lodash';
 
@@ -55,6 +57,10 @@ export default class ResponseSetDetails extends Component {
       <div className="col-md-9 nopadding maincontent">
         {this.props.currentUser && this.props.currentUser.id &&
           <div className="action_bar no-print">
+            {isPublishable(responseSet, this.props.currentUser) &&
+              <PublisherLookUp publishers={this.props.publishers}
+                             itemType="Response Set" />
+            }
             {isRevisable(responseSet, this.props.currentUser) &&
               <Link className="btn btn-default" to={`/responseSets/${responseSet.id}/revise`}>Revise</Link>
             }
@@ -147,5 +153,6 @@ ResponseSetDetails.propTypes = {
   currentUser: currentUserProps,
   publishResponseSet: PropTypes.func,
   deleteResponseSet:  PropTypes.func,
-  questions: PropTypes.arrayOf(questionProps)
+  questions: PropTypes.arrayOf(questionProps),
+  publishers: publishersProps
 };

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -57,7 +57,7 @@ export default class ResponseSetDetails extends Component {
       <div className="col-md-9 nopadding maincontent">
         {this.props.currentUser && this.props.currentUser.id &&
           <div className="action_bar no-print">
-            {isPublishable(responseSet, this.props.currentUser) &&
+            {isEditable(responseSet, this.props.currentUser) &&
               <PublisherLookUp publishers={this.props.publishers}
                              itemType="Response Set" />
             }

--- a/webpack/components/shared_show/PublisherLookUp.js
+++ b/webpack/components/shared_show/PublisherLookUp.js
@@ -1,0 +1,37 @@
+import React, { Component, PropTypes } from 'react';
+import { publishersProps } from '../../prop-types/publisher_props';
+import _ from 'lodash';
+import strictUriEncode from 'strict-uri-encode';
+
+class PublisherLookUp extends Component {
+  render() {
+    return (<div className="btn-group">
+              <button className="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <span className="fa fa-envelope-o"></span> Send to Publisher <span className="fa fa-users"></span><span className="caret"></span>
+              </button>
+              <ul className="dropdown-menu">
+                <li key="header" className="dropdown-header">Publishers</li>
+                {_.values(this.props.publishers).map((p, i) => {
+                  return <li key={i}><a href={this.link(p)}>{p.name} &lt;{p.email}&gt;</a></li>;
+                })}
+              </ul>
+            </div>);
+  }
+
+  link(publisher) {
+    const subject = `Publish New ${this.props.itemType} - CDC Vocabulary Service`;
+    const body = `Hello ${publisher.firstName},
+
+Please review and publish my recently authored ${this.props.itemType}: ${window.location.href}
+
+Thanks!`;
+    return `mailto:${publisher.email}?subject=${strictUriEncode(subject)}&body=${strictUriEncode(body)}`;
+  }
+}
+
+PublisherLookUp.propTypes = {
+  itemType: PropTypes.string.isRequired,
+  publishers: publishersProps
+};
+
+export default PublisherLookUp;

--- a/webpack/components/shared_show/PublisherLookUp.js
+++ b/webpack/components/shared_show/PublisherLookUp.js
@@ -7,7 +7,7 @@ class PublisherLookUp extends Component {
   render() {
     return (<div className="btn-group">
               <button className="btn btn-default dropdown-toggle" type="button" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                <span className="fa fa-envelope-o"></span> Send to Publisher <span className="fa fa-users"></span><span className="caret"></span>
+                <span className="fa fa-envelope-o"></span> Send to publisher <span className="fa fa-users"></span><span className="caret"></span>
               </button>
               <ul className="dropdown-menu">
                 <li key="header" className="dropdown-header">Publishers</li>

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -1,9 +1,14 @@
 import React, { Component, PropTypes } from 'react';
-import { hashHistory, Link} from 'react-router';
+import { hashHistory, Link } from 'react-router';
+
+import VersionInfo from '../VersionInfo';
+import PublisherLookUp from "../shared_show/PublisherLookUp";
+
 import { surveyProps } from '../../prop-types/survey_props';
 import { formProps } from '../../prop-types/form_props';
 import currentUserProps from '../../prop-types/current_user_props';
-import VersionInfo from '../VersionInfo';
+import { publishersProps } from "../../prop-types/publisher_props";
+
 import { isEditable, isRevisable, isPublishable, isExtendable } from '../../utilities/componentHelpers';
 
 class SurveyShow extends Component{
@@ -25,6 +30,10 @@ class SurveyShow extends Component{
     return (
       <div className="col-md-9 nopadding maincontent">
         <div className="action_bar no-print">
+          {isEditable(this.props.survey, this.props.currentUser) &&
+            <PublisherLookUp publishers={this.props.publishers}
+                           itemType="Survey" />
+          }
           {isPublishable(this.props.survey, this.props.currentUser) &&
               <a className="btn btn-default" href="#" onClick={(e) => {
                 e.preventDefault();
@@ -144,7 +153,8 @@ SurveyShow.propTypes = {
   router: PropTypes.object,
   currentUser: currentUserProps,
   publishSurvey: PropTypes.func,
-  deleteSurvey:  PropTypes.func
+  deleteSurvey:  PropTypes.func,
+  publishers: publishersProps
 };
 
 export default SurveyShow;

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -14,6 +14,7 @@ import { surveillanceProgramsProps } from '../prop-types/surveillance_program_pr
 import { fetchCurrentUser, logIn, signUp, updateUser } from '../actions/current_user_actions';
 import { fetchSurveillanceSystems } from '../actions/surveillance_system_actions';
 import { fetchSurveillancePrograms } from '../actions/surveillance_program_actions';
+import { fetchPublishers } from '../actions/publisher_actions';
 
 class App extends Component {
   constructor(props) {
@@ -25,6 +26,7 @@ class App extends Component {
     this.props.fetchCurrentUser();
     this.props.fetchSurveillancePrograms();
     this.props.fetchSurveillanceSystems();
+    this.props.fetchPublishers();
   }
 
   openLogInModal() {
@@ -97,6 +99,7 @@ App.propTypes = {
   updateUser: PropTypes.func,
   fetchSurveillanceSystems: PropTypes.func,
   fetchSurveillancePrograms: PropTypes.func,
+  fetchPublishers: PropTypes.func,
   children: PropTypes.object,
   surveillanceSystems: surveillanceSystemsProps,
   surveillancePrograms: surveillanceProgramsProps
@@ -112,4 +115,4 @@ function mapStateToProps(state) {
 }
 
 export default connect(mapStateToProps, {fetchCurrentUser, logIn, signUp, updateUser,
-  fetchSurveillanceSystems, fetchSurveillancePrograms})(App);
+  fetchSurveillanceSystems, fetchSurveillancePrograms, fetchPublishers})(App);

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -10,6 +10,7 @@ import { questionsProps } from '../prop-types/question_props';
 import { responseSetsProps } from '../prop-types/response_set_props';
 import CommentList from '../containers/CommentList';
 import currentUserProps from '../prop-types/current_user_props';
+import { publishersProps } from "../prop-types/publisher_props";
 
 class FormShowContainer extends Component {
   componentWillMount() {
@@ -63,7 +64,8 @@ class FormShowContainer extends Component {
                       router={this.props.router}
                       currentUser={this.props.currentUser}
                       publishForm={this.props.publishForm}
-                      deleteForm ={this.props.deleteForm} />
+                      deleteForm ={this.props.deleteForm}
+                      publishers ={this.props.publishers} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
             <CommentList commentableType='Form' commentableId={this.props.form.id} />
           </div>
@@ -74,7 +76,13 @@ class FormShowContainer extends Component {
 }
 
 function mapStateToProps(state, ownProps) {
-  const props = {currentUser: state.currentUser, responseSets: state.responseSets, questions: state.questions, form: state.forms[ownProps.params.formId]};
+  const props = {
+    currentUser: state.currentUser,
+    responseSets: state.responseSets,
+    questions: state.questions,
+    form: state.forms[ownProps.params.formId],
+    publishers: state.publishers
+  };
   return props;
 }
 
@@ -93,7 +101,8 @@ FormShowContainer.propTypes = {
   fetchQuestions: PropTypes.func,
   fetchResponseSets: PropTypes.func,
   deleteForm:  PropTypes.func,
-  publishForm: PropTypes.func
+  publishForm: PropTypes.func,
+  publishers: publishersProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FormShowContainer);

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -7,6 +7,7 @@ import QuestionDetails  from '../components/QuestionDetails';
 import CommentList from '../containers/CommentList';
 import { responseSetProps } from "../prop-types/response_set_props";
 import currentUserProps from "../prop-types/current_user_props";
+import { publishersProps } from "../prop-types/publisher_props";
 
 class QuestionShowContainer extends Component {
 
@@ -50,7 +51,8 @@ class QuestionShowContainer extends Component {
                              router={this.props.router}
                              currentUser={this.props.currentUser}
                              handlePublish={this.handlePublish.bind(this)}
-                             deleteQuestion={this.props.deleteQuestion} />
+                             deleteQuestion={this.props.deleteQuestion}
+                             publishers={this.props.publishers} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
             <CommentList commentableType='Question' commentableId={this.props.question.id} />
           </div>
@@ -64,6 +66,7 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.question = state.questions[ownProps.params.qId];
   props.currentUser = state.currentUser;
+  props.publishers = state.publishers;
   if (props.question && props.question.responseSets) {
     props.responseSets = props.question.responseSets.map((rsId) => state.responseSets[rsId]);
   }
@@ -83,7 +86,8 @@ QuestionShowContainer.propTypes = {
   responseSets:  PropTypes.arrayOf(responseSetProps),
   fetchQuestion: PropTypes.func,
   fetchQuestionUsage: PropTypes.func,
-  deleteQuestion: PropTypes.func
+  deleteQuestion: PropTypes.func,
+  publishers: publishersProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionShowContainer);

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -7,6 +7,7 @@ import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
 import CommentList from '../containers/CommentList';
 import currentUserProps from "../prop-types/current_user_props";
+import { publishersProps } from "../prop-types/publisher_props";
 import _ from 'lodash';
 
 class ResponseSetShowContainer extends Component {
@@ -41,12 +42,7 @@ class ResponseSetShowContainer extends Component {
       <div className="container">
         <div className="row basic-bg">
           <div className="col-md-12">
-            <ResponseSetDetails responseSet={this.props.responseSet}
-                                currentUser={this.props.currentUser}
-                                publishResponseSet={this.props.publishResponseSet}
-                                questions={this.props.questions}
-                                deleteResponseSet={this.props.deleteResponseSet}
-                                router={this.props.router} />
+            <ResponseSetDetails {...this.props} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
             <CommentList commentableType='ResponseSet' commentableId={this.props.responseSet.id} />
           </div>
@@ -60,6 +56,7 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.currentUser = state.currentUser;
   props.responseSet = state.responseSets[ownProps.params.rsId];
+  props.publishers = state.publishers;
   if (props.responseSet && props.responseSet.questions) {
     props.questions = _.compact(props.responseSet.questions.map((qId) => state.questions[qId]));
   }
@@ -79,7 +76,8 @@ ResponseSetShowContainer.propTypes = {
   fetchResponseSetUsage: PropTypes.func,
   deleteResponseSet:  PropTypes.func,
   params: PropTypes.object,
-  router: PropTypes.object.isRequired
+  router: PropTypes.object.isRequired,
+  publishers: publishersProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ResponseSetShowContainer);

--- a/webpack/containers/surveys/ShowContainer.js
+++ b/webpack/containers/surveys/ShowContainer.js
@@ -9,6 +9,7 @@ import { surveyProps } from '../../prop-types/survey_props';
 import { formProps } from '../../prop-types/form_props';
 import CommentList from '../../containers/CommentList';
 import currentUserProps from '../../prop-types/current_user_props';
+import { publishersProps } from "../../prop-types/publisher_props";
 
 class SurveyShowContainer extends Component {
   componentWillMount() {
@@ -35,12 +36,7 @@ class SurveyShowContainer extends Component {
       <div className="container">
         <div className="row basic-bg">
           <div className="col-md-12">
-            <SurveyShow currentUser={this.props.currentUser}
-                        publishSurvey={this.props.publishSurvey}
-                        router={this.props.router}
-                        survey={this.props.survey}
-                        forms ={this.props.forms}
-                        deleteSurvey={this.props.deleteSurvey} />
+            <SurveyShow {...this.props} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
             <CommentList commentableType='Survey' commentableId={this.props.survey.id} />
           </div>
@@ -53,6 +49,7 @@ class SurveyShowContainer extends Component {
 function mapStateToProps(state, ownProps) {
   const props = {};
   props.currentUser = state.currentUser;
+  props.publishers = state.publishers;
   props.survey = state.surveys[ownProps.params.surveyId];
   if (props.survey) {
     props.forms = props.survey.surveyForms.map((form) => state.forms[form.formId]);
@@ -81,7 +78,8 @@ SurveyShowContainer.propTypes = {
   fetchQuestions: PropTypes.func,
   fetchForms: PropTypes.func,
   params: PropTypes.object,
-  router: PropTypes.object
+  router: PropTypes.object,
+  publishers: publishersProps
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(SurveyShowContainer);

--- a/webpack/prop-types/publisher_props.js
+++ b/webpack/prop-types/publisher_props.js
@@ -1,0 +1,12 @@
+import { PropTypes } from 'react';
+
+const publisherProps = PropTypes.shape({
+  id:        PropTypes.number,
+  email:     PropTypes.string,
+  firstName: PropTypes.string,
+  lastName:  PropTypes.string,
+  name:  PropTypes.string
+});
+
+const publishersProps = PropTypes.objectOf(publisherProps);
+export {publisherProps, publishersProps};

--- a/webpack/reducers/index.js
+++ b/webpack/reducers/index.js
@@ -8,7 +8,8 @@ import {
   FETCH_RESPONSE_TYPES_FULFILLED,
   FETCH_RESPONSE_TYPE_FULFILLED,
   FETCH_SURVEILLANCE_SYSTEMS_FULFILLED,
-  FETCH_SURVEILLANCE_PROGRAMS_FULFILLED
+  FETCH_SURVEILLANCE_PROGRAMS_FULFILLED,
+  FETCH_PUBLISHERS_FULFILLED
 } from '../actions/types';
 
 
@@ -32,11 +33,12 @@ const responseTypes = byIdWithIndividualReducer(FETCH_RESPONSE_TYPES_FULFILLED,
   FETCH_RESPONSE_TYPE_FULFILLED);
 const surveillanceSystems  = byIdReducer(FETCH_SURVEILLANCE_SYSTEMS_FULFILLED);
 const surveillancePrograms = byIdReducer(FETCH_SURVEILLANCE_PROGRAMS_FULFILLED);
+const publishers = byIdReducer(FETCH_PUBLISHERS_FULFILLED);
 
 const rootReducer = combineReducers({
   questions, comments, stats, currentUser, responseSets, forms, questionTypes,
   responseTypes, notifications, searchResults, concepts, conceptSystems,
-  surveillancePrograms, surveillanceSystems, surveys
+  surveillancePrograms, surveillanceSystems, surveys, publishers
 });
 
 export default rootReducer;


### PR DESCRIPTION
Provides a "Send to publisher" button on the show pages for Response Sets, Questions, Forms and Surveys. The button appears if the item is editable: most recent version, user is author and item is draft.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop

