### PR TITLE
Rake task to generate data for load testing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - 'bin/**/*'
     - 'lib/tasks/cucumber.rake'
+    - 'lib/tasks/data.rake'
     - 'db/schema.rb'
     - 'node_modules/**/*'
 Rails:

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -1,0 +1,30 @@
+namespace :data do
+  task :load_test, [:user_email] => :environment do |_t, args|
+    user = User.find_by(email: args.user_email)
+    if user.nil?
+      STDERR.puts "Unable to find user #{args.user_email}"
+      exit(-1)
+    end
+
+    rs = ResponseSet.new(created_by: user, status: 'draft',
+                         name: '30 Code Response Set')
+    responses = []
+    30.times do |i|
+      r = Response.new(value: "code-#{i}", code_system: 'test',
+                       display_name: "Code #{i}")
+      responses << r
+    end
+    rs.responses = responses
+    rs.save!
+
+    form = Form.new(name: '500 Question Form', created_by: user, status: 'draft')
+    500.times do |i|
+      position = i + 1
+      q = Question.create(content: "Is your favorite number #{position}?",
+                          created_by: user, status: 'draft')
+      fq = FormQuestion.new(question: q, position: position)
+      form.form_questions << fq
+    end
+    form.save!
+  end
+end


### PR DESCRIPTION
This rake task populates the database with items needed for load testing, as specified in the test plan. Those items include:

* A response set with 30 codes
* A form with 500 questions

Running the rake task will insert these into the database. The task does not check to see if those items exist before putting them in the db.