### PR TITLE
[SDP-full list below] Screen Reader Helpers on Dash and Details Pages

### DIFF
--- a/test/frontend/components/question_details_test.js
+++ b/test/frontend/components/question_details_test.js
@@ -12,7 +12,7 @@ describe('QuestionDetails', () => {
   });
 
   it('should display a question', () => {
-    expect(component.find("h1[class='panel-title']")).to.contain("Details");
+    expect(component.find("h2[class='panel-title']")).to.contain("Details");
   });
 
 });

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -24,7 +24,7 @@ class FormShow extends Component {
         <div className="showpage_header_container no-print">
           <ul className="list-inline">
             <li className="showpage_button"><span className="fa fa-arrow-left fa-2x" aria-hidden="true" onClick={hashHistory.goBack}></span></li>
-            <li className="showpage_title">Form Details {form.status === 'draft' && <text>[DRAFT]</text>}</li>
+            <li className="showpage_title"><h1>Form Details {form.status === 'draft' && <text>[DRAFT]</text>}</h1></li>
           </ul>
         </div>
         {this.historyBar(form)}
@@ -36,12 +36,13 @@ class FormShow extends Component {
   historyBar(form){
     return (
       <div className="col-md-3 nopadding no-print">
-        <div className="showpage_sidenav_subtitle">
+        <h2 className="showpage_sidenav_subtitle">
+          <text className="sr-only">Version History Navigation Links</text>
           <ul className="list-inline">
             <li className="subtitle_icon"><span className="fa fa-history" aria-hidden="true"></span></li>
             <li className="subtitle">History</li>
           </ul>
-        </div>
+        </h2>
         <VersionInfo versionable={form} versionableType='form' />
       </div>
     );
@@ -94,7 +95,7 @@ class FormShow extends Component {
           <p className="maincontent-item-info">Version: {form.version} - Author: {form.userId} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">Description</h1>
+              <h2 className="panel-title">Description</h2>
             </div>
             <div className="box-content">
               {form.description}

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -28,7 +28,7 @@ export default class QuestionDetails extends Component {
         <div className="showpage_header_container no-print">
           <ul className="list-inline">
             <li className="showpage_button"><span className="fa fa-arrow-left fa-2x" aria-hidden="true" onClick={hashHistory.goBack}></span></li>
-            <li className="showpage_title">Question Details {question.status === 'draft' && <text>[DRAFT]</text>}</li>
+            <li className="showpage_title"><h1>Question Details {question.status === 'draft' && <text>[DRAFT]</text>}</h1></li>
           </ul>
         </div>
         {this.historyBar(question)}
@@ -96,7 +96,7 @@ export default class QuestionDetails extends Component {
           <p className="maincontent-item-info">Version: {question.version} - Author: {question.createdBy && question.createdBy.email} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">Details</h1>
+              <h2 className="panel-title">Details</h2>
             </div>
             <div className="box-content">
               <strong>Description: </strong>
@@ -133,7 +133,7 @@ export default class QuestionDetails extends Component {
           </div>
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h1 className="panel-title">Tags</h1>
+                <h2 className="panel-title">Tags</h2>
               </div>
               <div className="box-content">
                 <div id="concepts-table">
@@ -144,7 +144,7 @@ export default class QuestionDetails extends Component {
           {responseSets && responseSets.length > 0 &&
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h1 className="panel-title">Linked Response Sets</h1>
+                <h2 className="panel-title">Linked Response Sets</h2>
               </div>
               <div className="box-content">
                 <ResponseSetList responseSets={_.keyBy(responseSets, 'id')} />
@@ -162,12 +162,13 @@ export default class QuestionDetails extends Component {
   historyBar(question) {
     return (
       <div className="col-md-3 nopadding no-print">
-        <div className="showpage_sidenav_subtitle">
+        <h2 className="showpage_sidenav_subtitle">
+          <text className="sr-only">Version History Navigation Links</text>
           <ul className="list-inline">
             <li className="subtitle_icon"><span className="fa fa-history" aria-hidden="true"></span></li>
             <li className="subtitle">History</li>
           </ul>
-        </div>
+        </h2>
         <VersionInfo versionable={question} versionableType='Question' />
       </div>
     );

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -147,7 +147,7 @@ class QuestionForm extends Component{
           <div>
             <div className="panel panel-default">
               <div className="panel-heading">
-                <h1 className="panel-title">{`${this.actionWord()} Question`}</h1>
+                <h2 className="panel-title">{`${this.actionWord()} Question`}</h2>
               </div>
               <div className="panel-body">
                 <div className="row">

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -29,7 +29,7 @@ export default class ResponseSetDetails extends Component {
         <div className="showpage_header_container no-print">
           <ul className="list-inline">
             <li className="showpage_button"><span className="fa fa-arrow-left fa-2x" aria-hidden="true" onClick={hashHistory.goBack}></span></li>
-            <li className="showpage_title">Response Set Details {responseSet.status === 'draft' && <text>[DRAFT]</text>}</li>
+            <li className="showpage_title"><h1>Response Set Details {responseSet.status === 'draft' && <text>[DRAFT]</text>}</h1></li>
           </ul>
         </div>
         {this.historyBar(responseSet)}
@@ -41,12 +41,13 @@ export default class ResponseSetDetails extends Component {
   historyBar(responseSet) {
     return (
       <div className="col-md-3 nopadding no-print">
-        <div className="showpage_sidenav_subtitle">
+        <h2 className="showpage_sidenav_subtitle">
+          <text className="sr-only">Version History Navigation Links</text>
           <ul className="list-inline">
             <li className="subtitle_icon"><span className="fa fa-history" aria-hidden="true"></span></li>
             <li className="subtitle">History</li>
           </ul>
-        </div>
+        </h2>
         <VersionInfo versionable={responseSet} versionableType='ResponseSet' />
       </div>
     );
@@ -97,7 +98,7 @@ export default class ResponseSetDetails extends Component {
           <p className="maincontent-item-info">Version: {responseSet.version} - Author: {responseSet.createdBy && responseSet.createdBy.email} </p>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">Details</h1>
+              <h2 className="panel-title">Details</h2>
             </div>
             <div className="box-content">
               <strong>Description: </strong>
@@ -132,7 +133,7 @@ export default class ResponseSetDetails extends Component {
           </div>
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">Responses</h1>
+              <h2 className="panel-title">Responses</h2>
             </div>
             <div className="box-content">
             <CodedSetTable items={responseSet.responses} itemName={'Response'} />
@@ -141,7 +142,7 @@ export default class ResponseSetDetails extends Component {
           {this.props.questions && this.props.questions.length > 0 &&
             <div className="basic-c-box panel-default">
               <div className="panel-heading">
-                <h1 className="panel-title">Linked Questions</h1>
+                <h2 className="panel-title">Linked Questions</h2>
               </div>
               <div className="box-content">
                 <QuestionList questions={_.keyBy(this.props.questions, 'id')} routes={Routes} />

--- a/webpack/components/ResponseSetForm.js
+++ b/webpack/components/ResponseSetForm.js
@@ -140,7 +140,7 @@ export default class ResponseSetForm extends Component {
         <div>
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">{`${this.actionWord()} Response Set`}</h1>
+              <h2 className="panel-title">{`${this.actionWord()} Response Set`}</h2>
             </div>
             <div className="panel-body">
                 <div className="row">

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -68,14 +68,14 @@ export default class SearchResult extends Component {
       return(
         <li className="result-analytics-item">
           <span className="fa fa-check-square-o fa-lg item-status-published" aria-hidden="true"></span>
-          <p className="item-description">published</p>
+          <p className="item-description"><text className="sr-only">Item visibility status: </text>published</p>
         </li>
       );
     } else if (status === 'draft') {
       return(
         <li className="result-analytics-item">
           <span className="fa fa-pencil fa-lg item-status-draft" aria-hidden="true"></span>
-          <p className="item-description">draft</p>
+          <p className="item-description"><text className="sr-only">Item visibility status: </text>draft</p>
         </li>
       );
     }
@@ -98,8 +98,8 @@ export default class SearchResult extends Component {
   programsInfo(result) {
     return (
       <li className="result-analytics-item">
-        <span className="item-value">{result.surveillancePrograms.length}</span>
-        <p className="item-description">programs</p>
+        <span className="item-value"><text className="sr-only">Item program usage count: </text>{result.surveillancePrograms.length}</span>
+        <p className="item-description" aria-hidden="true">programs</p>
       </li>
     );
   }
@@ -107,8 +107,8 @@ export default class SearchResult extends Component {
   systemsInfo(result) {
     return (
       <li className="result-analytics-item">
-        <span className="item-value">{result.surveillanceSystems.length}</span>
-        <p className="item-description">systems</p>
+        <span className="item-value"><text className="sr-only">Item system usage count: </text>{result.surveillanceSystems.length}</span>
+        <p className="item-description" aria-hidden="true">systems</p>
       </li>
     );
   }
@@ -126,9 +126,9 @@ export default class SearchResult extends Component {
     if(result.responseType && result.responseType.name && result.responseType.name !== 'Choice' && result.responseType.name !== 'Open Choice') {
       return (<li><i className="fa fa-comments" aria-hidden="true"></i>Response Type: {result.responseType.name}</li>);
     } else if (result.responseSets && result.responseSets.length === 1) {
-      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Set</a></li>);
+      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about </text>Linked Response Set</a></li>);
     } else {
-      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>);
+      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about </text>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>);
     }
   }
 
@@ -136,27 +136,27 @@ export default class SearchResult extends Component {
     switch(type) {
       case 'question':
         return (
-          <ul className="list-inline result-linked-number result-linked-item associated__responseset">
+          <ul className="list-inline result-linked-number result-linked-item associated__responseset" aria-label="Additional Question details.">
             {this.questionCollapsable(result)}
           </ul>
         );
       case 'response_set':
         return (
-          <ul className="list-inline result-linked-number result-linked-item associated__question">
-            {result.codes && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-rs`}><i className="fa fa-bars" aria-hidden="true"></i>Responses: {result.codes && result.codes.length}</a></li>}
+          <ul className="list-inline result-linked-number result-linked-item associated__question" aria-label="Additional Response Set details.">
+            {result.codes && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-rs`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about linked </text>Responses: {result.codes && result.codes.length}</a></li>}
           </ul>
         );
       case 'form':
       case 'survey_form':
         return (
-          <ul className="list-inline result-linked-number result-linked-item associated__question">
-            <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-${type}`}><i className="fa fa-bars" aria-hidden="true"></i>Questions: {result.questions && result.questions.length}</a></li>
+          <ul className="list-inline result-linked-number result-linked-item associated__question" aria-label="Additional Form details.">
+            <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-${type}`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about linked </text>Questions: {result.questions && result.questions.length}</a></li>
           </ul>
         );
       case 'form_question':
         if(result.responseType && result.responseType.name && result.responseType.name !== 'Choice' && result.responseType.name !== 'Open Choice') {
           return (
-            <ul className="list-inline result-linked-number result-linked-item associated__responseset">
+            <ul className="list-inline result-linked-number result-linked-item associated__responseset" aria-label="Additional Question details.">
               <li><i className="fa fa-comments" aria-hidden="true"></i>Response Type: {result.responseType.name}</li>
             </ul>
           );
@@ -175,15 +175,15 @@ export default class SearchResult extends Component {
                   })}
                   <option aria-label=' '></option>
                 </select>
-                <a title="Search Response Sets to Link" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Search Response Sets</span></a>
+                <a title="Search Response Sets to Link" id="search-response-sets" href="#" onClick={this.props.showResponseSetSearch}><i className="fa fa-search fa-2x response-set-search"></i><span className="sr-only">Click link to search all Response Sets and select one to link to this question</span></a>
               </div>
             </div>
           );
         }
       case 'survey':
         return (
-          <ul className="list-inline result-linked-number result-linked-item associated__form">
-            <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-survey`}><i className="fa fa-bars" aria-hidden="true"></i>Forms: {result.forms && result.forms.length}</a></li>
+          <ul className="list-inline result-linked-number result-linked-item associated__form" aria-label="Additional Survey details.">
+            <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-survey`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about linked </text>Forms: {result.forms && result.forms.length}</a></li>
           </ul>
         );
     }
@@ -195,6 +195,7 @@ export default class SearchResult extends Component {
         return (
           <div className="panel-collapse panel-details collapse" id={`collapse-${result.id}-question`}>
             <div className="panel-body">
+              <text className="sr-only">List of links to response sets on this question:</text>
               {result.responseSets && result.responseSets.length > 0 &&
                 result.responseSets.map((rs, i) => {
                   return(
@@ -211,6 +212,7 @@ export default class SearchResult extends Component {
         return (
           <div className="panel-collapse panel-details collapse" id={`collapse-${result.id}-rs`}>
             <div className="panel-body">
+              <text className="sr-only">List of responses on this response set:</text>
               {result.codes && result.codes.length > 0 &&
                 result.codes.map((c, i) => {
                   return(
@@ -228,6 +230,7 @@ export default class SearchResult extends Component {
         return (
           <div className="panel-collapse panel-details collapse" id={`collapse-${result.id}-${type}`}>
             <div className="panel-body">
+              <text className="sr-only">List of links and names of questions linked to this form:</text>
               {result.questions && result.questions.length > 0 &&
                 result.questions.map((q, i) => {
                   return(
@@ -246,6 +249,7 @@ export default class SearchResult extends Component {
         return (
           <div className="panel-collapse panel-details collapse" id={`collapse-${result.id}-survey`}>
             <div className="panel-body">
+              <text className="sr-only">List of links and names of forms on this survey</text>
               {result.forms && result.forms.length > 0 &&
                 result.forms.map((f, i) => {
                   return(
@@ -267,18 +271,18 @@ export default class SearchResult extends Component {
       <div className="u-result-group">
         <div className="u-result" id={`${type}_id_${result.id}`}>
           <div className="u-result-container">
-            <ul className="u-result-content">
+            <ul className="u-result-content" aria-label="Summary of a search result or linked object's attributes.">
               <li className="u-result-content-item">
                 <div className={`u-result-details result__${type}`}>
                   <div className="result">
                     <ul className="list-inline result-type-wrapper">
                       <li className="result-type-icon"><span className={`fa ${iconMap[type]} fa-2x`} aria-hidden="true"></span></li>
-                      <li className="result-name">
+                      <li className="result-name" aria-label="Item Name.">
                         {this.resultName(result, highlight, type, isEditPage)}
                       </li>
                     </ul>
                   </div>
-                  <div className="result-description">
+                  <div className="result-description" aria-label="Item Description.">
                     {highlight && highlight.description ? <text dangerouslySetInnerHTML={{__html: highlight.description[0]}} /> : result.description}
                   </div>
                   <div className="result-analytics">
@@ -287,9 +291,9 @@ export default class SearchResult extends Component {
                       {result.surveillanceSystems && this.systemsInfo(result)}
                       {result.status && this.resultStatus(result.status)}
                       <li className={`result-timestamp pull-right ${this.props.programVar && 'list-program-var'}`}>
-                      <p>{ moment(result.createdAt,'').format('MMMM Do, YYYY') }</p>
-                      <p>version {result.version && result.version} | {type}</p>
-                      {this.props.programVar && (<p>{this.props.programVar}</p>)}
+                        <p>{ moment(result.createdAt,'').format('MMMM Do, YYYY') }</p>
+                        <p><text className="sr-only">Item Version Number: </text>version {result.version && result.version} | <text className="sr-only">Item type: </text>{type}</p>
+                        {this.props.programVar && (<p><text className="sr-only">Item program defined Variable: </text>{this.props.programVar}</p>)}
                       </li>
                     </ul>
                   </div>
@@ -297,6 +301,7 @@ export default class SearchResult extends Component {
                 <div className="result-linked-details">
                   {this.linkedDetails(result, type)}
                 </div>
+                {(type !== "form_question") && this.detailsPanel(result, type)}
               </li>
               <li className="u-result-content-item result-nav" role="navigation" aria-label="Search Result">
                 <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i><span className="sr-only">View Item Details</span></Link></div>
@@ -316,7 +321,6 @@ export default class SearchResult extends Component {
               </li>
             </ul>
           </div>
-          {(type !== "form_question") && this.detailsPanel(result, type)}
         </div>
       </div>
     );

--- a/webpack/components/shared_show/ProgramsAndSystems.js
+++ b/webpack/components/shared_show/ProgramsAndSystems.js
@@ -5,7 +5,7 @@ class ProgramsAndSystems extends Component {
   render() {
     return (<div className="basic-c-box panel-default">
       <div className="panel-heading">
-        <h1 className="panel-title">Usage</h1>
+        <h2 className="panel-title">Usage</h2>
       </div>
       <div className="box-content">
         <strong>Surveillance Programs: </strong> {this.surveillancePrograms(this.props.item)}

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -15,12 +15,13 @@ class SurveyShow extends Component{
   historyBar() {
     return (
       <div className="col-md-3 nopadding no-print">
-        <div className="showpage_sidenav_subtitle">
+        <h2 className="showpage_sidenav_subtitle">
+          <text className="sr-only">Version History Navigation Links</text>
           <ul className="list-inline">
             <li className="subtitle_icon"><span className="fa fa-history" aria-hidden="true"></span></li>
             <li className="subtitle">History</li>
           </ul>
-        </div>
+        </h2>
         <VersionInfo versionable={this.props.survey} versionableType='survey' />
       </div>
     );
@@ -72,7 +73,7 @@ class SurveyShow extends Component{
           {this.surveillanceSystem()}
           <div className="basic-c-box panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">Description</h1>
+              <h2 className="panel-title">Description</h2>
             </div>
             <div className="box-content">
               {this.props.survey.description}
@@ -93,7 +94,7 @@ class SurveyShow extends Component{
           {this.props.forms.map((f,i ) =>
             <div  key={i} className="basic-c-box panel-default survey-form">
               <div className="panel-heading">
-                <h1 className="panel-title"><Link to={`/forms/${f.id}`}>{ f.name }</Link></h1>
+                <h2 className="panel-title"><Link to={`/forms/${f.id}`}>{ f.name }</Link></h2>
               </div>
               <div className="box-content">
                 <ul>
@@ -137,7 +138,7 @@ class SurveyShow extends Component{
         <div className="showpage_header_container no-print">
           <ul className="list-inline">
             <li className="showpage_button"><span className="fa fa-arrow-left fa-2x" aria-hidden="true" onClick={hashHistory.goBack}></span></li>
-            <li className="showpage_title">Survey Details {survey.status === 'draft' && <text>[DRAFT]</text>}</li>
+            <li className="showpage_title"><h1>Survey Details {survey.status === 'draft' && <text>[DRAFT]</text>}</h1></li>
           </ul>
         </div>
         {this.historyBar()}

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -56,6 +56,7 @@ class App extends Component {
   render() {
     return (
       <div>
+        <text className="sr-only">Welcome to the vocabulary service. Click the next link to skip navigation and go to main content.</text>
         <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 location={this.props.location}

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -299,21 +299,25 @@ class DashboardContainer extends Component {
       <div className="recent-items-panel">
         <div className="recent-items-heading">My Stuff</div>
         <div className="recent-items-body">
-          <ul className="list-group">
+          <ul className="list-group" name="Filter by stuff you own">
             <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'question' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('question', true)}>
               <div className="recent-items-icon"><i className="fa fa-tasks recent-items-icon" aria-hidden="true"></i></div>
+              <text className="sr-only">Click button to filter search results by questions you own.</text>
               <div className="recent-items-value">{this.props.myQuestionCount} Questions</div>
             </button>
             <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'response_set' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('response_set', true)}>
               <div className="recent-items-icon"><i className="fa fa-list recent-items-icon" aria-hidden="true"></i></div>
+              <text className="sr-only">Click button to filter search results by response sets you own.</text>
               <div className="recent-items-value">{this.props.myResponseSetCount} Response Sets</div>
             </button>
             <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'form' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('form', true)}>
               <div className="recent-items-icon"><i className="fa fa-list-alt recent-items-icon" aria-hidden="true"></i></div>
+              <text className="sr-only">Click button to filter search results by forms you own.</text>
               <div className="recent-items-value">{this.props.myFormCount} Forms</div>
             </button>
             <button tabIndex="4" className={"recent-item-list btn" + (searchType === 'survey' && myStuffFilter ? " analytics-active-item" : "")} onClick={() => this.selectType('survey', true)}>
               <div className="recent-items-icon"><i className="fa fa-clipboard recent-items-icon" aria-hidden="true"></i></div>
+              <text className="sr-only">Click button to filter search results by surveys you own.</text>
               <div className="recent-items-value">{this.props.mySurveyCount} Surveys</div>
             </button>
             {myStuffFilter ? (<a href="#" className="col-md-12 text-center" onClick={() => this.selectType(searchType)}>Clear My Stuff Filter</a>) : (

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -125,7 +125,7 @@ class FormsEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Form </h1>
+              <h2 className="panel-title">{_.capitalize(this.props.params.action)} Form </h2>
             </div>
             <div className="panel-body">
               <div className="col-md-5">

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -77,10 +77,10 @@ let SignedInMenu = ({currentUser, location, notifications, notificationCount}) =
           <li className="dropdown">
             <a href="#" id="create-menu" tabIndex="2" className="dropdown-toggle cdc-navbar-item create-menu" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-clipboard item-navbar-icon" aria-hidden="true"></i>Create<span className="caret"></span></a>
             <ul className="cdc-nav-dropdown">
-              <li className="nav-dropdown-item"><Link to="/questions/new" tabIndex="2">Questions</Link></li>
-              <li className="nav-dropdown-item"><Link to="/responseSets/new" tabIndex="2">Response Sets</Link></li>
-              <li className="nav-dropdown-item"><Link to="/forms/new" tabIndex="2">Forms</Link></li>
-              <li className="nav-dropdown-item"><Link to="/surveys/new" tabIndex="2">Surveys</Link></li>
+              <li className="nav-dropdown-item"><Link to="/questions/new" tabIndex="2"><text className="sr-only">Click link to create new </text>Questions</Link></li>
+              <li className="nav-dropdown-item"><Link to="/responseSets/new" tabIndex="2"><text className="sr-only">Click link to create new </text>Response Sets</Link></li>
+              <li className="nav-dropdown-item"><Link to="/forms/new" tabIndex="2"><text className="sr-only">Click link to create new </text>Forms</Link></li>
+              <li className="nav-dropdown-item"><Link to="/surveys/new" tabIndex="2"><text className="sr-only">Click link to create new </text>Surveys</Link></li>
             </ul>
           </li>
         }
@@ -90,7 +90,7 @@ let SignedInMenu = ({currentUser, location, notifications, notificationCount}) =
             <NotificationMenu notifications={notifications} />
           ) : (
             <ul className="cdc-nav-dropdown">
-              <ul><li className="notification-menu-item">No new notifications</li></ul>
+              <li className="notification-menu-item">No new notifications</li>
             </ul>
           )}
         </li>

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -159,12 +159,13 @@ class Help extends Component {
     return(
       <div className="tab-pane active" id="instructions" role="tabpanel">
         <div className="col-md-3 how-to-nav no-print">
-          <div className="showpage_sidenav_subtitle">
+          <h2 className="showpage_sidenav_subtitle">
+            <text className="sr-only">Version History Navigation Links</text>
             <ul className="list-inline">
               <li className="subtitle_icon"><span className="fa fa-graduation-cap " aria-hidden="true"></span></li>
               <li className="subtitle">Learn How To:</li>
             </ul>
-          </div>
+          </h2>
           <ul className="nav nav-pills nav-stacked">
             <li className="active" role="presentation"><a data-toggle="tab" href="#general">General</a></li>
             <li role="presentation"><a data-toggle="tab" href="#manage-account">Manage Account</a></li>
@@ -215,7 +216,7 @@ class Help extends Component {
             <div className="showpage_header_container no-print">
               <ul className="list-inline">
                 <li className="showpage_button"><span className="fa fa-question-circle fa-2x" aria-hidden="true"></span></li>
-                <li className="showpage_title">Help</li>
+                <li className="showpage_title"><h1>Help</h1></li>
               </ul>
             </div>
             <div className="container col-md-12">

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -94,7 +94,7 @@ class SurveyEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h1>
+              <h2 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h2>
             </div>
             <div className="panel-body">
               <div className="col-md-5">

--- a/webpack/styles/layouts/_showpageheader.scss
+++ b/webpack/styles/layouts/_showpageheader.scss
@@ -9,6 +9,11 @@
   color: $cdc-blue;
   margin-left: 8px;
   font-weight: bold;
+  h1 {
+    margin: 0px;
+    font-size: 24px;
+    font-weight: bold;
+  }
 }
 
 .showpage-comments-title {
@@ -29,9 +34,10 @@
 
 .showpage_sidenav_subtitle {
   font-size: 18px;
+  margin: 0px;
   color: $dark-gray;
   height: 42px;
-  padding-top: 6px;
+  padding-top: 12px;
   padding-left: 8px;
   border-bottom: 1px solid $light-gray;
 }

--- a/webpack/styles/navigation/_nav.scss
+++ b/webpack/styles/navigation/_nav.scss
@@ -111,6 +111,7 @@ a.cdc-brand:focus {
 
 .cdc-nav-dropdown {
   @extend .dropdown-menu;
+  min-width: 200px;
   ul {
     list-style-type: none;
     padding-left: 0px;


### PR DESCRIPTION
Added a lot of screen reader helper text and aria-labels to better organize items on details pages and dashboard. For details see descriptions of the following SDP items:
SDP-565,566,568,569,570,571

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
