### PR TITLE
[SDP-591] Form container cleanup

### DIFF
--- a/app/views/forms/_form.json.jbuilder
+++ b/app/views/forms/_form.json.jbuilder
@@ -9,3 +9,9 @@ json.questions form.questions do |q|
                 :version, :version_independent_id, \
                 :other_allowed
 end
+
+json.response_sets form.response_sets.uniq do |rs|
+  json.extract! rs, :id, :name, :description, :oid, \
+                :status, :version, :version_independent_id, \
+                :created_at, :updated_at, :published_by_id, :source
+end

--- a/test/frontend/middleware/test_questions_from_search_result.js
+++ b/test/frontend/middleware/test_questions_from_search_result.js
@@ -1,0 +1,38 @@
+import { expect } from '../test_helper';
+import MockStore from '../mock_store';
+
+import questionsFromSearchResult from '../../../webpack/middleware/questions_from_search_result';
+
+import {
+  FETCH_SEARCH_RESULTS_FULFILLED,
+  FETCH_QUESTION_FULFILLED
+} from '../../../webpack/actions/types';
+
+describe('questionsFromSearchResult middleware', () => {
+  let store;
+  let action;
+
+  const results = {hits: {hits: [
+    {Type: 'question', Source: {id:1, name: "M?", questionTypeId: 1, createdBy: {id: 1}}},
+    {Type: 'question', Source: {id:2, name: "F?", questionTypeId: 1, createdBy: {id: 1}}}
+  ]}};
+
+  const next = () => {
+    1 + 1; //do nothing
+  };
+
+  beforeEach(() => {
+    store = new MockStore();
+    action = {
+      type: FETCH_SEARCH_RESULTS_FULFILLED,
+      payload: {data: results}
+    };
+  });
+
+  it('will dispatch actions for questions in forms', () => {
+    questionsFromSearchResult(store)(next)(action);
+    let dispatchedAction = store.dispatchedActions.find((a) => a.type === FETCH_QUESTION_FULFILLED);
+    expect(dispatchedAction).to.exist;
+    expect(dispatchedAction.payload.data.content).to.equal('M?');
+  });
+});

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -2,8 +2,6 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchForm, publishForm, deleteForm } from '../actions/form_actions';
-import { fetchQuestions } from '../actions/questions_actions';
-import { fetchResponseSets } from '../actions/response_set_actions';
 import { setSteps } from '../actions/tutorial_actions';
 import FormShow from '../components/FormShow';
 import { formProps } from '../prop-types/form_props';
@@ -16,7 +14,6 @@ import { publishersProps } from "../prop-types/publisher_props";
 class FormShowContainer extends Component {
   componentWillMount() {
     this.props.fetchForm(this.props.params.formId);
-    this.props.fetchResponseSets();
   }
 
   componentDidMount() {
@@ -50,8 +47,6 @@ class FormShowContainer extends Component {
   componentDidUpdate(prevProps) {
     if(prevProps.params.formId != this.props.params.formId){
       this.props.fetchForm(this.props.params.formId);
-      this.props.fetchQuestions();
-      this.props.fetchResponseSets();
     }
   }
 
@@ -115,7 +110,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({setSteps, fetchForm, fetchQuestions, fetchResponseSets, publishForm, deleteForm}, dispatch);
+  return bindActionCreators({setSteps, fetchForm, publishForm, deleteForm}, dispatch);
 }
 
 FormShowContainer.propTypes = {
@@ -127,8 +122,6 @@ FormShowContainer.propTypes = {
   currentUser: currentUserProps,
   setSteps: PropTypes.func,
   fetchForm: PropTypes.func,
-  fetchQuestions: PropTypes.func,
-  fetchResponseSets: PropTypes.func,
   deleteForm:  PropTypes.func,
   publishForm: PropTypes.func,
   publishers: publishersProps

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -35,11 +35,6 @@ class FormsEditContainer extends Component {
     this.handleSaveQuestionSuccess = this.handleSaveQuestionSuccess.bind(this);
   }
 
-  componentWillMount() {
-    this.props.fetchQuestions();
-    this.props.fetchResponseSets();
-  }
-
   componentDidMount() {
     this.props.setSteps([
       {

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -3,10 +3,9 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { setSteps } from '../actions/tutorial_actions';
 import { fetchForm, saveForm, newForm, saveDraftForm } from '../actions/form_actions';
-import { addQuestion, removeQuestion, reorderQuestion, fetchQuestion, fetchQuestions } from '../actions/questions_actions';
+import { addQuestion, removeQuestion, reorderQuestion, fetchQuestion } from '../actions/questions_actions';
 import FormEdit from '../components/FormEdit';
 import ResponseSetModal from '../components/ResponseSetModal';
-import { fetchResponseSets }   from '../actions/response_set_actions';
 import QuestionModalContainer  from './QuestionModalContainer';
 import QuestionSearchContainer from './QuestionSearchContainer';
 import { formProps } from '../prop-types/form_props';
@@ -149,7 +148,7 @@ class FormsEditContainer extends Component {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({setSteps, fetchResponseSets, addQuestion, fetchQuestions, fetchQuestion,
+  return bindActionCreators({setSteps, addQuestion, fetchQuestion,
     newForm, fetchForm, removeQuestion, reorderQuestion,
     saveForm, saveDraftForm}, dispatch);
 }
@@ -176,10 +175,8 @@ FormsEditContainer.propTypes = {
   addQuestion: PropTypes.func,
   saveDraftForm: PropTypes.func,
   fetchQuestion: PropTypes.func,
-  fetchQuestions: PropTypes.func,
   removeQuestion: PropTypes.func,
-  reorderQuestion: PropTypes.func,
-  fetchResponseSets: PropTypes.func
+  reorderQuestion: PropTypes.func
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FormsEditContainer);

--- a/webpack/middleware/questions_from_search_result.js
+++ b/webpack/middleware/questions_from_search_result.js
@@ -1,0 +1,29 @@
+import {
+  FETCH_SEARCH_RESULTS_FULFILLED,
+  FETCH_QUESTION_FULFILLED
+} from '../actions/types';
+
+import { dispatchIfNotPresent } from './store_helper';
+
+const questionsFromSearchResult = store => next => action => {
+  if(store == null) return;
+  switch (action.type) {
+    case FETCH_SEARCH_RESULTS_FULFILLED:
+      const results = action.payload.data.hits.hits;
+      results.forEach((hit) => {
+        if (hit.Type === 'question') {
+          const question = {id: hit.Source.id, content: hit.Source.name,
+            createdAt: hit.Source.createdAt, createdById: hit.Source.createdBy.id,
+            description: hit.Source.description, updatedAt: hit.Source.updatedAt,
+            status: hit.Source.status, responseType: hit.Source.responseType,
+            version: hit.Source.version, versionIndependentId: hit.Source.versionIndependentId
+          };
+          dispatchIfNotPresent(store, 'questions', question, FETCH_QUESTION_FULFILLED);
+        }
+      });
+  }
+
+  next(action);
+};
+
+export default questionsFromSearchResult;

--- a/webpack/middleware/response_sets_from_forms.js
+++ b/webpack/middleware/response_sets_from_forms.js
@@ -1,0 +1,22 @@
+import {
+  FETCH_RESPONSE_SET_FULFILLED,
+  FETCH_FORM_FULFILLED,
+} from '../actions/types';
+
+import { dispatchIfNotPresent } from './store_helper';
+
+const responseSetsFromForms = store => next => action => {
+  switch (action.type) {
+    case FETCH_FORM_FULFILLED:
+      if(action.payload.data.responseSets){
+        action.payload.data.responseSets.forEach((rs) => {
+          dispatchIfNotPresent(store, 'responseSets', rs, FETCH_RESPONSE_SET_FULFILLED);
+        });
+        action.payload.data.responseSets = action.payload.data.responseSets.map((rs) => rs.id);
+      }
+  }
+
+  next(action);
+};
+
+export default responseSetsFromForms;

--- a/webpack/store/configure_store.js
+++ b/webpack/store/configure_store.js
@@ -3,6 +3,7 @@ import promiseMiddleware from 'redux-promise-middleware';
 import createLogger from 'redux-logger';
 
 import questionsFromResponseSets from '../middleware/questions_from_response_sets';
+import questionsFromSearchResult from '../middleware/questions_from_search_result';
 import questionsFromForms from '../middleware/questions_from_forms';
 import responseSetsFromQuestions from '../middleware/response_sets_from_questions';
 import responseSetsFromForms from '../middleware/response_sets_from_forms';
@@ -23,6 +24,7 @@ export default function configureStore(initialState) {
     unauthenticatedResponse,
     questionsFromResponseSets,
     questionsFromForms,
+    questionsFromSearchResult,
     responseSetsFromQuestions,
     parentFromResponseSets,
     parentFromQuestions,

--- a/webpack/store/configure_store.js
+++ b/webpack/store/configure_store.js
@@ -5,6 +5,7 @@ import createLogger from 'redux-logger';
 import questionsFromResponseSets from '../middleware/questions_from_response_sets';
 import questionsFromForms from '../middleware/questions_from_forms';
 import responseSetsFromQuestions from '../middleware/response_sets_from_questions';
+import responseSetsFromForms from '../middleware/response_sets_from_forms';
 import parentFromResponseSets from '../middleware/parent_from_response_sets';
 import parentFromQuestions from '../middleware/parent_from_questions';
 import parentFromForms from '../middleware/parent_from_forms';
@@ -28,7 +29,8 @@ export default function configureStore(initialState) {
     parentFromForms,
     parentFromSurveys,
     responseTypesFromQuestions,
-    questionTypesFromQuestions
+    questionTypesFromQuestions,
+    responseSetsFromForms
   );
 
   // Sets up http://zalmoxisus.github.io/redux-devtools-extension/


### PR DESCRIPTION
Removes fetching all questions and fetching all response sets from the form containers. Retrieval of the information is now done through augmenting the individual form object that is returned by fetchForm and middleware to pull the information from the form or search results.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop

