### PR TITLE
[SDP-518,520] Displaying RS Source & Hiding Linked RS

### DIFF
--- a/app/serializers/es_question_serializer.rb
+++ b/app/serializers/es_question_serializer.rb
@@ -18,6 +18,7 @@ class ESQuestionSerializer < ActiveModel::Serializer
   attribute :forms
   attribute :surveillance_programs
   attribute :surveillance_systems
+  attribute :response_type
 
   def forms
     object.form_questions.collect do |fq|
@@ -27,6 +28,10 @@ class ESQuestionSerializer < ActiveModel::Serializer
 
   def codes
     object.concepts.collect { |c| CodeSerializer.new(c).as_json }
+  end
+
+  def response_type
+    { name: object.response_type.name, code: object.response_type.code } if object.response_type
   end
 
   def response_sets

--- a/app/views/response_sets/_response_set.json.jbuilder
+++ b/app/views/response_sets/_response_set.json.jbuilder
@@ -1,4 +1,4 @@
 json.extract! response_set, :id, :name, :description, :oid, :created_by, :created_by_id, :responses, \
               :status, :version, :all_versions, :most_recent, :version_independent_id, \
-              :questions, :created_at, :updated_at, :parent, :published_by
+              :questions, :created_at, :updated_at, :parent, :published_by, :source
 json.url response_set_url(response_set, format: :json)

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -76,6 +76,17 @@
         "updatedAt": {
           "type": "date"
         },
+        "responseType": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "code": {
+              "type": "string"
+            }
+          }
+        },
         "createdBy": {
           "type": "object",
           "properties": {

--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -126,6 +126,7 @@ Feature: Edit Forms
   Scenario: Create New Form from List and Create a Response Set using New Response Set Modal
     Given I have a Response Set with the name "Gender Full"
     And I have a Question with the content "What is your gender?" and the type "MC"
+    And I have a Question with the content "Do you like apples?" and the description "A simple boolean" and the response type "Boolean"
     And I am logged in as test_author@gmail.com
     When I go to the dashboard
     And I click on the create "Forms" dropdown item
@@ -135,6 +136,7 @@ Feature: Edit Forms
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
+    And I use the question search to select "Do you like apples?"
     And I use the question search to select "What is your gender?"
     Then I click on the "Add New Response Set" button
     Then I fill in the "response-set-name" field with "New Response Set"
@@ -144,6 +146,7 @@ Feature: Edit Forms
     And I click on the "Save" button
     Then I should see "Test Form"
     And I should see "What is your gender?"
+    And I should see "Response Type: Boolean"
 
   Scenario: Show warning modal after adding question
     Given I have a Response Set with the name "Gender Full"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -22,6 +22,7 @@ Feature: Manage Response Sets
     Then I should see "Name: Gender Full"
     And I should see "Response set description"
     And I should see "Original Response"
+    And I should see "Source: Local"
     And I should see "Surveillance Programs: 0"
     And I should see "Surveillance Systems: 1"
 

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -6,6 +6,12 @@ Given(/^I have a Question with the content "([^"]*)" and the description "([^"]*
                    concepts_attributes: [{ value: '', display_name: concept, code_system: '' }])
 end
 
+Given(/^I have a Question with the content "([^"]*)" and the description "([^"]*)" and the response type "([^"]*)"$/) do |content, description, type|
+  user  = get_user('test_author@gmail.com')
+  qt314 = ResponseType.find_or_create_by(name: type)
+  Question.create!(content: content, description: description, response_type_id: qt314.id, version: 1, created_by: user)
+end
+
 Given(/^I have a Question with the content "([^"]*)" and the description "([^"]*)" and the type "([^"]*)"$/) do |content, description, type|
   user  = get_user('test_author@gmail.com')
   qt314 = QuestionType.find_or_create_by(name: type)

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -113,6 +113,16 @@ export default class ResponseSetDetails extends Component {
                 <Link to={`/responseSets/${responseSet.parent.id}`}>{ responseSet.parent.name }</Link>
               </div>
             }
