### PR TITLE
[SDP-522,524,536] Compliance navigation

### DIFF
--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -18,7 +18,7 @@ end
 When(/^I go to the list of Forms$/) do
   Elastictest.fake_form_search_results
   visit '/'
-  page.find('li[id="forms-analytics-item"]').click
+  page.find('button[id="forms-analytics-item"]').click
 end
 
 When(/^I click on the button to add the Question "([^"]*)"$/) do |question_content|

--- a/features/step_definitions/question_steps.rb
+++ b/features/step_definitions/question_steps.rb
@@ -54,7 +54,7 @@ end
 When(/^I go to the list of Questions$/) do
   Elastictest.fake_question_search_results
   visit '/'
-  page.find('li[id="questions-analytics-item"]').click
+  page.find('button[id="questions-analytics-item"]').click
 end
 
 Given(/^I have a published Question with the content "([^"]*)"$/) do |content|

--- a/features/step_definitions/response_set_steps.rb
+++ b/features/step_definitions/response_set_steps.rb
@@ -38,7 +38,7 @@ end
 When(/^I go to the list of Response Sets$/) do
   Elastictest.fake_rs_search_results
   visit '/'
-  page.find('li[id="response-sets-analytics-item"]').click
+  page.find('button[id="response-sets-analytics-item"]').click
 end
 
 Given(/^I have a Response Set with the name "([^"]*)"$/) do |set_name|

--- a/features/step_definitions/survey_steps.rb
+++ b/features/step_definitions/survey_steps.rb
@@ -23,7 +23,7 @@ end
 When(/^I go to the list of Surveys$/) do
   Elastictest.fake_survey_search_results
   visit '/'
