### PR TITLE
[SDP-562]Fixing advanced filtering in IE

### DIFF
--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -4,6 +4,7 @@ import { Modal, Button } from 'react-bootstrap';
 import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
 import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 import _ from 'lodash';
+import $ from 'jquery';
 
 class DashboardSearch extends Component {
   constructor(props){
@@ -44,8 +45,8 @@ class DashboardSearch extends Component {
   }
 
   selectFilters(e, filterType) {
-    let newState = {};
-    newState[filterType] = _.values(e.target.selectedOptions).map((opt) => opt.value);
+    var newState = {};
+    newState[filterType] = $(e.target).val().map((opt) => parseInt(opt));
     this.props.setFiltersParent(newState);
     return this.setState(newState);
   }

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -178,7 +178,6 @@ class FormEdit extends Component {
           <div className="response-set-header">
             <div className="col-md-5 response-set-label"><span><b>Questions</b></span></div>
             <div className="col-md-7 response-set-label">
-              <span className="right"><b>Response Sets</b></span>
               <Button onClick={this.props.showResponseSetModal} bsStyle="primary">Add New Response Set</Button>
             </div>
           </div>


### PR DESCRIPTION
Advanced search filter by programs and systems now works in IE (selectedOptions not supported in IE).

- [na] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [na] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [na] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
