### PR TITLE
[SDP-523] Make Login configurable

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,5 +45,8 @@
   },
   "plugins": [
     "react"
-  ]
+  ],
+  "globals": {
+        OPIDC_HOST: true
+    }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -47,6 +47,6 @@
     "react"
   ],
   "globals": {
-        OPIDC_HOST: true
+        OIDC_LOGIN_URL: true
     }
 }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   rolify
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  if Settings.openid_connect.client_options.host
+  if Rails.env.production?
     devise :database_authenticatable,
            :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:openid_connect]
   else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,8 +2,14 @@ class User < ApplicationRecord
   rolify
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:openid_connect]
+  if Settings.openid_connect.client_options.host
+    devise :database_authenticatable,
+           :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:openid_connect]
+  else
+    devise :database_authenticatable, :registerable,
+           :recoverable, :rememberable, :trackable, :validatable, :omniauthable, omniauth_providers: [:openid_connect]
+
+  end
 
   validates :email, uniqueness: true, case_sensitive: false
   has_many :authentications

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations',
                                     sessions: 'sessions',
                                     omniauth_callbacks: 'users/omniauth_callbacks' }
+
   resources :authentications
 
   get '/publishers' => 'publishers#index'

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -90,7 +90,8 @@ if (production) {
       sourceMap: false
     }),
     new webpack.DefinePlugin({
-      'process.env': { NODE_ENV: JSON.stringify('production') }
+      'process.env': { NODE_ENV: JSON.stringify('production') },
+      OPIDC_HOST: JSON.stringify(process.env.OPIDC_HOST || '')
     }),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin()

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -75,7 +75,11 @@ var config = {
     new webpack.ProvidePlugin({
       $: "jquery",
       jQuery: "jquery"
-    })]
+    }),
+    new webpack.DefinePlugin({
+      OPIDC_HOST: JSON.stringify(process.env.OPIDC_HOST || '')
+    }),
+  ]
 };
 
 if (production) {

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -77,7 +77,7 @@ var config = {
       jQuery: "jquery"
     }),
     new webpack.DefinePlugin({
-      OPIDC_HOST: JSON.stringify(process.env.OPIDC_HOST || '')
+      OIDC_LOGIN_URL: JSON.stringify(process.env.OIDC_LOGIN_URL || '')
     }),
   ]
 };
