### PR TITLE
[SDP-606] Fixes bug with creating a question on form edit

### DIFF
--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -30,8 +30,8 @@ class FormsEditContainer extends Component {
       this.props.params.formId = 0;
       this.props.params.action = 'new';
     }
-    this.state = {selectedFormSaver: selectedFormSaver, showQuestionModal: false, showResponseSetModal: false};
-    this.closeQuestionModal = this.closeQuestionModal.bind(this);
+    this.state = {selectedFormSaver: selectedFormSaver, showQuestionModal: false,
+      showResponseSetModal: false, searchResultsInUse: false};
     this.handleSaveQuestionSuccess = this.handleSaveQuestionSuccess.bind(this);
   }
 
@@ -95,10 +95,6 @@ class FormsEditContainer extends Component {
     }
   }
 
-  closeQuestionModal(){
-    this.setState({showQuestionModal: false});
-  }
-
   handleSaveQuestionSuccess(successResponse){
     this.setState({showQuestionModal: false});
     this.props.fetchQuestion(successResponse.data.id);
@@ -116,7 +112,7 @@ class FormsEditContainer extends Component {
         <QuestionModalContainer route ={this.props.route}
                                 router={this.props.router}
                                 showModal={this.state.showQuestionModal}
-                                closeQuestionModal ={()=>this.setState({showQuestionModal: false})}
+                                closeQuestionModal={()=>this.setState({showQuestionModal: false, searchResultsInUse: false})}
                                 handleSaveQuestionSuccess={this.handleSaveQuestionSuccess} />
         <ResponseSetModal show={this.state.showResponseSetModal}
                           router={this.props.router}
@@ -130,9 +126,9 @@ class FormsEditContainer extends Component {
             <div className="panel-body">
               <div className="col-md-5">
                 <div className="row add-question">
-                  <Button tabIndex="4" onClick={()=>this.setState({showQuestionModal: true})} bsStyle="primary">Add New Question</Button>
+                  <Button tabIndex="4" onClick={()=>this.setState({showQuestionModal: true, searchResultsInUse: true})} bsStyle="primary">Add New Question</Button>
                 </div>
-                <QuestionSearchContainer form={this.props.form} />
+                <QuestionSearchContainer form={this.props.form} searchResultsInUse={this.state.searchResultsInUse}/>
               </div>
               <FormEdit ref ='form'
                         form={this.props.form}

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -29,13 +29,10 @@ class QuestionSearchContainer extends Component {
     this.search('');
   }
 
-  componentDidUpdate(_prevProps, prevState) {
-    if(prevState != this.state && prevState.page === this.state.page) {
-      let searchType = this.state.searchType;
+  componentDidUpdate(prevProps, prevState) {
+    if((prevState != this.state && prevState.page === this.state.page) ||
+       (prevProps.searchResultsInUse !== this.props.searchResultsInUse && !this.props.searchResultsInUse)) {
       let searchTerms = this.state.searchTerms;
-      if(searchType === '') {
-        searchType = null;
-      }
       if(searchTerms === ''){
         searchTerms = null;
       }
@@ -48,11 +45,13 @@ class QuestionSearchContainer extends Component {
   }
 
   search(searchTerms, progFilters, sysFilters) {
-    if(searchTerms === ''){
-      searchTerms = null;
+    if (!this.props.searchResultsInUse) {
+      if(searchTerms === ''){
+        searchTerms = null;
+      }
+      this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
+      this.props.fetchSearchResults(searchTerms, 'question', progFilters, sysFilters);
     }
-    this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
-    this.props.fetchSearchResults(searchTerms, 'question', progFilters, sysFilters);
   }
 
   loadMore() {
@@ -114,7 +113,8 @@ QuestionSearchContainer.propTypes = {
   currentUser: currentUserProps,
   searchResults: PropTypes.object,
   surveillanceSystems: surveillanceSystemsProps,
-  surveillancePrograms: surveillanceProgramsProps
+  surveillancePrograms: surveillanceProgramsProps,
+  searchResultsInUse: PropTypes.bool.isRequired
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(QuestionSearchContainer);


### PR DESCRIPTION
If you clicked the "New Question" button on the form edit page, it would
load QuestionModalContainer, which would cause ResponseSetDragWidget to
mount, which triggers a search for response sets. This replaces
searchResults key in the redux store with response sets. After you close
the modal, the old response set search results would hang around and
cause odd behavior.

This fix lets QuestionSearchContainer know that the search results are
in use. When the search results are no longer in use, the
QuestionSearchContainer is notified via props and will execute a search
again to replace searchResults in the redux store with questions.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