-  page.find('li[id="surveys-analytics-item"]').click
+  page.find('button[id="surveys-analytics-item"]').click
 end
 
 When(/^I use the form search to select "([^"]*)"$/) do |name|

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -56,12 +56,13 @@ class App extends Component {
   render() {
     return (
       <div>
+        <a href="#main-content" className="sr-only sr-only-focusable">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 location={this.props.location}
                 logInOpener={() => this.openLogInModal()}
                 signUpOpener={() => this.openSignUpModal()}
                 settingsOpener={() => this.openSettingsModal()}/>
-        <div className='main-content'>
+        <div className='main-content' id="main-content">
           {this.props.children}
         </div>
         <footer className="footer">

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -264,29 +264,29 @@ class DashboardContainer extends Component {
         <li id="questions-analytics-item" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
           <div>
             <i className="fa fa-tasks fa-3x item-icon" aria-hidden="true"></i>
-            <p className="item-value">{this.props.questionCount}</p>
-            <h2 className="item-title">Questions</h2>
+            <p className="item-value" aria-describedby="question-analytics-item-title">{this.props.questionCount}</p>
+            <h2 className="item-title" id="question-analytics-item-title">Questions</h2>
           </div>
         </li>
         <li id="response-sets-analytics-item" className={"analytics-list-item btn" + (searchType === 'response_set' ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set')}>
           <div>
             <i className="fa fa-list fa-3x item-icon" aria-hidden="true"></i>
-            <p className="item-value">{this.props.responseSetCount}</p>
-            <h2 className="item-title">Response Sets</h2>
+            <p className="item-value" aria-describedby="response-sets-analytics-item-title">{this.props.responseSetCount}</p>
+            <h2 className="item-title" id="response-sets-analytics-item-title">Response Sets</h2>
           </div>
           </li>
         <li id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
           <div>
             <i className="fa fa-list-alt fa-3x item-icon" aria-hidden="true"></i>
-            <p className="item-value">{this.props.formCount}</p>
-            <h2 className="item-title">Forms</h2>
+            <p className="item-value" aria-describedby="forms-analytics-item-title">{this.props.formCount}</p>
+            <h2 className="item-title" id="forms-analytics-item-title">Forms</h2>
           </div>
           </li>
         <li id="surveys-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
           <div>
             <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
-            <p className="item-value">{this.props.surveyCount}</p>
-            <h2 className="item-title">Surveys</h2>
+            <p className="item-value" aria-describedby="surveys-analytics-item-title">{this.props.surveyCount}</p>
+            <h2 className="item-title" id="surveys-analytics-item-title">Surveys</h2>
           </div>
           </li>
       </ul>

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -261,34 +261,34 @@ class DashboardContainer extends Component {
     return (
     <div className="analytics-group" role="navigation" aria-label="Analytics">
       <ul className="analytics-list-group">
-        <li id="questions-analytics-item" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
+        <button id="questions-analytics-item" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
           <div>
             <i className="fa fa-tasks fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="question-analytics-item-title">{this.props.questionCount}</p>
             <h2 className="item-title" id="question-analytics-item-title">Questions</h2>
           </div>
-        </li>
-        <li id="response-sets-analytics-item" className={"analytics-list-item btn" + (searchType === 'response_set' ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set')}>
+        </button>
+        <button id="response-sets-analytics-item" className={"analytics-list-item btn" + (searchType === 'response_set' ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set')}>
           <div>
             <i className="fa fa-list fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="response-sets-analytics-item-title">{this.props.responseSetCount}</p>
             <h2 className="item-title" id="response-sets-analytics-item-title">Response Sets</h2>
           </div>
-          </li>
-        <li id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
+          </button>
+        <button id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
           <div>
             <i className="fa fa-list-alt fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="forms-analytics-item-title">{this.props.formCount}</p>
             <h2 className="item-title" id="forms-analytics-item-title">Forms</h2>
           </div>
-          </li>
-        <li id="surveys-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
+          </button>
+        <button id="surveys-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
           <div>
             <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="surveys-analytics-item-title">{this.props.surveyCount}</p>
             <h2 className="item-title" id="surveys-analytics-item-title">Surveys</h2>
           </div>
-          </li>
+          </button>
       </ul>
       {searchType != '' && <a href="#" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
     </div>);
@@ -300,22 +300,22 @@ class DashboardContainer extends Component {
         <div className="recent-items-heading">My Stuff</div>
         <div className="recent-items-body">
           <ul className="list-group">
-            <li className={"recent-item-list btn" + (searchType === 'question' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('question', true)}>
+            <button className={"recent-item-list btn" + (searchType === 'question' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('question', true)}>
               <div className="recent-items-icon"><i className="fa fa-tasks recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myQuestionCount} Questions</div>
-            </li>
-            <li className={"recent-item-list btn" + (searchType === 'response_set' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set', true)}>
+            </button>
+            <button className={"recent-item-list btn" + (searchType === 'response_set' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set', true)}>
               <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myResponseSetCount} Response Sets</div>
-            </li>
-            <li className={"recent-item-list btn" + (searchType === 'form' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('form', true)}>
+            </button>
+            <button className={"recent-item-list btn" + (searchType === 'form' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('form', true)}>
               <div className="recent-items-icon"><i className="fa fa-list-alt recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myFormCount} Forms</div>
-            </li>
-            <li className={"recent-item-list btn" + (searchType === 'survey' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('survey', true)}>
+            </button>
+            <button className={"recent-item-list btn" + (searchType === 'survey' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('survey', true)}>
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.mySurveyCount} Surveys</div>
-            </li>
+            </button>
             {myStuffFilter ? (<a href="#" className="col-md-12 text-center" onClick={() => this.selectType(searchType)}>Clear My Stuff Filter</a>) : (
               <a href="#" className="col-md-12 text-center" onClick={() => this.selectType(searchType, true)}>Filter by My Stuff</a>
             )}

--- a/webpack/styles/widgets/_analytics.scss
+++ b/webpack/styles/widgets/_analytics.scss
@@ -18,24 +18,25 @@
 
 .analytics-list-item {
   @extend .list-group-item;
-  display: table-cell;
-  width: 23%;
-  color: $cdc-blue;
-  border: none;
-  border-left: solid 1px $light-gray;
-  border-bottom: solid 1px $light-gray;
-  height: 150px;
+  display: table-cell !important;
+  width: 25% !important;
+  color: $cdc-blue !important;
+  text-align: center !important;
+  border: none !important;
+  border-left: solid 1px $light-gray !important;
+  border-bottom: solid 1px $light-gray !important;
+  height: 150px !important;
   &:first-child {
-    border-left: none;
+    border-left: none !important;
   }
   &:hover {
-    background-color: $analytics-hover-blue;
-    text-decoration: none;
+    background-color: $analytics-hover-blue !important;
+    text-decoration: none !important;
   }
 }
 
 .analytics-active-item {
-  background-color: $analytics-hover-blue;
+  background-color: $analytics-hover-blue !important;
 }
 
 .item-icon {

--- a/webpack/styles/widgets/_recentitems.scss
+++ b/webpack/styles/widgets/_recentitems.scss
@@ -34,20 +34,24 @@
 
 .recent-item-list {
   @extend .list-group-item;
-  padding-right: 15px;
-  padding-left: 15px;
-  padding-top: 18px;
-  padding-bottom: 36px;
-  border: 0px;
-  font-weight: bold;
-  color: $cdc-blue;
-  font-size: 16px;
+  padding-right: 15px !important;
+  padding-left: 15px !important;
+  margin-bottom: 5px;
+  margin-top: 5px;
+  border: 0px !important;
+  font-weight: bold !important;
+  color: $cdc-blue !important;
+  font-size: 16px !important;
   &:first-child {
-    border-top-right-radius: 0px;
-    border-top-left-radius: 0px;
+    border-top-right-radius: 0px !important;
+    border-top-left-radius: 0px !important;
   }
   &:last-child {
-    border-bottom-right-radius: 0px;
-    border-bottom-left-radius: 0px;
+    border-bottom-right-radius: 0px !important;
+    border-bottom-left-radius: 0px !important;
+  }
+  &:hover {
+    background-color: $analytics-hover-blue !important;
+    text-decoration: none !important;
   }
 }


### PR DESCRIPTION
- [x] 522- Skip navigation (only shows on screen reader or tab navigation, shows on all pages to skip navigation)
- [x] 524- Analytics Widget (now tabable, as well as my stuff filters; can apply with spacebar)
- [x] 536- Analytics Data Elements (used aria-referencedby to link the floating numbers with the analytics-item-label)

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop