### PR TITLE
[SDP-615] Sorting code set tables by system, then code

### DIFF
--- a/test/frontend/components/coded_set_table_test.js
+++ b/test/frontend/components/coded_set_table_test.js
@@ -5,9 +5,9 @@ describe('CodedSetTable', () => {
   let component;
 
   beforeEach(() => {
-    const items = [{value: "Bravo", display: "Display Name 1", codeSystem: "Test system B"},
-                   {value: "Alpha", display: "Display Name 2", codeSystem: "Test system B"},
-                   {value: "Charlie", display: "Display Name 3", codeSystem: "Test system A"}];
+    const items = [{value: "Bravo", displayName: "Display Name 1", codeSystem: "Test system B"},
+                   {value: "Alpha", displayName: "Display Name 2", codeSystem: "Test system B"},
+                   {value: "Charlie", displayName: "Display Name 3", codeSystem: "Test system A"}];
     component = renderComponent(CodedSetTable, {items});
   });
 
@@ -16,8 +16,8 @@ describe('CodedSetTable', () => {
   });
 
   it('should create a list of vocab concepts in order', () => {
-    expect(component.find("tbody tr:nth-child(1) td:nth-child(1)")).to.have.text("Charlie");
-    expect(component.find("tbody tr:nth-child(2) td:nth-child(1)")).to.have.text("Alpha");
-    expect(component.find("tbody tr:nth-child(3) td:nth-child(1)")).to.have.text("Bravo");
+    expect(component.find("tbody tr:nth-child(1) td:nth-child(2)")).to.have.text("Charlie");
+    expect(component.find("tbody tr:nth-child(2) td:nth-child(2)")).to.have.text("Alpha");
+    expect(component.find("tbody tr:nth-child(3) td:nth-child(2)")).to.have.text("Bravo");
   });
 });

--- a/test/frontend/components/coded_set_table_test.js
+++ b/test/frontend/components/coded_set_table_test.js
@@ -5,13 +5,19 @@ describe('CodedSetTable', () => {
   let component;
 
   beforeEach(() => {
-    const items = [{code:"Code 1",display:" Display Name 1",system:"Test system 1"},
-                   {code:"Code 2",display:" Display Name 2",system:"Test system 2"},
-                   {code:"Code 3",display:" Display Name 3",system:"Test system 3"}];
+    const items = [{value: "Bravo", display: "Display Name 1", codeSystem: "Test system B"},
+                   {value: "Alpha", display: "Display Name 2", codeSystem: "Test system B"},
+                   {value: "Charlie", display: "Display Name 3", codeSystem: "Test system A"}];
     component = renderComponent(CodedSetTable, {items});
   });
 
   it('should create a list of vocab concepts', () => {
     expect(component.find("tr").length).to.equal(4);
+  });
+
+  it('should create a list of vocab concepts in order', () => {
+    expect(component.find("tbody tr:nth-child(1) td:nth-child(1)")).to.have.text("Charlie");
+    expect(component.find("tbody tr:nth-child(2) td:nth-child(1)")).to.have.text("Alpha");
+    expect(component.find("tbody tr:nth-child(3) td:nth-child(1)")).to.have.text("Bravo");
   });
 });

--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -1,4 +1,5 @@
 import React, { Component, PropTypes } from 'react';
+import _ from 'lodash';
 
 export default class CodedSetTable extends Component {
 
@@ -17,7 +18,7 @@ export default class CodedSetTable extends Component {
           </tr>
         </thead>
         <tbody>
-          {this.props.items.map((item,i) => {
+          {this.sortedItems().map((item,i) => {
             return (
               <tr key={i}>
                 <td headers="display-name-column">{item.displayName}</td>
@@ -30,12 +31,16 @@ export default class CodedSetTable extends Component {
       </table>
     );
   }
+
+  sortedItems() {
+    return _.sortBy(this.props.items, ['codeSystem', 'value']);
+  }
 }
 
 CodedSetTable.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
-    code:    PropTypes.string,
-    system:  PropTypes.string,
+    value:    PropTypes.string,
+    codeSystem:  PropTypes.string,
     display: PropTypes.string
   })),
   itemName:  PropTypes.string

--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -41,7 +41,7 @@ CodedSetTable.propTypes = {
   items: PropTypes.arrayOf(PropTypes.shape({
     value:    PropTypes.string,
     codeSystem:  PropTypes.string,
-    display: PropTypes.string
+    displayName: PropTypes.string
   })),
   itemName:  PropTypes.string
 };


### PR DESCRIPTION
Noticed a bunch of mismatches in the tests and React props with how the component works in the real world.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
