### PR TITLE
[SDP-527,556] Interactive Elements and Tab navigation

### DIFF
--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -157,6 +157,23 @@ Then(/^I press the key (.*)$/) do |key|
   find('.body').send_keys(key)
 end
 
+Then(/^I press the (.*) key (.*) times$/) do |key, iterations|
+  key = key.to_sym if key.length > 1
+  iterations.to_i.times do
+    find('.body').send_keys(key)
+  end
+end
+
+Then(/^I press the keys (.*) and (.*)$/) do |key_one, key_two|
+  key_one = key_one.to_sym if key_one.length > 1
+  key_two = key_two.to_sym if key_two.length > 1
+  find('.body').send_keys([key_one, key_two])
+end
+
+Then(/^"(.*)" should be my focus$/) do |element|
+  page.evaluate_script('document.activeElement.id') == element
+end
+
 Then(/^I take a screenshot named (.*)$/) do |name|
   page.save_screenshot('/tmp/' + name + '.png')
 end

--- a/features/tab_navigation.feature
+++ b/features/tab_navigation.feature
@@ -1,0 +1,20 @@
+Feature: Tab Navigation and Order
+  As a user without a mouse
+  I want tab navigation to be logical so I can solely use a keyboard
+
+  Scenario: See skip navigation
+    Given I am on the "/" page
+    When I press the key tab
+    And I press the key tab
+    Then I should see "Skip to main content"
+    And "skip-nav" should be my focus
+
+  Scenario: Get to action buttons without going through all search results
+    Given I am logged in as test_author@gmail.com
+    And I have a Question with the content "What is your gender 1?" and the type "MC"
+    And I have a Question with the content "What is your gender 2?" and the type "MC"
+    And I have a Question with the content "What is your gender 3?" and the type "MC"
+    And I am on the "/" page
+    And I click on the create "Forms" dropdown item
+    And I press the tab key 11 times
+    Then "form-name" should be my focus

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -131,17 +131,17 @@ class DashboardSearch extends Component {
       <div className="row">
         <div className="col-md-12">
           <div className="input-group search-group">
-            <input onChange={this.onInputChange} type="text" id="search" name="search" aria-label="search-bar" className="search-input" placeholder="Search..."/>
+            <input onChange={this.onInputChange} type="text" id="search" tabIndex="4" name="search" aria-label="search-bar" className="search-input" placeholder="Search..."/>
             <span className="input-group-btn">
-              <button id="search-btn" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
+              <button id="search-btn" tabIndex="4" className="search-btn search-btn-default" aria-label="search-btn" type="submit"><i className="fa fa-search search-btn-icon" aria-hidden="true"></i></button>
             </span>
           </div>
           <div>
-            {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" className="adv-search-link pull-right" onClick={(e) => {
+            {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" tabIndex="4" className="adv-search-link pull-right" onClick={(e) => {
               e.preventDefault();
               this.clearAdvSearch();
             }}>Clear Filters</a>}
