### PR TITLE
[SDP-574]Form edit screen reader

### DIFF
--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -208,7 +208,7 @@ class FormEdit extends Component {
                          event.preventDefault();
                          this.props.reorderQuestion(form, i, 1);
                        }}>
-                    <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move question up on form</span>
+                    <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">{`Move Up question ${this.props.questions[q.questionId].content} on form`}</span>
                   </button>
                 </div>
                 <div className="row form-question-controls">
@@ -217,7 +217,7 @@ class FormEdit extends Component {
                          event.preventDefault();
                          this.props.reorderQuestion(form, i, -1);
                        }}>
-                    <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move question down on form</span>
+                    <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">{`Move down question ${this.props.questions[q.questionId].content} on form`}</span>
                   </button>
                 </div>
                 <div className="row form-question-controls">
@@ -226,7 +226,7 @@ class FormEdit extends Component {
                          event.preventDefault();
                          this.props.removeQuestion(form, i);
                        }}>
-                    <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove question from selected question list</span>
+                    <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">{`Remove question ${this.props.questions[q.questionId].content} on form`}</span>
                   </button>
                 </div>
               </div>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -164,7 +164,7 @@ export default class SearchResult extends Component {
           var selectedResponseSet = this.props.responseSets.find((r) => r.id == this.props.selectedResponseSetId);
           return (
             <div className="panel-body panel-body-form-question">
-              <span className="selected-response-set">Response Set: {(selectedResponseSet && selectedResponseSet.name) || '(None)'}</span>
+              <span className="selected-response-set" aria-label={`Selected Response set for Question ${result.content}`}>Response Set: {(selectedResponseSet && selectedResponseSet.name) || '(None)'}</span>
               <div className="form-question-group">
                 <input aria-label="Question IDs" type="hidden" name="question_ids[]" value={this.props.result.id}/>
                 <select className="response-set-select" aria-label="Response Set IDs" name='responseSet' data-question={this.props.index} value={this.props.selectedResponseSetId || ''} onChange={this.props.handleResponseSetChange}>

--- a/webpack/components/SurveyFormList.js
+++ b/webpack/components/SurveyFormList.js
@@ -34,7 +34,7 @@ class SurveyFormList extends Component {
                                      event.preventDefault();
                                      this.props.reorderForm(survey, i, 1);
                                    }}>
-                                <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">Move form up on survey</span>
+                                <i title="Move Up" className="fa fa fa-arrow-up"></i><span className="sr-only">{`Move Up form ${f.name} on survey`}</span>
                               </button>
                           </div>
                           <div className="row survey-form-controls">
@@ -43,7 +43,7 @@ class SurveyFormList extends Component {
                                      event.preventDefault();
                                      this.props.reorderForm(survey, i, -1);
                                    }}>
-                                <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">Move form down on survey</span>
+                                <i className="fa fa fa-arrow-down" title="Move Down"></i><span className="sr-only">{`Move down form ${f.name} on survey`}</span>
                               </button>
                           </div>
                           <div className="row survey-form-controls">
@@ -52,7 +52,7 @@ class SurveyFormList extends Component {
                                      event.preventDefault();
                                      this.props.removeForm(survey, i);
                                    }}>
-                                <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">Remove form from selected form list</span>
+                                <i className="fa fa fa-trash" title="Remove"></i><span className="sr-only">{`Delete form ${f.name} on survey`}</span>
                               </button>
                           </div>
                         </div>

--- a/webpack/containers/QuestionEditContainer.js
+++ b/webpack/containers/QuestionEditContainer.js
@@ -16,6 +16,12 @@ class QuestionEditContainer extends Component {
     if(this.props.params.qId){
       this.props.fetchQuestion(this.props.params.qId);
     }
+    this.action = this.props.params.action;
+    this.id = this.props.params.qId;
+    if (this.props.params.action === undefined) {
+      this.action = 'new';
+    }
+
     this.props.fetchQuestionTypes();
     this.props.fetchResponseTypes();
     this.props.fetchResponseSets();
@@ -55,15 +61,10 @@ class QuestionEditContainer extends Component {
         <div>Loading...</div>
       );
     }
-    let action = this.props.params.action;
-    let id = this.props.params.qId;
-    if (action === undefined) {
-      action = 'new';
-    }
     return (
       <div className="container">
-        <QuestionForm id={id}
-                      action={action}
+        <QuestionForm id={this.id}
+                      action={this.action}
                       question={this.props.question}
                       draftSubmitter={this.props.saveDraftQuestion}
                       questionSubmitter={this.props.saveQuestion}


### PR DESCRIPTION
Screen reader now reads selected response set on added questions in form edit page.
Buttons for selected questions are now more descriptive for screen reader

- [na] Added unit tests for new functionality
- [na] Passed all unit tests using `rails test` with 90%+ coverage
- [na] Added cucumber tests for any new functionality
- [na] Passed all cucumber tests using `bundle exec cucumber`
- [na] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
