### PR TITLE
[SDP-626] Extend bug

### DIFF
--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -107,7 +107,7 @@ class QuestionForm extends Component{
     var extendState = {};
     _.forOwn(this.stateForNew(), (v, k) => extendState[k] = question[k] || v);
     extendState.conceptsAttributes = filterConcepts(question.concepts);
-    extendState.linkedResponseSets = question.responseSets;
+    extendState.linkedResponseSets = question.responseSets || [];
     extendState.version = 1;
     extendState.parentId  = question.id;
     extendState.oid = '';


### PR DESCRIPTION
I was able to reproduce the 626 bug where extension of certain questions wouldn't allow you to add selected RS sets to the right via drag and drop or the button. It took awhile to figure out but the fix is very simple (the selected rs was empty for non choice on extension but the state for extension was storing an undefined when extending into a choice type).

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