-            <a className="adv-search-link pull-right" title="Advanced Search" href="#" onClick={(e) => {
+            <a className="adv-search-link pull-right" title="Advanced Search" href="#" tabIndex="4" onClick={(e) => {
               e.preventDefault();
               this.showAdvSearch();
             }}>{this.props.searchSource === 'simple_search' && <i className="fa fa-exclamation-triangle simple-search-icon" aria-hidden="true"></i>} Advanced</a>

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -146,9 +146,9 @@ class FormEdit extends Component {
 
   cancelButton() {
     if(this.props.form && this.props.form.id) {
-      return(<Link className="btn btn-default pull-right" to={`/forms/${this.props.form.id}`}>Cancel</Link>);
+      return(<Link tabIndex="3" className="btn btn-default pull-right" to={`/forms/${this.props.form.id}`}>Cancel</Link>);
     }
-    return(<Link className="btn btn-default pull-right" to='/'>Cancel</Link>);
+    return(<Link tabIndex="3" className="btn btn-default pull-right" to='/'>Cancel</Link>);
   }
 
   addLinkedResponseSet(questionIndex, responseSet){
@@ -254,9 +254,9 @@ class FormEdit extends Component {
       <form onSubmit={(e) => this.handleSubmit(e)}>
         <Errors errors={this.state.errors} />
           <div className="form-inline">
-            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
-            <input  className='btn btn-default pull-right' name="Save Form" type="submit" value={`Save`}/>
-            <button className="btn btn-default pull-right" disabled>Export</button>
+            <button tabIndex="3" className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
+            <input tabIndex="3" className='btn btn-default pull-right' name="Save Form" type="submit" value={`Save`}/>
+            <button tabIndex="3" className="btn btn-default pull-right" disabled>Export</button>
             {this.cancelButton()}
           </div>
         <div className="row">
@@ -269,17 +269,17 @@ class FormEdit extends Component {
             <div className="row">
               <div className="form-group col-md-12">
                 <label htmlFor="form-name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="form-name" id="form-name" onChange={this.handleChange('name')}/>
+                <input tabIndex="3" className="input-format" placeholder="Name" type="text" value={this.state.name} name="form-name" id="form-name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="form-group col-md-8">
                 <label htmlFor="form-description">Description</label>
-                <input className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="form-description" id="form-description" onChange={this.handleChange('description')}/>
+                <input tabIndex="3" className="input-format" placeholder="Enter a description here..." type="text" value={this.state.description || ''} name="form-description" id="form-description" onChange={this.handleChange('description')}/>
               </div>
               <div className="form-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>
-                <input className="input-format" placeholder="XXXX-XXXX" type="text" value={this.state.controlNumber || ''} name="controlNumber" id="controlNumber" onChange={this.handleChange('controlNumber')}/>
+                <input tabIndex="3" className="input-format" placeholder="XXXX-XXXX" type="text" value={this.state.controlNumber || ''} name="controlNumber" id="controlNumber" onChange={this.handleChange('controlNumber')}/>
               </div>
             </div>
           </div>

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -203,22 +203,22 @@ class FormEdit extends Component {
               </div>
               <div className="col-md-1">
                 <div className="row form-question-controls">
-                  <div className="btn btn-small btn-default move-up"
-                       onClick={() => this.props.reorderQuestion(form, i, 1)}>
-                    <i title="Move Up" className="fa fa fa-arrow-up"></i>
-                  </div>
+                  <button className="btn btn-small btn-default move-up"
+                       onClick={(event) => {event.preventDefault(); this.props.reorderQuestion(form, i, 1);}}>
+                    <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move question up on form</span>
+                  </button>
                 </div>
                 <div className="row form-question-controls">
-                  <div className="btn btn-small btn-default move-down"
-                       onClick={() => this.props.reorderQuestion(form, i, -1)}>
-                    <i className="fa fa fa-arrow-down" title="Move Down"></i>
-                  </div>
+                  <button className="btn btn-small btn-default move-down"
+                       onClick={(event) => {event.preventDefault(); this.props.reorderQuestion(form, i, -1);}}>
+                    <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move question down on form</span>
+                  </button>
                 </div>
                 <div className="row form-question-controls">
-                  <div className="btn btn-small btn-default delete-question"
-                       onClick={() => this.props.removeQuestion(form, i)}>
-                    <i className="fa fa fa-trash" title="Remove"></i>
-                  </div>
+                  <button className="btn btn-small btn-default delete-question"
+                       onClick={(event) => {event.preventDefault(); this.props.removeQuestion(form, i);}}>
+                    <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove question from selected question list</span>
+                  </button>
                 </div>
               </div>
               </div>

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -204,19 +204,28 @@ class FormEdit extends Component {
               <div className="col-md-1">
                 <div className="row form-question-controls">
                   <button className="btn btn-small btn-default move-up"
-                       onClick={(event) => {event.preventDefault(); this.props.reorderQuestion(form, i, 1);}}>
+                       onClick={(event) => {
+                         event.preventDefault();
+                         this.props.reorderQuestion(form, i, 1);
+                       }}>
                     <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move question up on form</span>
                   </button>
                 </div>
                 <div className="row form-question-controls">
                   <button className="btn btn-small btn-default move-down"
-                       onClick={(event) => {event.preventDefault(); this.props.reorderQuestion(form, i, -1);}}>
+                       onClick={(event) => {
+                         event.preventDefault();
+                         this.props.reorderQuestion(form, i, -1);
+                       }}>
                     <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move question down on form</span>
                   </button>
                 </div>
                 <div className="row form-question-controls">
                   <button className="btn btn-small btn-default delete-question"
-                       onClick={(event) => {event.preventDefault(); this.props.removeQuestion(form, i);}}>
+                       onClick={(event) => {
+                         event.preventDefault();
+                         this.props.removeQuestion(form, i);
+                       }}>
                     <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove question from selected question list</span>
                   </button>
                 </div>

--- a/webpack/components/Notification.js
+++ b/webpack/components/Notification.js
@@ -4,7 +4,7 @@ class Notification extends Component {
   render() {
     return (
       <div>
-        <li className="notification-menu-item" onClick={() => this.onNotificationClick(this.props.notification.url)}>{this.props.notification.message}</li>
+        <li className="notification-menu-item" tabIndex="2" onClick={() => this.onNotificationClick(this.props.notification.url)}>{this.props.notification.message}</li>
       </div>
     );
   }

--- a/webpack/components/NotificationDropdown.js
+++ b/webpack/components/NotificationDropdown.js
@@ -33,7 +33,7 @@ class NotificationDropdown extends Component {
   render() {
     if(this.state.notificationCount > 0 && this.props.notifications){
       return (
-        <a href="#notifications" className="dropdown-toggle cdc-navbar-item" id="notification-dropdown"  data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" onClick={() => this.onDropdownClick(this.props.notifications)}>
+        <a href="#notifications" tabIndex="2" className="dropdown-toggle cdc-navbar-item" id="notification-dropdown"  data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false" onClick={() => this.onDropdownClick(this.props.notifications)}>
           <i className="fa fa-bell item-navbar-icon" aria-hidden="true"></i>
           Alerts
           <span className="caret"></span>
@@ -42,7 +42,7 @@ class NotificationDropdown extends Component {
       );
     } else {
       return (
-        <a href="#notifications" className="dropdown-toggle cdc-navbar-item" id="notification-dropdown"  data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
+        <a href="#notifications" tabIndex="2" className="dropdown-toggle cdc-navbar-item" id="notification-dropdown"  data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">
           <i className="fa fa-bell item-navbar-icon" aria-hidden="true"></i>
           Alerts
           <span className="caret"></span>

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -38,7 +38,7 @@ class DropTarget extends Component {
         {selectedResponseSets.map((rs, i) => {
           return (
           <div key={i}>
-          <i className='pull-right fa fa-close' onClick={() => removeResponseSet(rs.id)}/>
+          <button className="pull-right" onClick={() => removeResponseSet(rs.id)}><i className='fa fa-close' aria-hidden="true"/><span className="sr-only">Remove Selected Response Set</span></button>
           <DraggableResponseSet type='response_set' result={{Source: rs}} currentUser={{id: -1}} />
           </div>);
         })}
@@ -115,7 +115,7 @@ class ResponseSetDragWidget extends Component {
                       handleSelectSearchResult={() => this.addRsButtonHandler(rs)} />;
             })}
             {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
-              <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
+              <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
             }
           </div>
         </div>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -303,8 +303,9 @@ export default class SearchResult extends Component {
                     this.selectResultButton(result, handleSelectSearchResult)
                   ) : (
                     <div className="dropdown">
-                      <a id={`${type}_${result.id}_menu`} className="dropdown-toggle" type="" data-toggle="dropdown">
+                      <a id={`${type}_${result.id}_menu`} role="navigation" href="#item-menu" className="dropdown-toggle widget-dropdown-toggle" data-toggle="dropdown">
                         <span className="fa fa-ellipsis-h" aria-hidden="true"></span>
+                        <span className="sr-only">View Item Action Menu</span>
                       </a>
                       {this.resultDropdownMenu(result, type, actionName, action)}
                     </div>

--- a/webpack/components/SurveyEdit.js
+++ b/webpack/components/SurveyEdit.js
@@ -140,9 +140,9 @@ class SurveyEdit extends Component {
 
   cancelButton() {
     if(this.props.survey && this.props.survey.id) {
-      return(<Link className="btn btn-default pull-right" to={`/surveys/${this.props.survey.id}`}>Cancel</Link>);
+      return(<Link tabIndex="3" className="btn btn-default pull-right" to={`/surveys/${this.props.survey.id}`}>Cancel</Link>);
     }
-    return(<Link className="btn btn-default pull-right" to='/'>Cancel</Link>);
+    return(<Link tabIndex="3" className="btn btn-default pull-right" to='/'>Cancel</Link>);
   }
 
   render() {
@@ -169,8 +169,8 @@ class SurveyEdit extends Component {
       <form onSubmit={(e) => this.handleSubmit(e)}>
         <Errors errors={this.state.errors} />
           <div className="survey-inline">
-            <button className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
-            <input className='btn btn-default pull-right' name="Save Survey" type="submit" value={`Save`}/>
+            <button tabIndex="3" className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
+            <input tabIndex="3" className='btn btn-default pull-right' name="Save Survey" type="submit" value={`Save`}/>
             {this.cancelButton()}
           </div>
         <div className="row">
@@ -183,17 +183,17 @@ class SurveyEdit extends Component {
             <div className="row">
               <div className="survey-group col-md-12">
                 <label htmlFor="survey-name" hidden>Name</label>
-                <input className="input-format" placeholder="Name" type="text" value={this.state.name} name="survey-name" id="survey-name" onChange={this.handleChange('name')}/>
+                <input tabIndex="3" className="input-format" placeholder="Name" type="text" value={this.state.name} name="survey-name" id="survey-name" onChange={this.handleChange('name')}/>
               </div>
             </div>
             <div className="row">
               <div className="survey-group col-md-8">
                 <label htmlFor="survey-description">Description</label>
-                <input className="input-format" type="text" value={this.state.description || ''} name="survey-description" id="survey-description" onChange={this.handleChange('description')}/>
+                <input tabIndex="3" className="input-format" type="text" value={this.state.description || ''} name="survey-description" id="survey-description" onChange={this.handleChange('description')}/>
               </div>
               <div className="survey-group col-md-4">
                 <label htmlFor="controlNumber">OMB Approval</label>
-                <input className="input-format" placeholder="XXXX-XXXX" type="text" value={this.state.controlNumber || ''} name="controlNumber" id="controlNumber" onChange={this.handleChange('controlNumber')}/>
+                <input tabIndex="3" className="input-format" placeholder="XXXX-XXXX" type="text" value={this.state.controlNumber || ''} name="controlNumber" id="controlNumber" onChange={this.handleChange('controlNumber')}/>
               </div>
             </div>
           </div>

--- a/webpack/components/SurveyFormList.js
+++ b/webpack/components/SurveyFormList.js
@@ -23,15 +23,24 @@ class SurveyFormList extends Component {
                   <h1 className="panel-title">{f.name}</h1>
                   <div className='form-group-controls'>
                     <button className="btn btn-small btn-default move-up"
-                         onClick={(event) => {event.preventDefault(); this.props.reorderForm(survey, i, 1);}}>
+                         onClick={(event) => {
+                           event.preventDefault();
+                           this.props.reorderForm(survey, i, 1);
+                         }}>
                       <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move form up on survey</span>
                     </button>
                     <button className="btn btn-small btn-default move-down"
-                         onClick={(event) => {event.preventDefault(); this.props.reorderForm(survey, i, -1);}}>
+                         onClick={(event) => {
+                           event.preventDefault();
+                           this.props.reorderForm(survey, i, -1);
+                         }}>
                       <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move form down on survey</span>
                     </button>
                     <button className="btn btn-small btn-default"
-                         onClick={(event) => {event.preventDefault(); this.props.removeForm(survey, i);}}>
+                         onClick={(event) => {
+                           event.preventDefault();
+                           this.props.removeForm(survey, i);
+                         }}>
                       <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove form from selected form list</span>
                     </button>
                   </div>

--- a/webpack/components/SurveyFormList.js
+++ b/webpack/components/SurveyFormList.js
@@ -22,18 +22,18 @@ class SurveyFormList extends Component {
                 <div className="panel-heading">
                   <h1 className="panel-title">{f.name}</h1>
                   <div className='form-group-controls'>
-                    <div className="btn btn-small btn-default move-up"
-                         onClick={() => this.props.reorderForm(survey, i, 1)}>
-                      <i title="Move Up" className="fa fa fa-arrow-up"></i>
-                    </div>
-                    <div className="btn btn-small btn-default move-down"
-                         onClick={() => this.props.reorderForm(survey, i, -1)}>
-                      <i className="fa fa fa-arrow-down" title="Move Down"></i>
-                    </div>
-                    <div className="btn btn-small btn-default"
-                         onClick={() => this.props.removeForm(survey, i)}>
-                      <i className="fa fa fa-trash" title="Remove"></i>
-                    </div>
+                    <button className="btn btn-small btn-default move-up"
+                         onClick={(event) => {event.preventDefault(); this.props.reorderForm(survey, i, 1);}}>
+                      <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move form up on survey</span>
+                    </button>
+                    <button className="btn btn-small btn-default move-down"
+                         onClick={(event) => {event.preventDefault(); this.props.reorderForm(survey, i, -1);}}>
+                      <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move form down on survey</span>
+                    </button>
+                    <button className="btn btn-small btn-default"
+                         onClick={(event) => {event.preventDefault(); this.props.removeForm(survey, i);}}>
+                      <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove form from selected form list</span>
+                    </button>
                   </div>
                 </div>
                 <div className="box-content">

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -56,7 +56,7 @@ class App extends Component {
   render() {
     return (
       <div>
-        <a href="#main-content" className="sr-only sr-only-focusable">Skip to main content</a>
+        <a href="#main-content" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 location={this.props.location}
                 logInOpener={() => this.openLogInModal()}

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -56,7 +56,7 @@ class App extends Component {
   render() {
     return (
       <div>
-        <a href="#main-content" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
+        <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 location={this.props.location}
                 logInOpener={() => this.openLogInModal()}

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -142,7 +142,7 @@ class DashboardContainer extends Component {
                         <h1 className="banner-title">CDC Vocabulary Service</h1>
                         <h2 className="banner-subtitle">Author Questions, Response Sets, Forms, and Surveys</h2>
                         <p className="lead">The Vocabulary Service allows users to author their own questions and response sets, and to reuse others’ wording for their new data collection needs when applicable. A goal of this service is to increase consistency by reducing the number of different ways that CDC asks for similar information, lowering the reporting burden on partners.</p>
-                        <p><a className="btn btn-lg btn-success" href="#" role="button" onClick={this.openSignUpModal}>Get Started!</a></p>
+                        <p><a className="btn btn-lg btn-success" href="#" tabIndex="2" role="button" onClick={this.openSignUpModal}>Get Started!</a></p>
                       </div>
                     </div>
                     <div className="col-md-4"></div>
@@ -261,28 +261,28 @@ class DashboardContainer extends Component {
     return (
     <div className="analytics-group" role="navigation" aria-label="Analytics">
       <ul className="analytics-list-group">
-        <button id="questions-analytics-item" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
+        <button id="questions-analytics-item" tabIndex="4" className={"analytics-list-item btn" + (searchType === 'question' ? " analytics-active-item" : "")} onClick={() => this.selectType('question')}>
           <div>
             <i className="fa fa-tasks fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="question-analytics-item-title">{this.props.questionCount}</p>
             <h2 className="item-title" id="question-analytics-item-title">Questions</h2>
           </div>
         </button>
-        <button id="response-sets-analytics-item" className={"analytics-list-item btn" + (searchType === 'response_set' ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set')}>
+        <button id="response-sets-analytics-item" tabIndex="4" className={"analytics-list-item btn" + (searchType === 'response_set' ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set')}>
           <div>
             <i className="fa fa-list fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="response-sets-analytics-item-title">{this.props.responseSetCount}</p>
             <h2 className="item-title" id="response-sets-analytics-item-title">Response Sets</h2>
           </div>
           </button>
-        <button id="forms-analytics-item" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
+        <button id="forms-analytics-item" tabIndex="4" className={"analytics-list-item btn" + (searchType === 'form' ? " analytics-active-item" : "")} onClick={() => this.selectType('form')}>
           <div>
             <i className="fa fa-list-alt fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="forms-analytics-item-title">{this.props.formCount}</p>
             <h2 className="item-title" id="forms-analytics-item-title">Forms</h2>
           </div>
           </button>
-        <button id="surveys-analytics-item" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
+        <button id="surveys-analytics-item" tabIndex="4" className={"analytics-list-item btn" + (searchType === 'survey' ? " analytics-active-item" : "")} onClick={() => this.selectType('survey')}>
           <div>
             <i className="fa fa-clipboard fa-3x item-icon" aria-hidden="true"></i>
             <p className="item-value" aria-describedby="surveys-analytics-item-title">{this.props.surveyCount}</p>
@@ -300,24 +300,24 @@ class DashboardContainer extends Component {
         <div className="recent-items-heading">My Stuff</div>
         <div className="recent-items-body">
           <ul className="list-group">
-            <button className={"recent-item-list btn" + (searchType === 'question' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('question', true)}>
+            <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'question' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('question', true)}>
               <div className="recent-items-icon"><i className="fa fa-tasks recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myQuestionCount} Questions</div>
             </button>
-            <button className={"recent-item-list btn" + (searchType === 'response_set' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set', true)}>
+            <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'response_set' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set', true)}>
               <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myResponseSetCount} Response Sets</div>
             </button>
-            <button className={"recent-item-list btn" + (searchType === 'form' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('form', true)}>
+            <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'form' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('form', true)}>
               <div className="recent-items-icon"><i className="fa fa-list-alt recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.myFormCount} Forms</div>
             </button>
-            <button className={"recent-item-list btn" + (searchType === 'survey' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('survey', true)}>
+            <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'survey' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('survey', true)}>
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
               <div className="recent-items-value">{this.props.mySurveyCount} Surveys</div>
             </button>
             {myStuffFilter ? (<a href="#" className="col-md-12 text-center" onClick={() => this.selectType(searchType)}>Clear My Stuff Filter</a>) : (
-              <a href="#" className="col-md-12 text-center" onClick={() => this.selectType(searchType, true)}>Filter by My Stuff</a>
+              <a href="#" tabIndex="4" className="col-md-12 text-center" onClick={() => this.selectType(searchType, true)}>Filter by My Stuff</a>
             )}
           </ul>
         </div>

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -168,7 +168,7 @@ class DashboardContainer extends Component {
                 <div className="load-more-search">
                   <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} isEditPage={false} />
                   {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
-                    <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
+                    <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
                   }
                 </div>
               </div>

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -93,7 +93,7 @@ class FormSearchContainer extends Component {
             );
           })}
           {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
-            <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
+            <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
           }
         </div>
       </div>

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -130,7 +130,7 @@ class FormsEditContainer extends Component {
             <div className="panel-body">
               <div className="col-md-5">
                 <div className="row add-question">
-                  <Button onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
+                  <Button tabIndex="4" onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
                 </div>
                 <QuestionSearchContainer form={this.props.form} />
               </div>

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -15,13 +15,13 @@ let LoginMenu = ({logInOpener, signUpOpener, currentUser}) => {
     return (
       <ul className="nav navbar-nav">
         <li className="log-in-link">
-          <a href="#" onClick={() => {
+          <a href="#" tabIndex="2" onClick={() => {
             logInOpener();
             return false;
           }}>Login </a>
         </li>
         <li>
-          <a href="#" onClick={() => {
+          <a href="#" tabIndex="2" onClick={() => {
             signUpOpener();
             return false;
           }}> Register </a>
@@ -45,16 +45,15 @@ let ContentMenu = ({settingsOpener, currentUser}) => {
     let {email} = currentUser;
     return(
       <li className="dropdown">
-        <a href="#" id="account-dropdown" className="dropdown-toggle account-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-cog utlt-navbar-icon" aria-hidden="true"></i>{email}<span className="caret"></span></a>
+        <a href="#" tabIndex="2" id="account-dropdown" className="dropdown-toggle account-dropdown" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-cog utlt-navbar-icon" aria-hidden="true"></i>{email}<span className="caret"></span></a>
         <ul className="dropdown-menu">
-          <li><Link to='/mystuff'>My Stuff</Link></li>
-          <li><a href="#" onClick={() => {
+          <li><a href="#" tabIndex="2" onClick={() => {
             settingsOpener();
             return false;
           }}>Settings</a></li>
           <li role="separator" className="divider"></li>
           <li>
-            <a href="/users/sign_out">Logout</a>
+            <a href="/users/sign_out" tabIndex="2">Logout</a>
           </li>
         </ul>
       </li>
@@ -73,15 +72,15 @@ let SignedInMenu = ({currentUser, location, notifications, notificationCount}) =
   if(loggedIn) {
     return (
       <ul className="cdc-nav cdc-utlt-navbar-nav">
-        <li className="active"><a href="#" className="cdc-navbar-item"><i className="fa fa-bar-chart item-navbar-icon" aria-hidden="true"></i>Dashboard</a></li>
+        <li className="active"><a href="#" tabIndex="2" className="cdc-navbar-item"><i className="fa fa-bar-chart item-navbar-icon" aria-hidden="true"></i>Dashboard</a></li>
         {!location.pathname.includes("revise") && !location.pathname.includes("edit") && !location.pathname.includes("extend") &&
           <li className="dropdown">
-            <a href="#" id = "create-menu" className="dropdown-toggle cdc-navbar-item create-menu" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-clipboard item-navbar-icon" aria-hidden="true"></i>Create<span className="caret"></span></a>
+            <a href="#" id="create-menu" tabIndex="2" className="dropdown-toggle cdc-navbar-item create-menu" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-clipboard item-navbar-icon" aria-hidden="true"></i>Create<span className="caret"></span></a>
             <ul className="cdc-nav-dropdown">
-              <li className="nav-dropdown-item"><Link to="/questions/new">Questions</Link></li>
-              <li className="nav-dropdown-item"><Link to="/responseSets/new">Response Sets</Link></li>
-              <li className="nav-dropdown-item"><Link to="/forms/new">Forms</Link></li>
-              <li className="nav-dropdown-item"><Link to="/surveys/new">Surveys</Link></li>
+              <li className="nav-dropdown-item"><Link to="/questions/new" tabIndex="2">Questions</Link></li>
+              <li className="nav-dropdown-item"><Link to="/responseSets/new" tabIndex="2">Response Sets</Link></li>
+              <li className="nav-dropdown-item"><Link to="/forms/new" tabIndex="2">Forms</Link></li>
+              <li className="nav-dropdown-item"><Link to="/surveys/new" tabIndex="2">Surveys</Link></li>
             </ul>
           </li>
         }
@@ -197,7 +196,7 @@ class Header extends Component {
             <span className="icon-bar"></span>
             <span className="icon-bar"></span>
             </button>
-            <Link to="/" className="cdc-brand">CDC Vocabulary Service</Link>
+            <Link to="/" className="cdc-brand" tabIndex="2">CDC Vocabulary Service</Link>
           </div>
           <SignedInMenu currentUser={this.props.currentUser} location={this.props.location} notifications={this.props.notifications} notificationCount={this.props.notificationCount} />
           <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
@@ -205,11 +204,11 @@ class Header extends Component {
               <ContentMenu currentUser={this.props.currentUser} settingsOpener={this.props.settingsOpener} />
               <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener}/>
               <li className="dropdown">
-                <a href="#" id = "help-menu" className="dropdown-toggle cdc-navbar-item help-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-question-circle utlt-navbar-icon" aria-hidden="true"></i>Help<span className="caret"></span></a>
+                <a href="#" id = "help-menu" tabIndex="2" className="dropdown-toggle cdc-navbar-item help-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-question-circle utlt-navbar-icon" aria-hidden="true"></i>Help<span className="caret"></span></a>
                 <ul className="cdc-nav-dropdown">
-                  <li className="nav-dropdown-item"><Link to='/Help'>Help Documentation</Link></li>
+                  <li className="nav-dropdown-item"><Link to='/Help' tabIndex="2">Help Documentation</Link></li>
                   {isReady && this.props.steps.length > 0 &&
-                    <li><a href="#" onClick={(e) => {
+                    <li><a href="#" tabIndex="2" onClick={(e) => {
                       e.preventDefault();
                       return this.joyride.reset(true);
                     }}>Step-by-Step Walkthrough</a></li>

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -85,7 +85,7 @@ class QuestionSearchContainer extends Component {
             );
           })}
           {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
-            <div id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</div>
+            <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
           }
         </div>
       </div>

--- a/webpack/styles/elements/_buttons.scss
+++ b/webpack/styles/elements/_buttons.scss
@@ -38,7 +38,22 @@
 }
 
 a.dropdown-toggle{
-  cursor: pointer;
+}
+
+a.widget-dropdown-toggle{
+  @extend .dropdown-toggle;
+  padding-left: 5px;
+  padding-right: 5px;
+  &:focus {
+    outline: 1px;
+    outline-style: dashed;
+    outline-color: black;
+    box-shadow: 2px 2px 2px #888;
+  }
+}
+
+caption {
+  color: $medium-gray;
 }
 
 i.fa-close{

--- a/webpack/styles/elements/_buttons.scss
+++ b/webpack/styles/elements/_buttons.scss
@@ -52,6 +52,11 @@ a.widget-dropdown-toggle{
   }
 }
 
+.load-more-btn {
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+}
+
 caption {
   color: $medium-gray;
 }

--- a/webpack/styles/navigation/_nav.scss
+++ b/webpack/styles/navigation/_nav.scss
@@ -121,3 +121,24 @@ a.cdc-brand:focus {
     overflow-x: hidden;
   }
 }
+
+.skiptocontent {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  background: $cdc-dark-blue;
+  color: white;
+  width: 15%;
+  -webkit-transition: top 1s ease-out, background 1s linear;
+  transition: top 1s ease-out, background 1s linear;
+  a:focus {
+    position: absolute;
+    top: 40px;
+    left: 0px;
+    padding: 10px;
+    background: $cdc-dark-blue;
+    color: white;
+    -webkit-transition: top .1s ease-in, background .5s linear;
+    transition: top .1s ease-in, background .5s linear;
+  }
+}

--- a/webpack/styles/widgets/_recentitems.scss
+++ b/webpack/styles/widgets/_recentitems.scss
@@ -2,6 +2,7 @@
   @extend .panel;
   border: none;
   border-radius: 0px;
+  box-shadow: none;
 }
 
 .recent-items-heading {


### PR DESCRIPTION
- [x] SDP-527 Interactive elements (made sure every element that should be focusable / tabable was using keyboard only)
- [x] SDP-556 Fix tab order (made sure the tab order made sense for each page) 

Basic tabIndex order heiarchy:
1) Skip Navigation
2) Navigation
3) Main Content on Pages where the is something to do before search
4) Search and search filters
5) (5+/undefined) anything that should come after 4 is left as undefined so it takes the normal automatic tab order after items that are declared, this works for items that are search results etc

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
