### PR TITLE
[SDP-610,613,614,617] Help docs updates

### DIFF
--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -11,18 +11,18 @@ export default class CodedSetTable extends Component {
         <caption>Information about associated {this.props.itemName}s:</caption>
         <thead>
           <tr>
+            <th scope="col" id="display-name-column">Display Name</th>
             <th scope="col" id="code-column">{this.props.itemName} Code</th>
             <th scope="col" id="code-system-column">Code System</th>
-            <th scope="col" id="display-name-column">Display Name</th>
           </tr>
         </thead>
         <tbody>
           {this.props.items.map((item,i) => {
             return (
               <tr key={i}>
+                <td headers="display-name-column">{item.displayName}</td>
                 <td headers="code-column">{item.value}</td>
                 <td headers="code-system-column">{item.codeSystem}</td>
-                <td headers="display-name-column">{item.displayName}</td>
               </tr>
             );
           })}

--- a/webpack/components/accounts/LogInModal.js
+++ b/webpack/components/accounts/LogInModal.js
@@ -15,7 +15,7 @@ export default class LogInModal extends Component {
         </Modal.Header>
         <Modal.Body>
           <form>
-            <div hidden={!this.state.invalidCredentials}>Invalid Credentials</div>
+            <div className="alert alert-danger" hidden={!this.state.invalidCredentials}><strong>Invalid Credentials!</strong> Please check the information you entered and try again.</div>
             <div>
               <label className="control-label" htmlFor="email">Email</label>
               <input autoFocus="autofocus" className="form-control input-lg" type="email" value={this.state.email} name="email" id="email" onChange={this.handleChange('email')}/>

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -189,9 +189,9 @@ class CodedSetTableEditContainer extends Component {
                 this.showCodeSearch();
               }}><i className="fa fa-search fa-2x"></i><span className="sr-only">Open Search Modal</span></a>
             </td>
-            <th scope="col" id="code-column">{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
-            <th scope="col" id="code-system-column">Code System</th>
-            <th scope="col" id="display-name-column">Display Name</th>
+            <th scope="col" className="display-name-column" id="display-name-column">Display Name</th>
+            <th scope="col" className="code-column" id="code-column">{this.state.childName[0].toUpperCase() + this.state.childName.slice(1)} Code</th>
+            <th scope="col" className="code-system-column" id="code-system-column">Code System</th>
             <td>
               <a title="Add Row" href="#" onClick={(e) => {
                 e.preventDefault();
@@ -209,6 +209,10 @@ class CodedSetTableEditContainer extends Component {
               <tr key={i}>
                 <td>
                 </td>
+                <td headers="display-name-column">
+                  <label className="hidden" htmlFor={`displayName_${i}`}>Display name</label>
+                  <input className="input-format" type="text" value={r.displayName} name="displayName" id={`displayName_${i}`} onChange={this.handleChange(i, 'displayName')}/>
+                </td>
                 <td headers="code-column">
                   <label className="hidden" htmlFor={`value_${i}`}>Value</label>
                   <input className="input-format" type="text" value={r.value} name="value" id={`value_${i}`} onChange={this.handleChange(i, 'value')}/>
@@ -216,10 +220,6 @@ class CodedSetTableEditContainer extends Component {
                 <td headers="code-system-column">
                   <label className="hidden" htmlFor={`codeSystem_${i}`}>Code system</label>
                   <input className="input-format" type="text" value={r.codeSystem}  name="codeSystem" id={`codeSystem_${i}`} onChange={this.handleChange(i, 'codeSystem')}/>
-                </td>
-                <td headers="display-name-column">
-                  <label className="hidden" htmlFor={`displayName_${i}`}>Display name</label>
-                  <input className="input-format" type="text" value={r.displayName} name="displayName" id={`displayName_${i}`} onChange={this.handleChange(i, 'displayName')}/>
                 </td>
                 <td>
                   <a href="#" title="Delete this row" aria-label={`remove_row_number_${i+1}`} id={`remove_${i}`} onClick={(e) => {

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -61,7 +61,7 @@ class DashboardContainer extends Component {
       let steps = [
         {
           title: 'Help',
-          text: 'Click next to see a step by step walkthrough for using this page.',
+          text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
           selector: '.help-link',
           position: 'bottom',
         },

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -20,7 +20,7 @@ class FormShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },
@@ -32,7 +32,7 @@ class FormShowContainer extends Component {
       },
       {
         title: 'View Details',
-        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions.',
+        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a class="tutorial-link" href="#help">Help Documentation (linked here).</a>',
         selector: '.maincontent',
         position: 'left',
       },

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -38,7 +38,7 @@ class FormsEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -12,7 +12,7 @@ class Help extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -94,6 +94,17 @@ class Help extends Component {
         <li>In most places the full details page can be seen by clicking the name / title link of the item.</li>
         <li>On the edit pages the name link is disabled but you can click the eyeball icon on any of the widgets to navigate to the details page.</li>
         </ul>
+        <h2 className="help-section-subtitle" id="exporting">Exporting</h2>
+        <p>On the view pages for forms there is an action button that exports the current form to Redcap. To export a form and use it in redcap execute the following steps (exact wording may differ slightly based on your version of Redcap):</p>
+        <ul>
+        <li>Click on the 'Export to Redcap' button on the Vocabulary service form details page (this will save a .xml file to the folder your browser directs downloads)</li>
+        <li>Open up Redcap</li>
+        <li>Choose the option to create a new project</li>
+        <li>On the project creation page follow the on screen instructions to add a name and various attributes to the new projects</li>
+        <li>Look for an option titled something similar to "Start project from scratch or begin with a template?" and choose the "Upload a REDCap project XML file" option</li>
+        <li>Click the "Choose File" button to select the .xml file you downloaded from the vocabulary service, it will be in the folder your browser downloads content into (usually the 'Downloads' folder)</li>
+        <li>After selecting the .xml file to import and filling out the rest of the fields, click on the Create Project or Start Project button at the bottom of the page</li>
+        </ul>
       </div>
     );
   }
@@ -170,7 +181,7 @@ class Help extends Component {
             <li className="active" role="presentation"><a data-toggle="tab" href="#general">General</a></li>
             <li role="presentation"><a data-toggle="tab" href="#manage-account">Manage Account</a></li>
             <li role="presentation"><a data-toggle="tab" href="#search">Search</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#view">View Content</a></li>
+            <li role="presentation"><a data-toggle="tab" href="#view">View and Export Content</a></li>
             <li role="presentation"><a data-toggle="tab" href="#create-and-edit">Create and Edit Content</a></li>
             <li role="presentation"><a data-toggle="tab" href="#comment">Comment on Content</a></li>
           </ul>

--- a/webpack/containers/QuestionEditContainer.js
+++ b/webpack/containers/QuestionEditContainer.js
@@ -46,6 +46,24 @@ class QuestionEditContainer extends Component {
         position: 'right',
       },
       {
+        title: 'Create Your Own Tags',
+        text: 'Alternatively, you can manually add a tag - click the plus sign to add additional tags to associate with the question.',
+        selector: '.fa-plus',
+        position: 'top',
+      },
+      {
+        title: 'Create Your Own Tags (Name)',
+        text: 'The Display Name field is what the user will see on the page.',
+        selector: '.display-name-column',
+        position: 'top',
+      },
+      {
+        title: 'Create Your Own Tags (Code)',
+        text: 'Optionally, you can enter a code and a code system for the tag you are adding if it belongs to an external system (such as LOINC or SNOWMED).',
+        selector: '.code-system-column',
+        position: 'top',
+      },
+      {
         title: 'Action Buttons',
         text: 'Click save to save a draft of the edited content.',
         selector: '.panel-footer',

--- a/webpack/containers/QuestionEditContainer.js
+++ b/webpack/containers/QuestionEditContainer.js
@@ -29,7 +29,7 @@ class QuestionEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -24,7 +24,7 @@ class QuestionShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },
@@ -36,7 +36,7 @@ class QuestionShowContainer extends Component {
       },
       {
         title: 'View Details',
-        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions.',
+        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a class="tutorial-link" href="#help">Help Documentation (linked here).</a>',
         selector: '.maincontent',
         position: 'left',
       },

--- a/webpack/containers/ResponseSetEditContainer.js
+++ b/webpack/containers/ResponseSetEditContainer.js
@@ -22,7 +22,7 @@ class ResponseSetEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/ResponseSetEditContainer.js
+++ b/webpack/containers/ResponseSetEditContainer.js
@@ -39,6 +39,24 @@ class ResponseSetEditContainer extends Component {
         position: 'right',
       },
       {
+        title: 'Create Your Own Responses',
+        text: 'Alternatively, you can manually add a response - click the plus sign to add additional responses to associate with the response set.',
+        selector: '.fa-plus',
+        position: 'top',
+      },
+      {
+        title: 'Create Your Own Responses (Name)',
+        text: 'The Display Name field is what the user will see on the page.',
+        selector: '.display-name-column',
+        position: 'top',
+      },
+      {
+        title: 'Create Your Own Responses (Code)',
+        text: 'Optionally, you can enter a code and a code system for the response you are adding if it belongs to an external system (such as LOINC or SNOWMED).',
+        selector: '.code-system-column',
+        position: 'top',
+      },
+      {
         title: 'Action Buttons',
         text: 'Click save to save a draft of the edited content.',
         selector: '.panel-footer',

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -24,7 +24,7 @@ class ResponseSetShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },
@@ -36,7 +36,7 @@ class ResponseSetShowContainer extends Component {
       },
       {
         title: 'View Details',
-        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions.',
+        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a class="tutorial-link" href="#help">Help Documentation (linked here).</a>',
         selector: '.maincontent',
         position: 'left',
       },

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -34,7 +34,7 @@ class SurveyEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/surveys/ShowContainer.js
+++ b/webpack/containers/surveys/ShowContainer.js
@@ -19,7 +19,7 @@ class SurveyShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page.',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
         selector: '.help-link',
         position: 'bottom',
       },
@@ -31,7 +31,7 @@ class SurveyShowContainer extends Component {
       },
       {
         title: 'View Details',
-        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions.',
+        text: 'See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a class="tutorial-link" href="#help">Help Documentation (linked here).</a>',
         selector: '.maincontent',
         position: 'left',
       },

--- a/webpack/styles/navigation/_nav.scss
+++ b/webpack/styles/navigation/_nav.scss
@@ -12,6 +12,10 @@
   }
 }
 
+a.tutorial-link {
+  color: $cdc-dark-blue !important;
+}
+
 a.cdc-brand:hover {
   color:white;
 }


### PR DESCRIPTION
Addresses the following bugs / updates:
* 610 - Notification of invalid credentials, now uses bootstrap alert to make improper login much more apparent
* 613 - Reorder display name, code, code system column on codedsetedittable, also added interactive help steps to the QuestionEdit and ResponseSetEdit pages to explain what the input columns are for
* 614 - Explain difference between edit and extend - inlining this into the actual step-by-step walkthrough was a bit dense looking so I tried to simplify it in two ways: 1) the first step on all pages now includes a link to the full documentation and says explicitly to look there for more detailed information. 2) The show page interactive tours now include a link to the help documentation and instructions as to what section to look for information about the action buttons. 
* 617 - XML export in redcap - added step by step instructions to Help Documentation on what to do with the exported XML, tested and grabbed a screenshot from rob confirming wording in redcap

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [just updating existing and tested functionality] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