+            { responseSet.source &&
+              <div className="box-content">
+                <strong>Import / Source: </strong>
+                {responseSet.source === 'PHIN_VADS' ? (
+                  <a href="https://phinvads.cdc.gov">PHIN VADS</a>
+                ) : (
+                  <text>{responseSet.source[0].toUpperCase() + responseSet.source.slice(1)}</text>
+                )}
+              </div>
+            }
             { responseSet.status === 'published' && responseSet.publishedBy && responseSet.publishedBy.email &&
             <div className="box-content">
               <strong>Published By: </strong>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -122,16 +122,22 @@ export default class SearchResult extends Component {
     );
   }
 
+  questionCollapsable(result) {
+    if(result.responseType && result.responseType.name && result.responseType.name !== 'Choice' && result.responseType.name !== 'Open Choice') {
+      return (<li><i className="fa fa-comments" aria-hidden="true"></i>Response Type: {result.responseType.name}</li>);
+    } else if (result.responseSets && result.responseSets.length === 1) {
+      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Set</a></li>);
+    } else {
+      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>);
+    }
+  }
+
   linkedDetails(result, type){
     switch(type) {
       case 'question':
         return (
           <ul className="list-inline result-linked-number result-linked-item associated__responseset">
-            {result.responseSets && result.responseSets.length === 1 ? (
-              <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Set</a></li>
-            ) : (
-              <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>
-            )}
+            {this.questionCollapsable(result)}
           </ul>
         );
       case 'response_set':
@@ -147,24 +153,32 @@ export default class SearchResult extends Component {
           </ul>
         );
       case 'form_question':
-        var selectedResponseSet = this.props.responseSets.find((r) => r.id == this.props.selectedResponseSetId);
-        return (
-          <div className="panel-body panel-body-form-question">
-            <span className="selected-response-set">Response Set: {(selectedResponseSet && selectedResponseSet.name) || '(None)'}</span>
-            <div className="form-question-group">
-            <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.result.id}/>
-            <select className="response-set-select" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSetId || ''} onChange={this.props.handleResponseSetChange}>
-              {this.props.responseSets.length > 0 && this.props.responseSets.map((r, i) => {
-                return (
-                  <option value={r.id} key={`${r.id}-${i}`}>{r.name} </option>
-                );
-              })}
-              <option aria-label=' '></option>
-            </select>
-            <a title="Search Response Sets to Link" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
+        if(result.responseType && result.responseType.name && result.responseType.name !== 'Choice' && result.responseType.name !== 'Open Choice') {
+          return (
+            <ul className="list-inline result-linked-number result-linked-item associated__responseset">
+              <li><i className="fa fa-comments" aria-hidden="true"></i>Response Type: {result.responseType.name}</li>
+            </ul>
+          );
+        } else {
+          var selectedResponseSet = this.props.responseSets.find((r) => r.id == this.props.selectedResponseSetId);
+          return (
+            <div className="panel-body panel-body-form-question">
+              <span className="selected-response-set">Response Set: {(selectedResponseSet && selectedResponseSet.name) || '(None)'}</span>
+              <div className="form-question-group">
+                <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.result.id}/>
+                <select className="response-set-select" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSetId || ''} onChange={this.props.handleResponseSetChange}>
+                  {this.props.responseSets.length > 0 && this.props.responseSets.map((r, i) => {
+                    return (
+                      <option value={r.id} key={`${r.id}-${i}`}>{r.name} </option>
+                    );
+                  })}
+                  <option aria-label=' '></option>
+                </select>
+                <a title="Search Response Sets to Link" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
+              </div>
             </div>
-          </div>
-        );
+          );
+        }
       case 'survey':
         return (
           <ul className="list-inline result-linked-number result-linked-item associated__form">


### PR DESCRIPTION
Displaying Source on RS & Hiding Linked RS on non-choice Questions.

It now hides the Linked response set accordion on non-choice response-type questions and shows the response-type instead. It also shows this info instead of the response-set linkage logic on QuestionItems on the FormEdit page

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
