### PR TITLE
[SDP-525,532,533,534] 508 Compliance (part 2)

### DIFF
--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -10,7 +10,7 @@ Feature: Edit Forms
     Then I should see "Test Form"
     Then I should see "Form description"
     When I click on the "Edit" link
-    And I fill in the "form name" field with "Edited Form"
+    And I fill in the "form-name" field with "Edited Form"
     And I click on the "Save" button
     Then I should see "Name: Edited Form"
     Then I should see "Form description"
@@ -25,8 +25,8 @@ Feature: Edit Forms
     When I go to the dashboard
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to Revise the Form with the name "Test Form"
-    And I fill in the "form name" field with "Gender Form"
-    And I fill in the "form description" field with "Revised Description"
+    And I fill in the "form-name" field with "Gender Form"
+    And I fill in the "form-description" field with "Revised Description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -52,7 +52,7 @@ Feature: Edit Forms
     When I go to the dashboard
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to Extend the Form with the name "Test Form"
-    And I fill in the "form name" field with "Test Form Extended"
+    And I fill in the "form-name" field with "Test Form Extended"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -102,9 +102,9 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
-    And I fill in the "form description" field with "Form description"
+    And I fill in the "form-description" field with "Form description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -113,7 +113,7 @@ Feature: Edit Forms
     And I click on the "Add New Question" button
     And I fill in the "Question" field with "What is your favorite color?"
     And I select the "Open Choice" option in the "Response Type" list
-    And I fill in the "question description" field with "This is a description"
+    And I fill in the "question-description" field with "This is a description"
     And I should see "No Response Sets selected"
     Then I select the "Text" option in the "Response Type" list
     And I should not see "No Response Sets selected"
@@ -129,15 +129,15 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
-    And I fill in the "form description" field with "Form description"
+    And I fill in the "form-description" field with "Form description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
     Then I click on the "Add New Response Set" button
-    Then I fill in the "response set name" field with "New Response Set"
+    Then I fill in the "response-set-name" field with "New Response Set"
     And I click on the "Add Response Set" button
     Then I wait 1 seconds
     And I use the response set search modal to select "New Response Set"
@@ -164,7 +164,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
@@ -182,7 +182,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the list of Forms
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     When I click on the "CDC Vocabulary Service" link
     And I click on the "Continue Without Saving" button
@@ -195,7 +195,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234"
     And I fill in the "search" field with "What"
     And I set search filter to "question"

--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -10,7 +10,7 @@ Feature: Edit Forms
     Then I should see "Test Form"
     Then I should see "Form description"
     When I click on the "Edit" link
-    And I fill in the "name" field with "Edited Form"
+    And I fill in the "form name" field with "Edited Form"
     And I click on the "Save" button
     Then I should see "Name: Edited Form"
     Then I should see "Form description"
@@ -25,8 +25,8 @@ Feature: Edit Forms
     When I go to the dashboard
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to Revise the Form with the name "Test Form"
-    And I fill in the "name" field with "Gender Form"
-    And I fill in the "description" field with "Revised Description"
+    And I fill in the "form name" field with "Gender Form"
+    And I fill in the "form description" field with "Revised Description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -52,7 +52,7 @@ Feature: Edit Forms
     When I go to the dashboard
     And I click on the menu link for the Form with the name "Test Form"
     And I click on the option to Extend the Form with the name "Test Form"
-    And I fill in the "name" field with "Test Form Extended"
+    And I fill in the "form name" field with "Test Form Extended"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -102,9 +102,9 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
-    And I fill in the "description" field with "Form description"
+    And I fill in the "form description" field with "Form description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
@@ -113,7 +113,7 @@ Feature: Edit Forms
     And I click on the "Add New Question" button
     And I fill in the "Question" field with "What is your favorite color?"
     And I select the "Open Choice" option in the "Response Type" list
-    And I fill in the "question_description" field with "This is a description"
+    And I fill in the "question description" field with "This is a description"
     And I should see "No Response Sets selected"
     Then I select the "Text" option in the "Response Type" list
     And I should not see "No Response Sets selected"
@@ -129,15 +129,15 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
-    And I fill in the "description" field with "Form description"
+    And I fill in the "form description" field with "Form description"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
     Then I click on the "Add New Response Set" button
-    Then I fill in the "response_set_name" field with "New Response Set"
+    Then I fill in the "response set name" field with "New Response Set"
     And I click on the "Add Response Set" button
     Then I wait 1 seconds
     And I use the response set search modal to select "New Response Set"
@@ -164,7 +164,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "search" field with "What"
     And I set search filter to "question"
@@ -182,7 +182,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the list of Forms
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234-1234"
     When I click on the "CDC Vocabulary Service" link
     And I click on the "Continue Without Saving" button
@@ -195,7 +195,7 @@ Feature: Edit Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "controlNumber" field with "1234"
     And I fill in the "search" field with "What"
     And I set search filter to "question"

--- a/features/edit_questions.feature
+++ b/features/edit_questions.feature
@@ -47,7 +47,7 @@ Feature: Edit Questions
     And I select the "Open Choice" option in the "Response Type" list
     And I click on the "select-Gender Full" link
     Then I click on the "Add New Response Set" button
-    Then I fill in the "response_set_name" field with "New Response Set"
+    Then I fill in the "response set name" field with "New Response Set"
     And I click on the "Add Response Set" button
     Then I should see "New Response Set"
     And I click on the "Save" button

--- a/features/edit_questions.feature
+++ b/features/edit_questions.feature
@@ -47,7 +47,7 @@ Feature: Edit Questions
     And I select the "Open Choice" option in the "Response Type" list
     And I click on the "select-Gender Full" link
     Then I click on the "Add New Response Set" button
-    Then I fill in the "response set name" field with "New Response Set"
+    Then I fill in the "response-set-name" field with "New Response Set"
     And I click on the "Add Response Set" button
     Then I should see "New Response Set"
     And I click on the "Save" button

--- a/features/export_forms.feature
+++ b/features/export_forms.feature
@@ -8,7 +8,7 @@ Feature: Export Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "search" field with "What"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -22,7 +22,7 @@ Feature: Export Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I fill in the "search" field with "What"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"

--- a/features/export_forms.feature
+++ b/features/export_forms.feature
@@ -8,7 +8,7 @@ Feature: Export Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "search" field with "What"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -22,7 +22,7 @@ Feature: Export Forms
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I fill in the "search" field with "What"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -43,7 +43,7 @@ Feature: Manage Response Sets
     And I click on the option to Details the Response Set with the name "Gender Full"
     Then I should see "Edit"
     When I click on the "Edit" button
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Save" button
     Then I should see "Gender Partial"
@@ -96,7 +96,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Revise the Response Set with the name "Gender Full"
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"
@@ -126,7 +126,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Extend the Response Set with the name "Gender Full"
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F / O"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"
@@ -143,7 +143,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I click on the "Add Row" link
@@ -174,7 +174,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"
@@ -191,7 +191,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response set name" field with "Gender Partial"
+    And I fill in the "response-set-name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -43,7 +43,7 @@ Feature: Manage Response Sets
     And I click on the option to Details the Response Set with the name "Gender Full"
     Then I should see "Edit"
     When I click on the "Edit" button
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Save" button
     Then I should see "Gender Partial"
