### PR TITLE
[SDP-606] Rework how search results are stored in redux

### DIFF
--- a/features/export_forms.feature
+++ b/features/export_forms.feature
@@ -10,6 +10,7 @@ Feature: Export Forms
     And I click on the create "Forms" dropdown item
     And I fill in the "form-name" field with "Test Form"
     And I fill in the "search" field with "What"
+    And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
     And I use the response set search modal to select "Gender Partial"
@@ -24,6 +25,7 @@ Feature: Export Forms
     And I click on the create "Forms" dropdown item
     And I fill in the "form-name" field with "Test Form"
     And I fill in the "search" field with "What"
+    And I set search filter to "question"
     And I click on the "search-btn" button
     And I use the question search to select "What is your gender?"
     And I use the response set search modal to select "Gender Partial"

--- a/features/step_definitions/form_steps.rb
+++ b/features/step_definitions/form_steps.rb
@@ -12,7 +12,7 @@ When(/^I use the response set search modal to select "([^"]*)"$/) do |name|
   Elastictest.fake_rs_search_results
   page.find('a', id: 'search-response-sets').click
   sleep 1
-  page.all('a', id: "select-#{name}")[1].click
+  page.all('a', id: "select-#{name}")[0].click
 end
 
 When(/^I go to the list of Forms$/) do

--- a/test/frontend/reducers/test_search_results.js
+++ b/test/frontend/reducers/test_search_results.js
@@ -10,10 +10,10 @@ describe('searchResults reducer', () => {
     const searchResultData = {data: { hits: { hits: [{id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"},
                                  {id: 2, name: "People", description: "A list of people", oid: "2.16.840.1.113883.3.1502.3.2"},
                                  {id: 3, name: "Things", description: "A list of things", oid: "2.16.840.1.113883.3.1502.3.3"}]}}};
-    const action = {type: FETCH_SEARCH_RESULTS_FULFILLED, payload: searchResultData};
+    const action = {type: FETCH_SEARCH_RESULTS_FULFILLED, payload: searchResultData, meta: {context: 'TEST_CONTEXT'}};
     const startState = {};
     const nextState = searchResults(startState, action);
-    expect(nextState.hits.hits.length).to.equal(3);
+    expect(nextState.TEST_CONTEXT.hits.hits.length).to.equal(3);
   });
 
 });

--- a/webpack/actions/search_results_actions.js
+++ b/webpack/actions/search_results_actions.js
@@ -5,9 +5,10 @@ import {
   FETCH_MORE_SEARCH_RESULTS
 } from './types';
 
