### PR TITLE
Fix display bug on form show

### DIFF
--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -16,6 +16,7 @@ import { publishersProps } from "../prop-types/publisher_props";
 class FormShowContainer extends Component {
   componentWillMount() {
     this.props.fetchForm(this.props.params.formId);
+    this.props.fetchResponseSets();
   }
 
   componentDidMount() {


### PR DESCRIPTION
Previous code removed the fetching of all response sets. This introduced
an issue when clicking on the linked response set for a question as it
might not be in the store.

This adds back in the fetching of all response sets. It's not the most
performance conscious solution, but it will work for now and will be
addressed at a later date.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