@@ -96,7 +96,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Revise the Response Set with the name "Gender Full"
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"
@@ -126,7 +126,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Gender Full"
     And I click on the option to Extend the Response Set with the name "Gender Full"
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F / O"
     And I click on the "Add Row" link
     And I fill in the "value_1" field with "Test Response 2"
@@ -143,7 +143,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I click on the "Add Row" link
@@ -174,7 +174,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"
@@ -191,7 +191,7 @@ Feature: Manage Response Sets
     Given I am logged in as test_author@gmail.com
     When I go to the list of Response Sets
     And I click on the create "Response Sets" dropdown item
-    And I fill in the "response_set_name" field with "Gender Partial"
+    And I fill in the "response set name" field with "Gender Partial"
     And I fill in the "Description" field with "M / F"
     And I click on the "Add Row" link
     And I fill in the "value_0" field with "Test Response 1"

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -38,8 +38,8 @@ Feature: Manage Surveys
    When I go to the dashboard
    And I click on the menu link for the Survey with the name "Test Survey"
    And I click on the option to Revise the Survey with the name "Test Survey"
-   And I fill in the "name" field with "Gender Survey"
-   And I fill in the "description" field with "Revised Description"
+   And I fill in the "survey name" field with "Gender Survey"
+   And I fill in the "survey description" field with "Revised Description"
    And I fill in the "search" field with "Gender"
    And I click on the "search-btn" button
    And I use the form search to select "Test Gender Form"
@@ -57,7 +57,7 @@ Feature: Manage Surveys
     When I go to the dashboard
     And I click on the menu link for the Survey with the name "Test Survey"
     And I click on the option to Extend the Survey with the name "Test Survey"
-    And I fill in the "name" field with "Test Survey Extended"
+    And I fill in the "survey name" field with "Test Survey Extended"
     And I fill in the "search" field with "Gender"
     And I click on the "search-btn" button
     And I use the form search to select "Test Gender Form"
@@ -107,7 +107,7 @@ Feature: Manage Surveys
     Then I should see "Test Survey"
     Then I should see "Survey description"
     When I click on the "Edit" link
-    And I fill in the "name" field with "Edited Survey"
+    And I fill in the "survey name" field with "Edited Survey"
     And I click on the "Save" button
     Then I should see "Name: Edited Survey"
     Then I should see "Survey description"
@@ -140,7 +140,7 @@ Feature: Manage Surveys
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Surveys" dropdown item
-    And I fill in the "name" field with "Test Survey"
+    And I fill in the "survey name" field with "Test Survey"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "search" field with "Gender"
     And I click on the "search-btn" button
@@ -157,7 +157,7 @@ Feature: Manage Surveys
    And I am logged in as test_author@gmail.com
    When I go to the dashboard
    And I click on the create "Surveys" dropdown item
-   And I fill in the "name" field with "Test Survey"
+   And I fill in the "survey name" field with "Test Survey"
    And I fill in the "controlNumber" field with "1234-1234"
    And I fill in the "search" field with "Gender"
    And I click on the "search-btn" button
@@ -173,7 +173,7 @@ Feature: Manage Surveys
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Surveys" dropdown item
-    And I fill in the "name" field with "Test Survey"
+    And I fill in the "survey name" field with "Test Survey"
     And I fill in the "controlNumber" field with "1234"
     And I click on the "Save" button
     Then I should see "error(s) prohibited this form from being saved"

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -38,8 +38,8 @@ Feature: Manage Surveys
    When I go to the dashboard
    And I click on the menu link for the Survey with the name "Test Survey"
    And I click on the option to Revise the Survey with the name "Test Survey"
-   And I fill in the "survey name" field with "Gender Survey"
-   And I fill in the "survey description" field with "Revised Description"
+   And I fill in the "survey-name" field with "Gender Survey"
+   And I fill in the "survey-description" field with "Revised Description"
    And I fill in the "search" field with "Gender"
    And I click on the "search-btn" button
    And I use the form search to select "Test Gender Form"
@@ -57,7 +57,7 @@ Feature: Manage Surveys
     When I go to the dashboard
     And I click on the menu link for the Survey with the name "Test Survey"
     And I click on the option to Extend the Survey with the name "Test Survey"
-    And I fill in the "survey name" field with "Test Survey Extended"
+    And I fill in the "survey-name" field with "Test Survey Extended"
     And I fill in the "search" field with "Gender"
     And I click on the "search-btn" button
     And I use the form search to select "Test Gender Form"
@@ -107,7 +107,7 @@ Feature: Manage Surveys
     Then I should see "Test Survey"
     Then I should see "Survey description"
     When I click on the "Edit" link
-    And I fill in the "survey name" field with "Edited Survey"
+    And I fill in the "survey-name" field with "Edited Survey"
     And I click on the "Save" button
     Then I should see "Name: Edited Survey"
     Then I should see "Survey description"
@@ -140,7 +140,7 @@ Feature: Manage Surveys
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Surveys" dropdown item
-    And I fill in the "survey name" field with "Test Survey"
+    And I fill in the "survey-name" field with "Test Survey"
     And I fill in the "controlNumber" field with "1234-1234"
     And I fill in the "search" field with "Gender"
     And I click on the "search-btn" button
@@ -157,7 +157,7 @@ Feature: Manage Surveys
    And I am logged in as test_author@gmail.com
    When I go to the dashboard
    And I click on the create "Surveys" dropdown item
-   And I fill in the "survey name" field with "Test Survey"
+   And I fill in the "survey-name" field with "Test Survey"
    And I fill in the "controlNumber" field with "1234-1234"
    And I fill in the "search" field with "Gender"
    And I click on the "search-btn" button
@@ -173,7 +173,7 @@ Feature: Manage Surveys
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Surveys" dropdown item
-    And I fill in the "survey name" field with "Test Survey"
+    And I fill in the "survey-name" field with "Test Survey"
     And I fill in the "controlNumber" field with "1234"
     And I click on the "Save" button
     Then I should see "error(s) prohibited this form from being saved"

--- a/features/usage.feature
+++ b/features/usage.feature
@@ -16,7 +16,7 @@ Feature: Manage Usage
     Then I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
     When I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -24,7 +24,7 @@ Feature: Manage Usage
     Then I should see "Test Form"
     When I click on the "Publish" button
     And I click on the create "Surveys" dropdown item
-    And I fill in the "name" field with "Test Survey"
+    And I fill in the "survey name" field with "Test Survey"
     And I set search filter to "form"
     And I click on the "search-btn" button
     And I use the form search to select "Test Form"
@@ -53,7 +53,7 @@ Feature: Manage Usage
     Then I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
     When I click on the create "Forms" dropdown item
-    And I fill in the "name" field with "Test Form"
+    And I fill in the "form name" field with "Test Form"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -62,7 +62,7 @@ Feature: Manage Usage
     Then I should see "Test Form"
     When I click on the "Publish" button
     And I click on the create "Surveys" dropdown item
-    And I fill in the "name" field with "Test Survey"
+    And I fill in the "survey name" field with "Test Survey"
     And I set search filter to "form"
     And I click on the "search-btn" button
     And I use the form search to select "Test Form"

