### PR TITLE
[SDP-552] Eliminate N+1 forms queries

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -4,7 +4,7 @@ class FormsController < ApplicationController
   # GET /forms
   # GET /forms.json
   def index
-    @forms = params[:search] ? Form.search(params[:search]).all : Form.all
+    @forms = params[:search] ? Form.includes(:form_questions, :questions).search(params[:search]).all : Form.includes(:form_questions, :questions).all
     @users = User.all
   end
 

--- a/app/views/forms/_form.json.jbuilder
+++ b/app/views/forms/_form.json.jbuilder
@@ -1,5 +1,11 @@
-json.extract! form, :id, :name, :description, :created_at, :updated_at, :questions, \
+json.extract! form, :id, :name, :description, :created_at, :updated_at, \
               :version_independent_id, :version, :all_versions, :most_recent, :parent, \
               :form_questions, :control_number, :status, :created_by_id, :published_by
 json.user_id form.created_by.email if form.created_by.present?
 json.url form_url(form, format: :json)
+
+json.questions form.questions do |q|
+  json.extract! q, :id, :content, :created_at, :created_by_id, :updated_at, :question_type_id, :description, :status, \
+                :version, :version_independent_id, \
+                :other_allowed
+end

--- a/app/views/forms/index.json.jbuilder
+++ b/app/views/forms/index.json.jbuilder
@@ -1,1 +1,12 @@
-json.array! @forms, partial: 'forms/form', as: :form
+json.array! @forms do |form|
+  json.extract! form, :id, :name, :description, :created_at, :updated_at, \
+                :version_independent_id, :version, :parent, \
+                :form_questions, :control_number, :status, :created_by_id, :published_by_id
+  json.url form_url(form, format: :json)
+
+  json.questions form.questions do |q|
+    json.extract! q, :id, :content, :created_at, :created_by_id, :updated_at, :question_type_id, :description, :status, \
+                  :version, :version_independent_id, \
+                  :other_allowed
+  end
+end

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "postcss-loader": "^1.0.0",
     "rails-erb-loader": "3.0.0",
     "react": "^15.4.0",
+    "react-addons-shallow-compare": "^15.5.2",
     "react-bootstrap": "^0.30.7",
     "react-dom": "^15.4.0",
     "react-joyride": "^1.10.1",

--- a/webpack/components/FormQuestionList.js
+++ b/webpack/components/FormQuestionList.js
@@ -1,8 +1,14 @@
 import React, { Component, PropTypes } from 'react';
