### PR TITLE
[SDP-567] Fix modals in screen readers

### DIFF
--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -86,7 +86,7 @@ class DashboardSearch extends Component {
 
   advSearchModal() {
     return (
-      <Modal show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch}>
+      <Modal show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch} aria-label="Advanced Search Filters">
         <Modal.Header closeButton bsStyle='search'>
           <Modal.Title>Advanced Search Filters</Modal.Title>
         </Modal.Header>

--- a/webpack/components/ModalDialog.js
+++ b/webpack/components/ModalDialog.js
@@ -12,7 +12,7 @@ class ModalDialog extends Component{
   render(){
     return(
       <div className="static-modal" id='saveModal'>
-        <Modal show={this.props.show} onHide={this.props.cancelButtonAction} role="dialog">
+        <Modal show={this.props.show} onHide={this.props.cancelButtonAction} role="dialog" aria-label={this.props.title}>
           <Modal.Header>
             <Modal.Title>{this.props.warning && <span className={'fa fa-exclamation-circle'}></span>} {this.props.title}</Modal.Title>
           </Modal.Header>

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -78,7 +78,7 @@ class QuestionItem extends Component {
 
   searchModal() {
     return (
-      <Modal show={this.state.showSearchModal} onHide={this.hideResponseSetSearch}>
+      <Modal show={this.state.showSearchModal} onHide={this.hideResponseSetSearch} aria-label="Search Response Sets">
         <Modal.Header closeButton bsStyle='search'>
           <Modal.Title>Search Response Sets</Modal.Title>
         </Modal.Header>

--- a/webpack/components/ResponseSetModal.js
+++ b/webpack/components/ResponseSetModal.js
@@ -26,7 +26,7 @@ class ResponseSetModal extends Component {
 
   render() {
     return (
-      <Modal bsStyle='response-set' show={this.props.show} onHide={this.props.closeModal}>
+      <Modal bsStyle='response-set' show={this.props.show} onHide={this.props.closeModal} aria-label="New Response Set">
         <Modal.Header closeButton bsStyle='response-set'>
           <Modal.Title>New Response Set</Modal.Title>
         </Modal.Header>

--- a/webpack/components/accounts/LogInModal.js
+++ b/webpack/components/accounts/LogInModal.js
@@ -9,7 +9,7 @@ export default class LogInModal extends Component {
 
   render() {
     return (
-      <Modal show={this.props.show} onHide={this.props.closer}>
+      <Modal show={this.props.show} onHide={this.props.closer} aria-label="Sign In">
         <Modal.Header closeButton>
           <Modal.Title>Sign In</Modal.Title>
         </Modal.Header>

--- a/webpack/components/accounts/ProfileEditor.js
+++ b/webpack/components/accounts/ProfileEditor.js
@@ -12,7 +12,7 @@ import { surveillanceProgramsProps } from '../../prop-types/surveillance_program
 export default class ProfileEditor extends Component {
   render() {
     return (
-      <Modal show={this.props.show} onHide={this.props.closer}>
+      <Modal show={this.props.show} onHide={this.props.closer} aria-label={this.title()}>
         <Modal.Header closeButton>
           <Modal.Title>{this.title()}</Modal.Title>
         </Modal.Header>

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -132,7 +132,7 @@ class CodedSetTableEditContainer extends Component {
 
   conceptModal(){
     return (
-      <Modal show={this.state.showConceptModal} onHide={this.hideCodeSearch} >
+      <Modal show={this.state.showConceptModal} onHide={this.hideCodeSearch} aria-label="Search Codes">
         <Modal.Header closeButton bsStyle='concept'>
           <Modal.Title>Search Codes</Modal.Title>
         </Modal.Header>

--- a/webpack/containers/QuestionModalContainer.js
+++ b/webpack/containers/QuestionModalContainer.js
@@ -154,7 +154,7 @@ class QuestionModalContainer extends Component {
       );
     }
     return (
-      <Modal bsStyle='question' show={this.props.showModal} onHide={this.closeQuestionModal} >
+      <Modal bsStyle='question' show={this.props.showModal} onHide={this.closeQuestionModal} aria-label="New Question">
         <Modal.Header closeButton bsStyle='question'>
           <Modal.Title>New Question</Modal.Title>
         </Modal.Header>


### PR DESCRIPTION
When modals open, they will now state their title in a screen reader as
opposed to reading all of the text in the modal.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