--- a/features/usage.feature
+++ b/features/usage.feature
@@ -16,7 +16,7 @@ Feature: Manage Usage
     Then I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
     When I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -24,7 +24,7 @@ Feature: Manage Usage
     Then I should see "Test Form"
     When I click on the "Publish" button
     And I click on the create "Surveys" dropdown item
-    And I fill in the "survey name" field with "Test Survey"
+    And I fill in the "survey-name" field with "Test Survey"
     And I set search filter to "form"
     And I click on the "search-btn" button
     And I use the form search to select "Test Form"
@@ -53,7 +53,7 @@ Feature: Manage Usage
     Then I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
     When I click on the create "Forms" dropdown item
-    And I fill in the "form name" field with "Test Form"
+    And I fill in the "form-name" field with "Test Form"
     And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
@@ -62,7 +62,7 @@ Feature: Manage Usage
     Then I should see "Test Form"
     When I click on the "Publish" button
     And I click on the create "Surveys" dropdown item
-    And I fill in the "survey name" field with "Test Survey"
+    And I fill in the "survey-name" field with "Test Survey"
     And I set search filter to "form"
     And I click on the "search-btn" button
     And I use the form search to select "Test Form"

--- a/test/frontend/components/errors_test.js
+++ b/test/frontend/components/errors_test.js
@@ -16,7 +16,7 @@ describe('Errors', () => {
   });
 
   it('should display the correct number of errors', () => {
-    expect(component.find('h2')).to.contain('3 error(s) prohibited this form from being saved');
+    expect(component.find('h1')).to.contain('3 error(s) prohibited this form from being saved');
   });
 
   it('should an error message with the key and error', () => {

--- a/test/frontend/components/question_details_test.js
+++ b/test/frontend/components/question_details_test.js
@@ -12,7 +12,7 @@ describe('QuestionDetails', () => {
   });
 
   it('should display a question', () => {
-    expect(component.find("h3[class='panel-title']")).to.contain("Details");
+    expect(component.find("h1[class='panel-title']")).to.contain("Details");
   });
 
 });

