### PR TITLE
[SDP 516] External Resources not loaded over HTTPS

### DIFF
--- a/webpack/styles/base/_fonts.scss
+++ b/webpack/styles/base/_fonts.scss
@@ -1,2 +1,2 @@
-@import url('http://fonts.googleapis.com/css?family=Montserrat');
+@import url('https://fonts.googleapis.com/css?family=Montserrat');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,800,300italic,400italic,600italic,700italic,800italic,700');


### PR DESCRIPTION
Moved Montserrat font to load over HTTPS. 

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