-export function fetchSearchResults(searchTerms=null, type=null, programFilter=[], systemFilter=[], myStuffFilter=false) {
+export function fetchSearchResults(context, searchTerms=null, type=null, programFilter=[], systemFilter=[], myStuffFilter=false) {
   return {
     type: FETCH_SEARCH_RESULTS,
+    meta: {context: context},
     payload: axios.get(routes.elasticsearchPath(), {
       headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'},
       params: { type: type, search: searchTerms, programs: programFilter, systems: systemFilter, mystuff: myStuffFilter }
@@ -15,9 +16,10 @@ export function fetchSearchResults(searchTerms=null, type=null, programFilter=[]
   };
 }
 
-export function fetchMoreSearchResults(searchTerms=null, type=null, page, programFilter=[], systemFilter=[], myStuffFilter=false) {
+export function fetchMoreSearchResults(context, searchTerms=null, type=null, page, programFilter=[], systemFilter=[], myStuffFilter=false) {
   return {
     type: FETCH_MORE_SEARCH_RESULTS,
+    meta: {context: context},
     payload: axios.get(routes.elasticsearchPath(), {
       headers: {'Accept': 'application/json', 'X-Key-Inflection': 'camel'},
       params: { type: type, search: searchTerms, page: page, programs: programFilter, systems: systemFilter, mystuff: myStuffFilter }

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -12,6 +12,8 @@ import DashboardSearch from './DashboardSearch';
 import SearchResultList from '../components/SearchResultList';
 import { Modal, Button } from 'react-bootstrap';
 
+const QUESTION_ITEM_CONTEXT = 'QUESTION_ITEM_CONTEXT';
+
 class QuestionItem extends Component {
   constructor(props) {
     super(props);
@@ -38,7 +40,7 @@ class QuestionItem extends Component {
       if(searchTerms === ''){
         searchTerms = null;
       }
-      this.props.fetchSearchResults(searchTerms, 'response_set', this.state.progFilters, this.state.sysFilters);
+      this.props.fetchSearchResults(QUESTION_ITEM_CONTEXT, searchTerms, 'response_set', this.state.progFilters, this.state.sysFilters);
     }
   }
 
@@ -73,7 +75,7 @@ class QuestionItem extends Component {
       searchTerms = null;
     }
     this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
-    this.props.fetchSearchResults(searchTerms, searchType, progFilters, sysFilters);
+    this.props.fetchSearchResults(QUESTION_ITEM_CONTEXT, searchTerms, searchType, progFilters, sysFilters);
   }
 
   searchModal() {
@@ -146,7 +148,7 @@ class QuestionItem extends Component {
                         showResponseSetSearch={(e) => {
                           e.preventDefault();
                           this.showResponseSetSearch();
-                          this.props.fetchSearchResults('', 'response_set');
+                          this.props.fetchSearchResults(QUESTION_ITEM_CONTEXT, '', 'response_set');
                         }}
                         showProgramVarModal={(e) => {
                           e.preventDefault();
@@ -162,7 +164,7 @@ class QuestionItem extends Component {
 
 function mapStateToProps(state) {
   return {
-    searchResults: state.searchResults,
+    searchResults: state.searchResults[QUESTION_ITEM_CONTEXT] || {},
     surveillanceSystems: state.surveillanceSystems,
     surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -60,6 +60,8 @@ DropTarget.propTypes = {
 
 let DroppableTarget = Droppable(DropTarget, onDrop);
 
+const DRAG_WIDGET_CONTEXT = 'DRAG_WIDGET_CONTEXT';
+
 class ResponseSetDragWidget extends Component {
   constructor(props){
     super(props);
@@ -81,7 +83,7 @@ class ResponseSetDragWidget extends Component {
       searchTerms = null;
     }
     this.setState({searchTerms: searchTerms});
-    this.props.fetchSearchResults(searchTerms, 'response_set');
+    this.props.fetchSearchResults(DRAG_WIDGET_CONTEXT, searchTerms, 'response_set');
   }
 
   loadMore() {
@@ -90,7 +92,7 @@ class ResponseSetDragWidget extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, 'response_set', tempState);
+    this.props.fetchMoreSearchResults(DRAG_WIDGET_CONTEXT, searchTerms, 'response_set', tempState);
     this.setState({page: tempState});
   }
 
@@ -129,7 +131,7 @@ class ResponseSetDragWidget extends Component {
 
 function mapStateToProps(state) {
   return {
-    searchResults: state.searchResults,
+    searchResults: state.searchResults[DRAG_WIDGET_CONTEXT] || {},
     currentUser: state.currentUser
   };
 }

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -13,6 +13,9 @@ import { surveillanceProgramsProps } from '../prop-types/surveillance_program_pr
 import { signUp } from '../actions/current_user_actions';
 import _ from 'lodash';
 
+const DASHBOARD_CONTEXT = 'DASHBOARD_CONTEXT';
+const NO_SEARCH_RESULTS = {};
+
 class DashboardContainer extends Component {
   constructor(props){
     super(props);
@@ -48,7 +51,7 @@ class DashboardContainer extends Component {
       if(searchTerms === ''){
         searchTerms = null;
       }
-      this.props.fetchSearchResults(searchTerms, searchType, this.state.progFilters, this.state.sysFilters, this.state.myStuffFilter);
+      this.props.fetchSearchResults(DASHBOARD_CONTEXT, searchTerms, searchType, this.state.progFilters, this.state.sysFilters, this.state.myStuffFilter);
     }
 
     if(prevProps != this.props) {
@@ -204,7 +207,7 @@ class DashboardContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, searchType, tempState,
+    this.props.fetchMoreSearchResults(DASHBOARD_CONTEXT, searchTerms, searchType, tempState,
                                       this.state.progFilters,
                                       this.state.sysFilters,
                                       this.state.myStuffFilter);
@@ -224,7 +227,7 @@ class DashboardContainer extends Component {
       searchTerms = null;
     }
     this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
-    this.props.fetchSearchResults(searchTerms, searchType, progFilters, sysFilters, this.state.myStuffFilter);
+    this.props.fetchSearchResults(DASHBOARD_CONTEXT, searchTerms, searchType, progFilters, sysFilters, this.state.myStuffFilter);
   }
 
   selectType(searchType, myStuffToggle=false) {
@@ -254,7 +257,7 @@ class DashboardContainer extends Component {
     if(searchType === '') {
       searchType = null;
     }
-    this.props.fetchSearchResults(searchTerms, searchType, this.state.progFilters, this.state.sysFilters, myStuffFilter);
+    this.props.fetchSearchResults(DASHBOARD_CONTEXT, searchTerms, searchType, this.state.progFilters, this.state.sysFilters, myStuffFilter);
   }
 
   analyticsGroup(searchType) {
@@ -340,7 +343,7 @@ function mapStateToProps(state) {
     myQuestionCount: state.stats.myQuestionCount,
     myResponseSetCount: state.stats.myResponseSetCount,
     mySurveyCount: state.stats.mySurveyCount,
-    searchResults: state.searchResults,
+    searchResults: state.searchResults[DASHBOARD_CONTEXT] || NO_SEARCH_RESULTS,
     surveillanceSystems: state.surveillanceSystems,
     surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -11,6 +11,8 @@ import currentUserProps from "../prop-types/current_user_props";
 import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
 import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 
+const FORM_SEARCH_CONTEXT = 'FORM_SEARCH_CONTEXT';
+
 class FormSearchContainer extends Component {
   constructor(props) {
     super(props);
@@ -47,7 +49,7 @@ class FormSearchContainer extends Component {
       if(searchTerms === ''){
         searchTerms = null;
       }
-      this.props.fetchSearchResults(searchTerms, 'form', this.state.progFilters, this.state.sysFilters);
+      this.props.fetchSearchResults(FORM_SEARCH_CONTEXT, searchTerms, 'form', this.state.progFilters, this.state.sysFilters);
     }
   }
 
@@ -60,7 +62,7 @@ class FormSearchContainer extends Component {
       searchTerms = null;
     }
     this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
-    this.props.fetchSearchResults(searchTerms, 'form', progFilters, sysFilters);
+    this.props.fetchSearchResults(FORM_SEARCH_CONTEXT, searchTerms, 'form', progFilters, sysFilters);
   }
 
   loadMore() {
@@ -103,7 +105,7 @@ class FormSearchContainer extends Component {
 
 function mapStateToProps(state) {
   return {
-    searchResults: state.searchResults,
+    searchResults: state.searchResults[FORM_SEARCH_CONTEXT] || {},
     surveillanceSystems: state.surveillanceSystems,
     surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -11,6 +11,8 @@ import currentUserProps from "../prop-types/current_user_props";
 import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
 import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 
+const QUESTION_SEARCH_CONTEXT = 'QUESTION_SEARCH_CONTEXT';
+
 class QuestionSearchContainer extends Component {
   constructor(props) {
     super(props);
@@ -39,7 +41,7 @@ class QuestionSearchContainer extends Component {
       if(searchTerms === ''){
         searchTerms = null;
       }
-      this.props.fetchSearchResults(searchTerms, 'question', this.state.progFilters, this.state.sysFilters);
+      this.props.fetchSearchResults(QUESTION_SEARCH_CONTEXT, searchTerms, 'question', this.state.progFilters, this.state.sysFilters);
     }
   }
 
@@ -52,7 +54,7 @@ class QuestionSearchContainer extends Component {
       searchTerms = null;
     }
     this.setState({searchTerms: searchTerms, progFilters: progFilters, sysFilters: sysFilters});
-    this.props.fetchSearchResults(searchTerms, 'question', progFilters, sysFilters);
+    this.props.fetchSearchResults(QUESTION_SEARCH_CONTEXT, searchTerms, 'question', progFilters, sysFilters);
   }
 
   loadMore() {
@@ -61,7 +63,7 @@ class QuestionSearchContainer extends Component {
     if(this.state.searchTerms === '') {
       searchTerms = null;
     }
-    this.props.fetchMoreSearchResults(searchTerms, 'question', tempState,
+    this.props.fetchMoreSearchResults(QUESTION_SEARCH_CONTEXT, searchTerms, 'question', tempState,
                                       this.state.progFilters,
                                       this.state.sysFilters);
     this.setState({page: tempState});
@@ -95,7 +97,7 @@ class QuestionSearchContainer extends Component {
 
 function mapStateToProps(state) {
   return {
-    searchResults: state.searchResults,
+    searchResults: state.searchResults[QUESTION_SEARCH_CONTEXT] || {},
     surveillanceSystems: state.surveillanceSystems,
     surveillancePrograms: state.surveillancePrograms,
     currentUser: state.currentUser

--- a/webpack/reducers/search_results_reducer.js
+++ b/webpack/reducers/search_results_reducer.js
@@ -6,10 +6,12 @@ import {
 export default function searchResults(state = {}, action) {
   switch (action.type) {
     case FETCH_SEARCH_RESULTS_FULFILLED:
-      return action.payload.data;
+      const stateClone = Object.assign({}, state);
+      stateClone[action.meta.context] = action.payload.data;
+      return stateClone;
     case FETCH_MORE_SEARCH_RESULTS_FULFILLED:
       const newStateClone = Object.assign({}, state);
-      const searchResultsArray = newStateClone.hits.hits;
+      const searchResultsArray = newStateClone[action.meta.context].hits.hits;
       searchResultsArray.push.apply(searchResultsArray, action.payload.data.hits.hits);
       return newStateClone;
     default:


### PR DESCRIPTION
Previously, all fetched search results were stored under a single key in
the redux store. That meant if there were multiple components capable of
search being displayed at the same time, all of their search results
would change in unison. This is not desired, as the components are often
searching for different items, like questions vs. response sets.

This change creates a context for each components' search results. That
way, they don't mess with each other.

This also cleans up some tests, where cucumber steps were written
anticipating the previous behavior.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop