### PR TITLE
[SDP-539] Drop down arrows on <select> in Question form

### DIFF
--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -157,7 +157,7 @@ class QuestionForm extends Component{
                     </div>
                     <div className="col-md-4 question-form-group">
                       <label className="input-label" htmlFor="questionTypeId">Category</label>
-                      <select className="input-format" name="questionTypeId" id="questionTypeId" defaultValue={state.questionTypeId} onChange={this.handleChange('questionTypeId')} >
+                      <select className="input-select" name="questionTypeId" id="questionTypeId" defaultValue={state.questionTypeId} onChange={this.handleChange('questionTypeId')} >
                         <option value=""></option>
                         {questionTypes && _.values(questionTypes).map((qt) => {
                           return <option key={qt.id} value={qt.id}>{qt.name}</option>;
@@ -174,7 +174,7 @@ class QuestionForm extends Component{
 
                 <div className="col-md-4 question-form-group">
                   <label className="input-label" htmlFor="responseTypeId">Response Type</label>
-                    <select name="responseTypeId" id="responseTypeId" className="input-format" defaultValue={ question ? question.responseTypeId :state.responseTypeId} onChange={this.handleResponseTypeChange()} >
+                    <select name="responseTypeId" id="responseTypeId" className="input-select" defaultValue={ question ? question.responseTypeId :state.responseTypeId} onChange={this.handleResponseTypeChange()} >
                       {this.sortedResponseTypes().map((rt) => {
                         return (<option key={rt.id} value={rt.id} >{rt.name} - {rt.description}</option>);
 

--- a/webpack/styles/elements/_input.scss
+++ b/webpack/styles/elements/_input.scss
@@ -9,7 +9,14 @@
   border-radius: 0px;
   -webkit-appearance: none;
   -webkit-border-radius: 0px;
-  -moz-appearance: textfield;
+  -moz-border-radius: 0px;
   text-indent: 1px;
   text-overflow: '';
+}
+
+.input-select {
+  @extend .input-format;
+  background: url("data:image/svg+xml;utf8,<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='24' height='24' viewBox='0 0 24 24'><path fill='#444' d='M7.406 7.828l4.594 4.594 4.594-4.594 1.406 1.406-6 6-6-6z'></path></svg>");
+  background-position: 100% 50%;
+  background-repeat: no-repeat;
 }


### PR DESCRIPTION
Fixes issue where drop down arrows were not present on select elements in the Question form.

This creates a new style for select elements. The only way to get rid
of rounded corners in Chrome is `-webkit-appearance: none;`.
Unfortunately, that causes Chrome to get rid of the arrows on a select
element. This adds an arrow back in via SVG.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