--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -8,11 +8,12 @@ export default class CodedSetTable extends Component {
     }
     return (
       <table className="table table-striped">
+        <caption>Information about associated {this.props.itemName}s:</caption>
         <thead>
           <tr>
-            <th>{this.props.itemName} Code</th>
-            <th>Code System</th>
-            <th>Display Name</th>
+            <th scope="col">{this.props.itemName} Code</th>
+            <th scope="col">Code System</th>
+            <th scope="col">Display Name</th>
           </tr>
         </thead>
         <tbody>

--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -4,7 +4,7 @@ export default class CodedSetTable extends Component {
 
   render() {
     if(!this.props.items || this.props.items.length < 1){
-      return (<h3>No {this.props.itemName}s Selected</h3>);
+      return (<strong>No {this.props.itemName}s Selected</strong>);
     }
     return (
       <table className="table table-striped">

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -56,7 +56,7 @@ class DashboardSearch extends Component {
     } else {
       return (
         <div className="form-group">
-          <label>Select Programs:</label>
+          <label htmlFor="select-prog">Select Programs:</label>
           <select multiple className="form-control" id="select-prog" value={this.state.progFilters} onChange={(e) => this.selectFilters(e, 'progFilters')}>
             {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
               return <option key={sp.id} value={sp.id}>{sp.name}</option>;
@@ -73,7 +73,7 @@ class DashboardSearch extends Component {
     } else {
       return (
         <div className="form-group">
-          <label>Select Systems:</label>
+          <label htmlFor="select-sys">Select Systems:</label>
           <select multiple className="form-control" id="select-sys" value={this.state.sysFilters} onChange={(e) => this.selectFilters(e, 'sysFilters')}>
             {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
               return <option key={ss.id} value={ss.id}>{ss.name}</option>;
@@ -131,8 +131,7 @@ class DashboardSearch extends Component {
       <div className="row">
         <div className="col-md-12">
           <div className="input-group search-group">
-            <label htmlFor="search" className="hidden">Search</label>
-            <input onChange={this.onInputChange} type="text" id="search" name="search" className="search-input" placeholder="Search..."/>
+            <input onChange={this.onInputChange} type="text" id="search" name="search" aria-label="search-bar" className="search-input" placeholder="Search..."/>
             <span className="input-group-btn">
               <button id="search-btn" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
             </span>

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -5,7 +5,7 @@ export default class Errors extends Component {
     if (_.keys(this.props.errors).length > 0) {
       return (
         <div id="error_explanation">
-          <h2>{this.errorCount()} error(s) prohibited this form from being saved:</h2>
+          <h1 aria-live="assertive">{this.errorCount()} error(s) prohibited this form from being saved:</h1>
           <ul>
           {_.map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
           </ul>

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -5,7 +5,7 @@ export default class Errors extends Component {
     if (_.keys(this.props.errors).length > 0) {
       return (
         <div id="error_explanation">
-          <h1 aria-live="assertive">{this.errorCount()} error(s) prohibited this form from being saved:</h1>
+          <h1>{this.errorCount()} error(s) prohibited this form from being saved:</h1>
           <ul>
           {_.map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
           </ul>

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -268,14 +268,14 @@ class FormEdit extends Component {
           <div className="col-md-12">
             <div className="row">
               <div className="form-group col-md-12">
-                <label htmlFor="form name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="form name" id="form name" onChange={this.handleChange('name')}/>
+                <label htmlFor="form-name" hidden>Name</label>
+                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="form-name" id="form-name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="form-group col-md-8">
-                <label htmlFor="form description">Description</label>
-                <input className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="form description" id="form description" onChange={this.handleChange('description')}/>
+                <label htmlFor="form-description">Description</label>
+                <input className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="form-description" id="form-description" onChange={this.handleChange('description')}/>
               </div>
               <div className="form-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -254,7 +254,7 @@ class FormEdit extends Component {
       <form onSubmit={(e) => this.handleSubmit(e)}>
         <Errors errors={this.state.errors} />
           <div className="form-inline">
-            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span></button>
+            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
             <input  className='btn btn-default pull-right' name="Save Form" type="submit" value={`Save`}/>
             <button className="btn btn-default pull-right" disabled>Export</button>
             {this.cancelButton()}
@@ -268,14 +268,14 @@ class FormEdit extends Component {
           <div className="col-md-12">
             <div className="row">
               <div className="form-group col-md-12">
-                <label htmlFor="name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="name" id="name" onChange={this.handleChange('name')}/>
+                <label htmlFor="form name" hidden>Name</label>
+                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="form name" id="form name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="form-group col-md-8">
-                <label htmlFor="description">Description</label>
-                <input className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="description" id="description" onChange={this.handleChange('description')}/>
+                <label htmlFor="form description">Description</label>
+                <input className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="form description" id="form description" onChange={this.handleChange('description')}/>
               </div>
               <div className="form-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -90,11 +90,11 @@ class FormShow extends Component {
           }
         </div>
         <div className="maincontent-details">
-          <h3 className="maincontent-item-name"><strong>Name:</strong> {form.name} </h3>
+          <h1 className="maincontent-item-name"><strong>Name:</strong> {form.name} </h1>
           <p className="maincontent-item-info">Version: {form.version} - Author: {form.userId} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">Description</h3>
+              <h1 className="panel-title">Description</h1>
             </div>
             <div className="box-content">
               {form.description}

--- a/webpack/components/ModalDialog.js
+++ b/webpack/components/ModalDialog.js
@@ -17,7 +17,7 @@ class ModalDialog extends Component{
             <Modal.Title>{this.props.warning && <span className={'fa fa-exclamation-circle'}></span>} {this.props.title}</Modal.Title>
           </Modal.Header>
           <Modal.Body>
-            {this.props.subTitle && <h4 style={{fontWeight: 'bold'}}>{this.props.subTitle}</h4>}
+            {this.props.subTitle && <h1 style={{fontWeight: 'bold'}}>{this.props.subTitle}</h1>}
             {this.props.message}
           </Modal.Body>
           <br/>

--- a/webpack/components/NestedSearchBar.js
+++ b/webpack/components/NestedSearchBar.js
@@ -13,6 +13,7 @@ class NestedSearchBar extends Component {
             className="input-format"
             placeholder={`Search ${this.props.modelName}s...`}
             value={this.state.term}
+            aria-label={`Search ${this.props.modelName}s`}
             onChange={event => this.onInputChange(event.target.value)}
             onKeyPress={event => this.onEnter(event)} />
       </div>

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -37,35 +37,6 @@ export default class QuestionDetails extends Component {
     );
   }
 
-  conceptTable(concepts){
-    if(!concepts || concepts.length < 1){
-      return (<h1>No Responses Selected</h1>);
-    }else{
-      return (
-        <table className="table table-striped">
-          <thead>
-            <tr>
-              <th>Response Code</th>
-              <th>Code System</th>
-              <th>Display Name</th>
-            </tr>
-          </thead>
-          <tbody>
-            { concepts.map((concept) => {
-              return (
-                <tr key={"concept_" + concept.id}>
-                  <td>{ concept.value }</td>
-                  <td>{ concept.codeSystem }</td>
-                  <td>{ concept.displayName }</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      );
-    }
-  }
-
   reviseQuestionButton(){
     if(this.props.currentUser && this.props.currentUser.id && this.props.question && this.props.question.mostRecent == this.props.question.version){
       if(this.props.question.status && this.props.question.status == 'draft'){

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -92,11 +92,11 @@ export default class QuestionDetails extends Component {
           </div>
         }
         <div className="maincontent-details">
-          <h3 className="maincontent-item-name"><strong>Name:</strong> {question.content} </h3>
+          <h1 className="maincontent-item-name"><strong>Name:</strong> {question.content} </h1>
           <p className="maincontent-item-info">Version: {question.version} - Author: {question.createdBy && question.createdBy.email} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">Details</h3>
+              <h1 className="panel-title">Details</h1>
             </div>
             <div className="box-content">
               <strong>Description: </strong>
@@ -133,7 +133,7 @@ export default class QuestionDetails extends Component {
           </div>
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h3 className="panel-title">Tags</h3>
+                <h1 className="panel-title">Tags</h1>
               </div>
               <div className="box-content">
                 <div id="concepts-table">
@@ -144,7 +144,7 @@ export default class QuestionDetails extends Component {
           {responseSets && responseSets.length > 0 &&
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h3 className="panel-title">Linked Response Sets</h3>
+                <h1 className="panel-title">Linked Response Sets</h1>
               </div>
               <div className="box-content">
                 <ResponseSetList responseSets={_.keyBy(responseSets, 'id')} />

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -147,7 +147,7 @@ class QuestionForm extends Component{
           <div>
             <div className="panel panel-default">
               <div className="panel-heading">
-                <h3 className="panel-title">{`${this.actionWord()} Question`}</h3>
+                <h1 className="panel-title">{`${this.actionWord()} Question`}</h1>
               </div>
               <div className="panel-body">
                 <div className="row">
@@ -185,7 +185,7 @@ class QuestionForm extends Component{
                 {this.otherAllowedBox()}
                 <div className="row ">
                   <div className="col-md-12 ">
-                    <label className="input-label" htmlFor="concept_id">Tags</label>
+                    <h1 className="tags-table-header"><strong>Tags</strong></h1>
                     <CodedSetTableEditContainer itemWatcher={(r) => this.handleConceptsChange(r)}
                              initialItems={this.state.conceptsAttributes}
                              parentName={'question'}

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -168,8 +168,8 @@ class QuestionForm extends Component{
 
                 <div className="row ">
                   <div className="col-md-8 question-form-group">
-                    <label className="input-label" htmlFor="question description">Description</label>
-                    <textarea className="input-format" placeholder="Question description" type="text" name="question description" id="question description" defaultValue={state.description} onChange={this.handleChange('description')} />
+                    <label className="input-label" htmlFor="question-description">Description</label>
+                    <textarea className="input-format" placeholder="Question description" type="text" name="question-description" id="question-description" defaultValue={state.description} onChange={this.handleChange('description')} />
                   </div>
 
                 <div className="col-md-4 question-form-group">

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -198,7 +198,7 @@ class QuestionForm extends Component{
                     <label htmlFor="linked_response_sets">Response Sets</label>
                   </div>
                   <div className="col-md-6 response-set-label">
-                    <label htmlFor="selected_response_sets">Selected Response Sets</label>
+                    <h2>Selected Response Sets</h2>
                     <button className="btn btn-primary add-new-response-set" type="button" id="add-new-response-set" onClick={() => this.setState({showResponseSetModal:true})}>Add New Response Set</button>
                   </div>
                 </div>

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -168,8 +168,8 @@ class QuestionForm extends Component{
 
                 <div className="row ">
                   <div className="col-md-8 question-form-group">
-                    <label className="input-label" htmlFor="description">Description</label>
-                    <textarea className="input-format" placeholder="Question description" type="text" name="question_description" id="description" defaultValue={state.description} onChange={this.handleChange('description')} />
+                    <label className="input-label" htmlFor="question description">Description</label>
+                    <textarea className="input-format" placeholder="Question description" type="text" name="question description" id="question description" defaultValue={state.description} onChange={this.handleChange('description')} />
                   </div>
 
                 <div className="col-md-4 question-form-group">

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -93,11 +93,11 @@ export default class ResponseSetDetails extends Component {
           </div>
         }
         <div className="maincontent-details">
-          <h3 className="maincontent-item-name"><strong>Name:</strong> {responseSet.name} </h3>
+          <h1 className="maincontent-item-name"><strong>Name:</strong> {responseSet.name} </h1>
           <p className="maincontent-item-info">Version: {responseSet.version} - Author: {responseSet.createdBy && responseSet.createdBy.email} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">Details</h3>
+              <h1 className="panel-title">Details</h1>
             </div>
             <div className="box-content">
               <strong>Description: </strong>
@@ -122,7 +122,7 @@ export default class ResponseSetDetails extends Component {
           </div>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">Responses</h3>
+              <h1 className="panel-title">Responses</h1>
             </div>
             <div className="box-content">
             <CodedSetTable items={responseSet.responses} itemName={'Response'} />
@@ -131,7 +131,7 @@ export default class ResponseSetDetails extends Component {
           {this.props.questions && this.props.questions.length > 0 &&
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h3 className="panel-title">Linked Questions</h3>
+                <h1 className="panel-title">Linked Questions</h1>
               </div>
               <div className="box-content">
                 <QuestionList questions={_.keyBy(this.props.questions, 'id')} routes={Routes} />

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -140,7 +140,7 @@ export default class ResponseSetForm extends Component {
         <div>
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">{`${this.actionWord()} Response Set`}</h3>
+              <h1 className="panel-title">{`${this.actionWord()} Response Set`}</h1>
             </div>
             <div className="panel-body">
                 <div className="row">
@@ -163,9 +163,9 @@ export default class ResponseSetForm extends Component {
 
                 <div className="row">
                   <div className="col-md-12">
-                    <label className="input-label" >Responses</label>
-                    </div>
+                    <h1 className="tags-table-header"><strong>Responses</strong></h1>
                   </div>
+                </div>
                 <CodedSetTableEditContainer itemWatcher={(r) => this.handleResponsesChange(r)}
                                    initialItems={this.state.responsesAttributes}
                                    parentName={'response_set'}

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -145,8 +145,8 @@ export default class ResponseSetForm extends Component {
             <div className="panel-body">
                 <div className="row">
                   <div className="col-md-8 question-form-group">
-                    <label className="input-label" htmlFor="response set name">Name</label>
-                    <input className="input-format" type="text" value={this.state.name} name="response set name" id="response set name" onChange={this.handleChange('name')}/>
+                    <label className="input-label" htmlFor="response-set-name">Name</label>
+                    <input className="input-format" type="text" value={this.state.name} name="response-set-name" id="response-set-name" onChange={this.handleChange('name')}/>
                   </div>
 
                   <div className="hidden">
@@ -156,8 +156,8 @@ export default class ResponseSetForm extends Component {
 
                 <div className="row">
                 <div className="col-md-8 question-form-group">
-                    <label className="input-label"  htmlFor="response set description">Description</label>
-                    <textarea className="input-format"  value={this.state.description} name="response set description" id="response set description" onChange={this.handleChange('description')}/>
+                    <label className="input-label"  htmlFor="response-set-description">Description</label>
+                    <textarea className="input-format"  value={this.state.description} name="response-set-description" id="response-set-description" onChange={this.handleChange('description')}/>
                   </div>
                 </div>
 

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -145,8 +145,8 @@ export default class ResponseSetForm extends Component {
             <div className="panel-body">
                 <div className="row">
                   <div className="col-md-8 question-form-group">
-                    <label className="input-label" htmlFor="name">Name</label>
-                    <input className="input-format" type="text" value={this.state.name} name="response_set_name" id="name" onChange={this.handleChange('name')}/>
+                    <label className="input-label" htmlFor="response set name">Name</label>
+                    <input className="input-format" type="text" value={this.state.name} name="response set name" id="response set name" onChange={this.handleChange('name')}/>
                   </div>
 
                   <div className="hidden">
@@ -156,8 +156,8 @@ export default class ResponseSetForm extends Component {
 
                 <div className="row">
                 <div className="col-md-8 question-form-group">
-                    <label className="input-label"  htmlFor="description">Description</label>
-                    <textarea className="input-format"  value={this.state.description} name="description" id="description" onChange={this.handleChange('description')}/>
+                    <label className="input-label"  htmlFor="response set description">Description</label>
+                    <textarea className="input-format"  value={this.state.description} name="response set description" id="response set description" onChange={this.handleChange('description')}/>
                   </div>
                 </div>
 

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -40,7 +40,7 @@ export default class SearchResult extends Component {
     return (
       <ul className="dropdown-menu dropdown-menu-right">
         {originalType === 'form_question' && <li>
-          <a title="Modify Program Variable" href="#" onClick={this.props.showProgramVarModal}>Modify Program Variable</a>
+          <a title="Modify Program Variable Value" href="#" onClick={this.props.showProgramVarModal}>Modify Program Variable</a>
         </li>}
         {this.isRevisable(result) && <li>
           <Link to={`/${type}s/${result.id}/revise`}>Revise</Link>
@@ -161,7 +161,7 @@ export default class SearchResult extends Component {
               })}
               <option aria-label=' '></option>
             </select>
-            <a title="Search Response Sets" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
+            <a title="Search Response Sets to Link" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
             </div>
           </div>
         );

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -118,7 +118,7 @@ export default class SearchResult extends Component {
       <a title="Select Search Result" href="#" id={`select-${result.name}`} onClick={(e) => {
         e.preventDefault();
         handleSelectSearchResult(result);
-      }}><i className="fa fa-plus-square fa-2x"></i></a>
+      }}><i className="fa fa-plus-square fa-2x"></i><span className="sr-only">Add or Select Result</span></a>
     );
   }
 
@@ -161,7 +161,7 @@ export default class SearchResult extends Component {
               })}
               <option aria-label=' '></option>
             </select>
-            <a title="Search Response Sets" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i></a>
+            <a title="Search Response Sets" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
             </div>
           </div>
         );
@@ -283,14 +283,14 @@ export default class SearchResult extends Component {
                 </div>
               </li>
               <li className="u-result-content-item result-nav" role="navigation" aria-label="Search Result">
-                <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i></Link></div>
+                <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i><span className="sr-only">View Item Details</span></Link></div>
                 <div className="result-nav-item">
                   {handleSelectSearchResult ? (
                     this.selectResultButton(result, handleSelectSearchResult)
                   ) : (
                     <div className="dropdown">
                       <a id={`${type}_${result.id}_menu`} className="dropdown-toggle" type="" data-toggle="dropdown">
-                        <span className="fa fa-ellipsis-h"></span>
+                        <span className="fa fa-ellipsis-h" aria-hidden="true"></span>
                       </a>
                       {this.resultDropdownMenu(result, type, actionName, action)}
                     </div>

--- a/webpack/components/SearchResultList.js
+++ b/webpack/components/SearchResultList.js
@@ -7,8 +7,8 @@ export default class SearchResultList extends Component {
     return (
       <div className="search-result-list">
         {this.props.searchResults.hits &&
-          <row className="search-result-heading">
-            <div>Search Results ({this.props.searchResults.hits && this.props.searchResults.hits.total && this.props.searchResults.hits.total})</div>
+          <row>
+            <h1 className="search-result-heading">Search Results ({this.props.searchResults.hits && this.props.searchResults.hits.total && this.props.searchResults.hits.total})</h1>
             <hr/>
           </row>
         }

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -169,7 +169,7 @@ class SurveyEdit extends Component {
       <form onSubmit={(e) => this.handleSubmit(e)}>
         <Errors errors={this.state.errors} />
           <div className="survey-inline">
-            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span></button>
+            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
             <input className='btn btn-default pull-right' name="Save Survey" type="submit" value={`Save`}/>
             {this.cancelButton()}
           </div>
@@ -182,14 +182,14 @@ class SurveyEdit extends Component {
           <div className="col-md-12">
             <div className="row">
               <div className="survey-group col-md-12">
-                <label htmlFor="name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="name" id="name" onChange={this.handleChange('name')}/>
+                <label htmlFor="survey name" hidden>Name</label>
+                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="survey name" id="survey name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="survey-group col-md-8">
-                <label htmlFor="description">Description</label>
-                <input className="input-format" type="text" value={this.state.description || ''} name="description" id="description" onChange={this.handleChange('description')}/>
+                <label htmlFor="survey description">Description</label>
+                <input className="input-format" type="text" value={this.state.description || ''} name="survey description" id="survey description" onChange={this.handleChange('description')}/>
               </div>
               <div className="survey-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -182,14 +182,14 @@ class SurveyEdit extends Component {
           <div className="col-md-12">
             <div className="row">
               <div className="survey-group col-md-12">
-                <label htmlFor="survey name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="survey name" id="survey name" onChange={this.handleChange('name')}/>
+                <label htmlFor="survey-name" hidden>Name</label>
+                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="survey-name" id="survey-name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="survey-group col-md-8">
-                <label htmlFor="survey description">Description</label>
-                <input className="input-format" type="text" value={this.state.description || ''} name="survey description" id="survey description" onChange={this.handleChange('description')}/>
+                <label htmlFor="survey-description">Description</label>
+                <input className="input-format" type="text" value={this.state.description || ''} name="survey-description" id="survey-description" onChange={this.handleChange('description')}/>
               </div>
               <div className="survey-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>

--- a/webpack/components/SurveyFormList.js
+++ b/webpack/components/SurveyFormList.js
@@ -20,7 +20,7 @@ class SurveyFormList extends Component {
               return (
               <div  key={i} className="basic-c-box panel-default survey-form" id={`form_id_${f.id}`}>
                 <div className="panel-heading">
-                  <h3 className="panel-title">{f.name}</h3>
+                  <h1 className="panel-title">{f.name}</h1>
                   <div className='form-group-controls'>
                     <div className="btn btn-small btn-default move-up"
                          onClick={() => this.props.reorderForm(survey, i, 1)}>

--- a/webpack/components/shared_show/ProgramsAndSystems.js
+++ b/webpack/components/shared_show/ProgramsAndSystems.js
@@ -5,7 +5,7 @@ class ProgramsAndSystems extends Component {
   render() {
     return (<div className="basic-c-box panel-default">
       <div className="panel-heading">
-        <h3 className="panel-title">Usage</h3>
+        <h1 className="panel-title">Usage</h1>
       </div>
       <div className="box-content">
         <strong>Surveillance Programs: </strong> {this.surveillancePrograms(this.props.item)}

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -66,13 +66,13 @@ class SurveyShow extends Component{
           <button className="btn btn-default" onClick={() => window.print()}>Print</button>
         </div>
         <div className="maincontent-details">
-          <h3 className="maincontent-item-name"><strong>Name:</strong> {this.props.survey.name} </h3>
+          <h1 className="maincontent-item-name"><strong>Name:</strong> {this.props.survey.name} </h1>
           <p className="maincontent-item-info">Version: {this.props.survey.version} - Author: {this.props.survey.userId} </p>
           {this.surveillanceProgram()}
           {this.surveillanceSystem()}
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">Description</h3>
+              <h1 className="panel-title">Description</h1>
             </div>
             <div className="box-content">
               {this.props.survey.description}
@@ -93,7 +93,7 @@ class SurveyShow extends Component{
           {this.props.forms.map((f,i ) =>
             <div  key={i} className="basic-c-box panel-default survey-form">
               <div className="panel-heading">
-                <h3 className="panel-title">{f.name}</h3>
+                <h1 className="panel-title">{f.name}</h1>
               </div>
               <div className="box-content">
                 <ul>

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -145,10 +145,12 @@ class CodedSetTableEditContainer extends Component {
                 title={this.state.selectedSystem ? this.state.selectedSystem : 'Code System'} onSelect={(key, e) => this.searchConcepts(e.target.text)} >
                 <MenuItem key={0} value={''}>None</MenuItem>
                 {_.values(this.props.conceptSystems).map((s, i) => {
-                  return <MenuItem key={i} value={s.name}>{s.name}</MenuItem>;
+                  if(s.name) {
+                    return <MenuItem key={i} value={s.name}>{s.name}</MenuItem>;
+                  }
                 })}
               </DropdownButton>
-              <FormControl type="text" onChange={(e) => this.handleSearchChange(e)} placeholder="Search Codes"/>
+              <FormControl type="text" onChange={(e) => this.handleSearchChange(e)} placeholder="Search Codes" aria-label="Search Codes"/>
               <FormControl.Feedback>
                 <Glyphicon glyph="search"/>
               </FormControl.Feedback>
@@ -184,7 +186,7 @@ class CodedSetTableEditContainer extends Component {
               <a title="Search Codes" href="#" onClick={(e) => {
                 e.preventDefault();
                 this.showCodeSearch();
-              }}><i className="fa fa-search fa-2x"></i></a>
+              }}><i className="fa fa-search fa-2x"></i><span className="sr-only">Open Search Modal</span></a>
             </th>
             <th>{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
             <th>Code System</th>
@@ -193,7 +195,7 @@ class CodedSetTableEditContainer extends Component {
               <a title="Add Row" href="#" onClick={(e) => {
                 e.preventDefault();
                 this.addItemRow();
-              }}><i className="fa fa-plus fa-2x"></i></a>
+              }}><i className="fa fa-plus fa-2x"></i><span className="sr-only">Add a row to the table</span></a>
             </th>
           </tr>
         </thead>
@@ -223,7 +225,7 @@ class CodedSetTableEditContainer extends Component {
                   <a href="#" title="Remove" id={`remove_${i}`} onClick={(e) => {
                     e.preventDefault();
                     this.removeItemRow(i);
-                  }}><i className="fa fa-2x fa-trash"></i></a>
+                  }}><i className="fa fa-2x fa-trash"></i><span className="sr-only">Delete this row</span></a>
                 </td>
               </tr>
             );

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -222,8 +222,7 @@ class CodedSetTableEditContainer extends Component {
                   <input className="input-format" type="text" value={r.displayName} name="displayName" id={`displayName_${i}`} onChange={this.handleChange(i, 'displayName')}/>
                 </td>
                 <td>
-                  <label className="hidden" htmlFor={`remove_${i}`}>Remove</label>
-                  <a href="#" title="Remove" id={`remove_${i}`} onClick={(e) => {
+                  <a href="#" title="Remove" aria-label={`remove_row_number_${i}`} id={`remove_${i}`} onClick={(e) => {
                     e.preventDefault();
                     this.removeItemRow(i);
                   }}><i className="fa fa-2x fa-trash"></i><span className="sr-only">Delete this row</span></a>

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -159,10 +159,10 @@ class CodedSetTableEditContainer extends Component {
           <table className="table table-striped scroll-table-header">
             <thead>
               <tr>
-                <th style={{width: '9%', paddingRight:' 0px', paddingBottom: '0px'}}>Add</th>
-                <th style={{width: '50%', padding:' 0px'}}>Display Name</th>
-                <th style={{width: '10%', padding:' 0px'}}>Code</th>
-                <th style={{width: '30%', padding:' 0px'}}>Code System</th>
+                <th scope="col" style={{width: '9%', paddingRight:' 0px', paddingBottom: '0px'}}>Add</th>
+                <th scope="col" style={{width: '50%', padding:' 0px'}}>Display Name</th>
+                <th scope="col" style={{width: '10%', padding:' 0px'}}>Code</th>
+                <th scope="col" style={{width: '30%', padding:' 0px'}}>Code System</th>
               </tr>
             </thead>
           </table>
@@ -179,19 +179,20 @@ class CodedSetTableEditContainer extends Component {
   render() {
     return (
       <table className="set-table">
+        <caption>Add, search, and create associated {this.state.childName[0].toUpperCase() + this.state.childName.slice(1)}s:</caption>
         {this.conceptModal()}
         <thead>
           <tr>
-            <th>
+            <th scope="col">
               <a title="Search Codes" href="#" onClick={(e) => {
                 e.preventDefault();
                 this.showCodeSearch();
               }}><i className="fa fa-search fa-2x"></i><span className="sr-only">Open Search Modal</span></a>
             </th>
-            <th>{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
-            <th>Code System</th>
-            <th>Display Name</th>
-            <th>
+            <th scope="col">{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
+            <th scope="col">Code System</th>
+            <th scope="col">Display Name</th>
+            <th scope="col">
               <a title="Add Row" href="#" onClick={(e) => {
                 e.preventDefault();
                 this.addItemRow();

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -140,7 +140,7 @@ class DashboardContainer extends Component {
                     <div className="col-md-8">
                       <div className="cdc-promo-banner">
                         <h1 className="banner-title">CDC Vocabulary Service</h1>
-                        <h3>Author Questions, Response Sets, and Forms</h3>
+                        <h2 className="banner-subtitle">Author Questions, Response Sets, Forms, and Surveys</h2>
                         <p className="lead">The Vocabulary Service allows users to author their own questions and response sets, and to reuse others’ wording for their new data collection needs when applicable. A goal of this service is to increase consistency by reducing the number of different ways that CDC asks for similar information, lowering the reporting burden on partners.</p>
                         <p><a className="btn btn-lg btn-success" href="#" role="button" onClick={this.openSignUpModal}>Get Started!</a></p>
                       </div>

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -125,7 +125,7 @@ class FormsEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">{_.capitalize(this.props.params.action)} Form </h3>
+              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Form </h1>
             </div>
             <div className="panel-body">
               <div className="col-md-5">

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -49,11 +49,11 @@ class Help extends Component {
         <li><a href="#logging-in">Logging In</a></li>
         <li><a href="#logging-out">Logging Out</a></li>
         </ul>
-        <h3 id="sign-up">Sign Up</h3>
+        <h2 className="help-section-subtitle" id="sign-up">Sign Up</h2>
         <p>When you navigate to the page and you have not yet logged in there will be a sign up button at the top right corner of the screen. You can also click the &quot;Get Started!&quot; button on the landing page banner. A window will pop up asking for your information. Fill out as much information as possible and save. You should now see your e-mail with a gear icon in the navigation bar in the top right.</p>
-        <h3 id="logging-in">Logging In</h3>
+        <h2 className="help-section-subtitle" id="logging-in">Logging In</h2>
         <p>If you already have an account simply click the log-in link in the blue navigation bar in the top right of the screen. If you do not see a log-in button the browser may be logged in from a previous session. In that case see how to log out below.</p>
-        <h3 id="logging-out">Logging Out</h3>
+        <h2 className="help-section-subtitle" id="logging-out">Logging Out</h2>
         <p>On any page you should be able to log-out by first clicking the e-mail in the top-right corner of the navigation bar, then selecting log-out from the drop-down menu that will appear. The page should refresh automatically.</p>
       </div>
     );
@@ -70,13 +70,13 @@ class Help extends Component {
         <li><a href="#see-content-you-own">See content you own</a></li>
         <li><a href="#advanced-filtering">Advanced filtering</a></li>
         </ul>
-        <h3 id="basic-search">Basic Search</h3>
+        <h2 className="help-section-subtitle" id="basic-search">Basic Search</h2>
         <p>On the dashboard there is a search bar that can be used to find questions, response sets, forms, and surveys. Typing in search terms that might be found in the name, description, author e-mail, and various other relevant fields on the items.</p>
-        <h3 id="filtering-by-type">Filtering by Type</h3>
+        <h2 className="help-section-subtitle" id="filtering-by-type">Filtering by Type</h2>
         <p>You can filter a search by the type of content by clicking on the analytics icons immediately below the search bar on the dashboard page. Clicking on any of those four squares on the top of the page will filter by the type specified in the square and highlight the square. Once a filter is applied you can click on the &#39;clear filter&#39; link that will appear under the icons on the dashboard.</p>
-        <h3 id="see-content-you-own">See Content You Own</h3>
+        <h2 className="help-section-subtitle" id="see-content-you-own">See Content You Own</h2>
         <p>Similar to searching by type (described above) when you are logged in to an account the dashboard will have a &quot;My Stuff&quot; section displayed on the right side of the dashboard. Clicking on any of the icons or the filter link in that panel will highlight the filter applied in blue and filter any searches done to only return drafts and published content that you own.</p>
-        <h3 id="advanced-filtering">Advanced Filtering</h3>
+        <h2 className="help-section-subtitle" id="advanced-filtering">Advanced Filtering</h2>
         <p>Under the search bars seen across the app there is an &#39;Advanced&#39; link. If you click that link it will pop up a window with additional filters that you can apply. Any filters you select will limit your searches by the selected filters. The window also has a clear filters buttons that will reset back to the default search.</p>
         <p>If a warning symbol appears next to the Advanced link or you see an error message in the advanced search pop-up, the advanced search server (Elasticsearch) is likely down. Please check back later or contact your system administrator if the issue is persistent.</p>
       </div>
@@ -109,27 +109,27 @@ class Help extends Component {
         <li><a href="#revise-content">Revise Content</a></li>
         <li><a href="#extend-content">Extend Content</a></li>
         </ul>
-        <h3 id="create-new-content">Create New Content</h3>
+        <h2 className="help-section-subtitle" id="create-new-content">Create New Content</h2>
         <ul>
         <li>To start a new draft of any item click on the &quot;Create&quot; drop down in the top navigation bar on the dashboard.</li>
         <li>On the creation / editing page change any fields that need to be updated and press save - this saves a draft of the first version of the new item that will need to get published by a publisher before it will be visible to others.</li>
         <li>If you try to navigate away before saving the changes a prompt will ask if you want to navigate away without saving or save before you leave.</li>
         </ul>
-        <h3 id="edit-content">Edit Content</h3>
+        <h2 className="help-section-subtitle" id="edit-content">Edit Content</h2>
         <p><strong>Note:</strong> You can only edit your own draft content - once content is published you will be given the option to create a new revision of the content.</p>
         <ul>
         <li>When looking at the search result for the item you want to edit click on the menu button in the bottom right and select edit.</li>
         <li>When on the details page of an item the edit or revise button should appear in the top right above the item information.</li>
         <li>On the edit page change any fields that need to be updated and press save - this overwrites the previous draft with the changes made and does not keep a history of the previous draft.</li>
         </ul>
-        <h3 id="revise-content">Revise Content</h3>
+        <h2 className="help-section-subtitle" id="revise-content">Revise Content</h2>
         <p><strong>Note:</strong> You can only revise your own published content. Saving a revision will save a draft of that revision until you publish the new version.</p>
         <ul>
         <li>When looking at the search result for the item you want to revise click on the menu button in the bottom right and select revise</li>
         <li>When on the details page of an item the edit or revise button should appear in the top right above the item information</li>
         <li>On the revision editing page change any fields that need to be updated and press save - this saves a draft of the new version that will need to get published by a publisher before it will be visible to others.</li>
         </ul>
-        <h3 id="extend-content">Extend Content</h3>
+        <h2 className="help-section-subtitle" id="extend-content">Extend Content</h2>
         <p><strong>Note:</strong> You can only extend published content. Unlike revising, you do not need to be the original author of something to extend it (use it as a template with its own version history). Saving an extension will save a draft that is the first version (new revision history) with a link to the content it was extended from.</p>
         <ul>
         <li>When looking at the search result for the item you want to revise click on the menu button in the bottom right and select revise</li>

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -228,7 +228,7 @@ class Help extends Component {
                     <li className="nav-item">
                       <a className="nav-link" data-toggle="tab" href="#glossary" role="tab">Glossary</a>
                     </li>
-                    <li className="nav-item disabled">
+                    <li className="nav-item">
                       <a className="nav-link" data-toggle="tab" href="#faq" role="tab">FAQs</a>
                     </li>
                   </ul>

--- a/webpack/containers/QuestionModalContainer.js
+++ b/webpack/containers/QuestionModalContainer.js
@@ -69,7 +69,7 @@ class QuestionModalContainer extends Component {
               <label htmlFor="linked_response_sets">Response Sets</label>
             </div>
             <div className="col-md-6 response-set-label">
-              <label htmlFor="selected_response_sets">Selected Response Sets</label>
+              <h2 className="tags-table-header">Selected Response Sets</h2>
             </div>
           </div>
           <ResponseSetDragWidget responseSets={this.props.responseSets}

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -94,7 +94,7 @@ class SurveyEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h3 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h3>
+              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h1>
             </div>
             <div className="panel-body">
               <div className="col-md-5">

--- a/webpack/styles/base/_colors.scss
+++ b/webpack/styles/base/_colors.scss
@@ -6,7 +6,7 @@ $cdc-orange: #EA5B0C;
 
 $very-light-gray: #FBFBFC;
 $light-gray: #e4e4e4;
-$medium-gray: #9D9D9C;
+$medium-gray: #535351;
 $dark-gray: #575756;
 
 $dark-bluegray: #283542;

--- a/webpack/styles/layouts/_cdcjumbotron.scss
+++ b/webpack/styles/layouts/_cdcjumbotron.scss
@@ -11,6 +11,9 @@
     background: url(../images/CDC_Landing_Page3.png)$cdc-blue left calc(50% - -310px) top no-repeat;
     background-size: auto 100%;
     border-bottom: 2px solid $cdc-dark-blue;
+    .banner-subtitle {
+      font-size: 24px;
+    }
   }
 }
 

--- a/webpack/styles/layouts/_footer.scss
+++ b/webpack/styles/layouts/_footer.scss
@@ -5,4 +5,11 @@
   background-color: $cdc-dark-blue;
   text-align: center;
   color: white;
+  padding-top: 10px;
+  a {
+    color: white;
+    margin-right: 5px;
+    margin-left: 5px;
+    text-decoration: underline;
+  }
 }

--- a/webpack/styles/layouts/_help.scss
+++ b/webpack/styles/layouts/_help.scss
@@ -16,6 +16,10 @@
   margin-bottom: 32px;
 }
 
+.help-section-subtitle {
+  font-size: 24px;
+}
+
 .how-to-nav {
   padding: 0 !important;
   margin-top: 10px;

--- a/webpack/styles/layouts/_maincontentarea.scss
+++ b/webpack/styles/layouts/_maincontentarea.scss
@@ -10,6 +10,7 @@
 
 .maincontent-item-name {
   margin-top: 0px;
+  font-size: 24px;
   color: $cdc-blue;
 }
 

--- a/webpack/styles/layouts/_panels.scss
+++ b/webpack/styles/layouts/_panels.scss
@@ -33,6 +33,12 @@
   overflow-y: auto;
 }
 
+.tags-table-header {
+  margin-top: 0px;
+  margin-bottom: 5px;
+  font-size: 18px;
+}
+
 .my-stuff {
   .panel-body {
     max-height: 320px;

--- a/webpack/styles/layouts/_showpageheader.scss
+++ b/webpack/styles/layouts/_showpageheader.scss
@@ -1,7 +1,7 @@
 .showpage_header_container {
   border-bottom: 1px solid $light-gray;
   height: 58px;
-  padding-top: 8px;   
+  padding-top: 8px;
 }
 
 .showpage_title {
@@ -55,7 +55,7 @@
 }
 
 .subtitle {
-  color: gray;
+  color: $medium-gray;
   span {
     margin-left: 10px;
     margin-right: 6px;

--- a/webpack/styles/navigation/_nav.scss
+++ b/webpack/styles/navigation/_nav.scss
@@ -40,11 +40,11 @@ a.cdc-brand:focus {
     height: 50px;
   }
   .utlt-navbar-icon {
-    padding-right: 6px; 
+    padding-right: 6px;
   }
   span {
     margin-left: 6px;
-  } 
+  }
 }
 
 .cdc-nav-main {
@@ -120,4 +120,4 @@ a.cdc-brand:focus {
     overflow-y: auto;
     overflow-x: hidden;
   }
-} 
+}

--- a/webpack/styles/widgets/_questions.scss
+++ b/webpack/styles/widgets/_questions.scss
@@ -8,6 +8,13 @@
   text-align: left;
   vertical-align: middle;
   margin-bottom: 0px;
+  h2 {
+    padding-top: 7px;
+    margin-top: 0px;
+    margin-bottom: 5px;
+    font-size: 14px;
+    font-weight: bold;
+  }
   label{
     padding-top: 7px;
   }
@@ -35,12 +42,12 @@
     padding: 6px 8px 6px 10px;
     li:first-child {
       width: 95%;
-      float: left;    
+      float: left;
     }
   }
 
   .question {
-    @extend .panel; 
+    @extend .panel;
     border-radius: 0px;
     border: 1px solid $light-gray;
   }

--- a/webpack/styles/widgets/_searchresults.scss
+++ b/webpack/styles/widgets/_searchresults.scss
@@ -74,7 +74,7 @@
     display: table-cell;
     width: 10%;
     text-align: center;
-    color: $light-gray;
+    color: $medium-gray;
     vertical-align: top;
     padding-top: 6px;
   }


### PR DESCRIPTION
PR #255 needs to be merged first 

This PR should get the app to the state where wave is no longer throwing any errors and the only alerts left should be suspicious link text and broken same page link (which is just a fallout of using the react-redux-router).

This PR fixes the following 508 issues:
- [x] - headings structure (semantic structure except bootstrap modal)
- [x] - table captions
- [x] - table scope
- [x] - table association warnings
- [x] - orphaned form labels
- [x] - redundant title text

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
