### PR TITLE
[SDP-551] Eliminate N+1 queries on the questions endpoint

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -3,7 +3,7 @@ class QuestionsController < ApplicationController
 
   # GET /questions.json
   def index
-    @questions = params[:search] ? Question.search(params[:search]).all : Question.all
+    @questions = params[:search] ? Question.search(params[:search]).includes(:response_sets).all : Question.includes(:response_sets).all
   end
 
   def my_questions

--- a/app/views/questions/index.json.jbuilder
+++ b/app/views/questions/index.json.jbuilder
@@ -1,1 +1,11 @@
-json.array! @questions, partial: 'questions/question', as: :question
+json.array! @questions do |question|
+  json.extract! question, :id, :content, :created_at, :created_by_id, :updated_at, :question_type_id, :description, :status, \
+                :question_type, :version, :version_independent_id, :response_type, \
+                :parent, :other_allowed
+  json.url question_url(question, format: :json)
+  json.response_sets question.response_sets do |rs|
+    json.extract! rs, :id, :name, :description, :oid, :created_by_id, \
+                  :status, :version, :version_independent_id, \
+                  :created_at, :updated_at, :source
+  end
+end

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -23,7 +23,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
     get my_questions_url, xhr: true, params: nil
     assert_response :success
     JSON.parse(response.body).each do |f|
-      assert f['created_by']['id'] == @current_user.id
+      assert f['created_by_id'] == @current_user.id
     end
   end
 


### PR DESCRIPTION
Previously, hitting the /questions endpoint on the web application would
cause at least one DB query per question returned. This was due to what
was being serialized into JSON. This eliminates some troublesome unused
attributes and uses includes on the initial query to eager load
necessary relationships.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop