### PR TITLE
[SDP-541] Alert modal fix

### DIFF
--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -202,3 +202,18 @@ Feature: Manage Response Sets
     And I click on the "Continue Without Saving" button
     And I go to the list of Response Sets
     Then I should not see "Gender Partial"
+
+  Scenario: Close the warning modal on New Response Set with the escape key
+    Given I am logged in as test_author@gmail.com
+    When I go to the list of Response Sets
+    And I click on the create "Response Sets" dropdown item
+    And I fill in the "response-set-name" field with "Gender Partial"
+    And I fill in the "Description" field with "M / F"
+    And I click on the "Add Row" link
+    And I fill in the "value_0" field with "Test Response 1"
+    And I fill in the "value_1" field with "Test Response 2"
+    And I click on the "remove_0" link
+    When I click on the "CDC Vocabulary Service" link
+    Then I should see "Unsaved Changes"
+    Then I press the key escape
+    Then I should not see "Unsaved Changes"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -152,6 +152,11 @@ When(/^I drag the "([^"]*)" option to the "([^"]*)" list$/) do |option, target|
   drag.drag_to(drop)
 end
 
+Then(/^I press the key (.*)$/) do |key|
+  key = key.to_sym if key.length > 1
+  find('.body').send_keys(key)
+end
+
 Then(/^I take a screenshot named (.*)$/) do |name|
   page.save_screenshot('/tmp/' + name + '.png')
 end

--- a/webpack/components/ModalDialog.js
+++ b/webpack/components/ModalDialog.js
@@ -12,7 +12,7 @@ class ModalDialog extends Component{
   render(){
     return(
       <div className="static-modal" id='saveModal'>
-        <Modal show={this.props.show} onHide={this.close}>
+        <Modal show={this.props.show} onHide={this.props.cancelButtonAction} role="dialog">
           <Modal.Header>
             <Modal.Title>{this.props.warning && <span className={'fa fa-exclamation-circle'}></span>} {this.props.title}</Modal.Title>
           </Modal.Header>


### PR DESCRIPTION
Alert modals already had keyboard focus and tabbing around would let you select the thing you want to do. This change enables the escape key to close the alert dialog and adds a role to the element.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop