### PR TITLE
[SDP-538] Adding navigation roles to some elements

### DIFF
--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -282,7 +282,7 @@ export default class SearchResult extends Component {
                   {this.linkedDetails(result, type)}
                 </div>
               </li>
-              <li className="u-result-content-item result-nav">
+              <li className="u-result-content-item result-nav" role="navigation" aria-label="Search Result">
                 <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i></Link></div>
                 <div className="result-nav-item">
                   {handleSelectSearchResult ? (

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -259,7 +259,7 @@ class DashboardContainer extends Component {
 
   analyticsGroup(searchType) {
     return (
-    <div className="analytics-group">
+    <div className="analytics-group" role="navigation" aria-label="Analytics">
       <ul className="analytics-list-group">
         <li id="questions-analytics-item" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
           <div>


### PR DESCRIPTION
The Analytics widget
The navigation portion of SearchResult
Skipped the header since it is already a <nav> element
Passing WAVE for the stuff I added

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
