### PR TITLE
[SDP-612] Fix form save performance

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -2,7 +2,7 @@ class Form < ApplicationRecord
   include OidGenerator, Versionable, Searchable
   acts_as_commentable
 
-  has_many :form_questions
+  has_many :form_questions, -> { order 'position asc' }
   has_many :questions, through: :form_questions
   has_many :response_sets, through: :form_questions
   has_many :survey_forms

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -7,7 +7,12 @@ class FormQuestion < ApplicationRecord
   after_commit :reindex, on: [:create, :update, :destroy]
 
   def reindex
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json)
-    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json) if response_set
+    # While question can't actually change, previous_changes[:question_id] will exist if this form question was just created
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json) if previous_changes[:question_id]
+    if response_set && previous_changes[:response_set_id]
+      UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json)
+    end
+    previous_response_set = ResponseSet.find_by(id: previous_changes[:response_set_id][0]) if previous_changes[:response_set_id]
+    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(previous_response_set).as_json) if previous_response_set
   end
 end

--- a/app/serializers/es_form_serializer.rb
+++ b/app/serializers/es_form_serializer.rb
@@ -32,7 +32,7 @@ class ESFormSerializer < ActiveModel::Serializer
   end
 
   def questions
-    object.form_questions.collect do |fq|
+    object.form_questions.includes(:response_set, question: [:concepts]).collect do |fq|
       { id: fq.question_id,
         name: fq.question.content,
         codes: (fq.question.concepts || []).collect { |c| CodeSerializer.new(c).as_json },

--- a/app/serializers/es_question_serializer.rb
+++ b/app/serializers/es_question_serializer.rb
@@ -21,7 +21,7 @@ class ESQuestionSerializer < ActiveModel::Serializer
   attribute :response_type
 
   def forms
-    object.form_questions.collect do |fq|
+    object.form_questions.includes(:form).collect do |fq|
       { id: fq.form.id, name: fq.form.name }
     end
   end


### PR DESCRIPTION
Testing on a 500 question form, reduced save time from 25.5 seconds to 2.3 seconds. Also made the ES serializers for Forms/Questions more efficient so those jobs are easier on the DB.

- [na] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [na] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [na] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