+import shallowCompare from 'react-addons-shallow-compare';
+
 import { questionProps } from "../prop-types/question_props";
 import SearchResult from './SearchResult';
 
 class FormQuestionList extends Component {
+  shouldComponentUpdate(nextProps, nextState) {
+    return shallowCompare(this, nextProps, nextState);
+  }
+
   render() {
     if(!this.props.questions){
       return (

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -16,8 +16,8 @@ import { publishersProps } from "../prop-types/publisher_props";
 class FormShowContainer extends Component {
   componentWillMount() {
     this.props.fetchForm(this.props.params.formId);
-    this.props.fetchQuestions();
-    this.props.fetchResponseSets();
+    //this.props.fetchQuestions();
+    //this.props.fetchResponseSets();
   }
 
   componentDidMount() {

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -16,8 +16,6 @@ import { publishersProps } from "../prop-types/publisher_props";
 class FormShowContainer extends Component {
   componentWillMount() {
     this.props.fetchForm(this.props.params.formId);
-    //this.props.fetchQuestions();
-    //this.props.fetchResponseSets();
   }
 
   componentDidMount() {

--- a/webpack/middleware/parent_from_questions.js
+++ b/webpack/middleware/parent_from_questions.js
@@ -3,7 +3,7 @@ import {
   FETCH_QUESTION_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const parentFromQuestions = store => next => action => {
   if(store == null) return;

--- a/webpack/middleware/parent_from_response_sets.js
+++ b/webpack/middleware/parent_from_response_sets.js
@@ -3,7 +3,7 @@ import {
   FETCH_RESPONSE_SET_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const parentFromResponseSets = store => next => action => {
   if (store == null) return;

--- a/webpack/middleware/question_types_from_questions.js
+++ b/webpack/middleware/question_types_from_questions.js
@@ -5,7 +5,7 @@ import {
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const questionTypesFromQuestions = store => next => action => {
   switch (action.type) {

--- a/webpack/middleware/questions_from_forms.js
+++ b/webpack/middleware/questions_from_forms.js
@@ -1,10 +1,11 @@
 import {
   FETCH_FORM_FULFILLED,
   FETCH_FORMS_FULFILLED,
-  FETCH_QUESTION_FULFILLED
+  FETCH_QUESTION_FULFILLED,
+  FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent, dispatchCollectionMembersIfNotPresent } from './store_helper';
 
 const questionsFromForms = store => next => action => {
   switch (action.type) {
@@ -23,9 +24,7 @@ const questionsFromForms = store => next => action => {
       break;
     case FETCH_FORM_FULFILLED:
       if (action.payload.data.questions) {
-        action.payload.data.questions.forEach((q) => {
-          dispatchIfNotPresent(store, 'questions', q, FETCH_QUESTION_FULFILLED);
-        });
+        dispatchCollectionMembersIfNotPresent(store, 'questions', action.payload.data.questions, FETCH_QUESTIONS_FULFILLED);
       }
       action.payload.data.questions = action.payload.data.questions.map((q) => {
         return ({id: q.id, content: q.content });

--- a/webpack/middleware/questions_from_response_sets.js
+++ b/webpack/middleware/questions_from_response_sets.js
@@ -4,7 +4,7 @@ import {
   FETCH_QUESTION_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const questionsFromResponseSets = store => next => action => {
   if(store == null) return;

--- a/webpack/middleware/response_sets_from_questions.js
+++ b/webpack/middleware/response_sets_from_questions.js
@@ -5,7 +5,7 @@ import {
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const responseSetsFromQuestions = store => next => action => {
   switch (action.type) {

--- a/webpack/middleware/response_types_from_questions.js
+++ b/webpack/middleware/response_types_from_questions.js
@@ -5,7 +5,7 @@ import {
   FETCH_QUESTIONS_FULFILLED
 } from '../actions/types';
 
-import dispatchIfNotPresent from './store_helper';
+import { dispatchIfNotPresent } from './store_helper';
 
 const responseTypesFromQuestions = store => next => action => {
   switch (action.type) {

--- a/webpack/middleware/store_helper.js
+++ b/webpack/middleware/store_helper.js
@@ -5,4 +5,17 @@ const dispatchIfNotPresent = (store, type, obj, dispatchAction) => {
   }
 };
 
-export default dispatchIfNotPresent;
+const dispatchCollectionMembersIfNotPresent = (store, type, collection, dispatchAction) => {
+  let membersNotInStore = [];
+  collection.forEach((obj) => {
+    if (store.getState()[type] === undefined ||
+        store.getState()[type][obj.id] === undefined) {
+      membersNotInStore.push(obj);
+    }
+  });
+  if (membersNotInStore.length > 0) {
+    store.dispatch({type: dispatchAction, payload: {data: membersNotInStore}});
+  }
+};
+
+export {dispatchIfNotPresent, dispatchCollectionMembersIfNotPresent};


### PR DESCRIPTION
This PR contains several performance fixes:
* Single query to the database for all forms
* Single query to the database for an individual form
* Middleware now queues nested items and dispatches them in a single action
* Avoid unnecessary re-rendering on FormQuestionList
* Removed unnecessary fetches in FormShowContainer

The first two items were implemented by cleaning up the JSON views and doing some eager loading in the controller.

Middleware now dispatches far fewer actions, meaning that mapStateToProps will be called far less, which means far fewer renders from components.

FormQuestionList now tells react when it should be re-rendered.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