@@ -91,7 +91,7 @@ if (production) {
     }),
     new webpack.DefinePlugin({
       'process.env': { NODE_ENV: JSON.stringify('production') },
-      OPIDC_HOST: JSON.stringify(process.env.OPIDC_HOST || '')
+      OIDC_LOGIN_URL: JSON.stringify(process.env.OIDC_LOGIN_URL || '')
     }),
     new webpack.optimize.DedupePlugin(),
     new webpack.optimize.OccurenceOrderPlugin()

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -59,7 +59,7 @@ class App extends Component {
         <text className="sr-only">Welcome to the vocabulary service. Click the next link to skip navigation and go to main content.</text>
         <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
-				openIdServer={OPIDC_HOST}
+				openIdLoginUrl={OIDC_LOGIN_URL}
                 location={this.props.location}
                 logInOpener={() => this.openLogInModal()}
                 signUpOpener={() => this.openSignUpModal()}

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -59,6 +59,7 @@ class App extends Component {
         <text className="sr-only">Welcome to the vocabulary service. Click the next link to skip navigation and go to main content.</text>
         <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
         <Header currentUser={this.props.currentUser}
+				openIdServer={OPIDC_HOST}
                 location={this.props.location}
                 logInOpener={() => this.openLogInModal()}
                 signUpOpener={() => this.openSignUpModal()}

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -19,7 +19,7 @@ let LoginMenu = ({openIdServer, logInOpener, signUpOpener, currentUser}) => {
             <a href={openIdServer}>Login</a>
           </li>
         </ul>
-      )
+      );
     }
     return (
       <ul className="nav navbar-nav">
@@ -45,7 +45,8 @@ let LoginMenu = ({openIdServer, logInOpener, signUpOpener, currentUser}) => {
 LoginMenu.propTypes = {
   currentUser: currentUserProps,
   logInOpener: PropTypes.func.isRequired,
-  signUpOpener: PropTypes.func.isRequired
+  signUpOpener: PropTypes.func.isRequired,
+  openIdServer: PropTypes.string
 };
 
 let ContentMenu = ({settingsOpener, currentUser}) => {

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -9,14 +9,14 @@ import NotificationDropdown from '../components/NotificationDropdown';
 import NotificationMenu from '../components/NotificationMenu';
 import { fetchNotifications } from '../actions/notification_actions';
 
-let LoginMenu = ({openIdServer, logInOpener, signUpOpener, currentUser}) => {
+let LoginMenu = ({openIdLoginUrl, logInOpener, signUpOpener, currentUser}) => {
   let loggedIn = ! _.isEmpty(currentUser);
   if(!loggedIn) {
-    if(openIdServer != '') {
+    if(openIdLoginUrl != '') {
       return (
         <ul className="nav navbar-nav">
           <li className="log-in-link">
-            <a tabIndex="2" href={openIdServer}>Login</a>
+            <a tabIndex="2" href={openIdLoginUrl}>Login</a>
           </li>
         </ul>
       );
@@ -46,7 +46,7 @@ LoginMenu.propTypes = {
   currentUser: currentUserProps,
   logInOpener: PropTypes.func.isRequired,
   signUpOpener: PropTypes.func.isRequired,
-  openIdServer: PropTypes.string
+  openIdLoginUrl: PropTypes.string
 };
 
 let ContentMenu = ({settingsOpener, currentUser}) => {
@@ -212,7 +212,7 @@ class Header extends Component {
           <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul className="cdc-nav cdc-utlt-navbar-nav navbar-right">
               <ContentMenu currentUser={this.props.currentUser} settingsOpener={this.props.settingsOpener} />
-              <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener} openIdServer={this.props.openIdServer}/>
+              <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener} openIdLoginUrl={this.props.openIdLoginUrl}/>
               <li className="dropdown">
                 <a href="#" id = "help-menu" tabIndex="2" className="dropdown-toggle cdc-navbar-item help-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-question-circle utlt-navbar-icon" aria-hidden="true"></i>Help<span className="caret"></span></a>
                 <ul className="cdc-nav-dropdown">
@@ -256,7 +256,7 @@ Header.propTypes = {
   logInOpener: PropTypes.func.isRequired,
   signUpOpener: PropTypes.func.isRequired,
   settingsOpener: PropTypes.func.isRequired,
-  openIdServer: PropTypes.string
+  openIdLoginUrl: PropTypes.string
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -9,9 +9,18 @@ import NotificationDropdown from '../components/NotificationDropdown';
 import NotificationMenu from '../components/NotificationMenu';
 import { fetchNotifications } from '../actions/notification_actions';
 
-let LoginMenu = ({logInOpener, signUpOpener, currentUser}) => {
+let LoginMenu = ({openIdServer, logInOpener, signUpOpener, currentUser}) => {
   let loggedIn = ! _.isEmpty(currentUser);
   if(!loggedIn) {
+    if(openIdServer != '') {
+      return (
+        <ul className="nav navbar-nav">
+          <li className="log-in-link">
+            <a href={openIdServer}>Login</a>
+          </li>
+        </ul>
+      )
+    }
     return (
       <ul className="nav navbar-nav">
         <li className="log-in-link">
@@ -202,7 +211,7 @@ class Header extends Component {
           <div className="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul className="cdc-nav cdc-utlt-navbar-nav navbar-right">
               <ContentMenu currentUser={this.props.currentUser} settingsOpener={this.props.settingsOpener} />
-              <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener}/>
+              <LoginMenu currentUser={this.props.currentUser} logInOpener={this.props.logInOpener} signUpOpener={this.props.signUpOpener} openIdServer={this.props.openIdServer}/>
               <li className="dropdown">
                 <a href="#" id = "help-menu" tabIndex="2" className="dropdown-toggle cdc-navbar-item help-link" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false"><i className="fa fa-question-circle utlt-navbar-icon" aria-hidden="true"></i>Help<span className="caret"></span></a>
                 <ul className="cdc-nav-dropdown">
@@ -246,6 +255,7 @@ Header.propTypes = {
   logInOpener: PropTypes.func.isRequired,
   signUpOpener: PropTypes.func.isRequired,
   settingsOpener: PropTypes.func.isRequired,
+  openIdServer: PropTypes.string
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -16,7 +16,7 @@ let LoginMenu = ({openIdServer, logInOpener, signUpOpener, currentUser}) => {
       return (
         <ul className="nav navbar-nav">
           <li className="log-in-link">
-            <a href={openIdServer}>Login</a>
+            <a tabIndex="2" href={openIdServer}>Login</a>
           </li>
         </ul>
       );


### PR DESCRIPTION
Login will now use the React login/account creation if the environment variable OPIDC_HOST isn't set. If it is it will redirect the user to the OPIDC_HOST url to do that workflow. 

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop


Tested by setting the environment variable OPIDC_HOST to "http://localhost:3000" to test that it created a link to that URL. Without that variable set it should run as normal. 