### PR TITLE
[SDP-625] Fixing bug w/removing response sets from questions

### DIFF
--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -35,10 +35,14 @@ class DropTarget extends Component {
 
     return (
       <div style={{minHeight: '440px', backgroundColor:isValidDrop?'green':'grey'}}>
-        {selectedResponseSets.map((rs, i) => {
+        {selectedResponseSets.map((rs) => {
           return (
-          <div key={i}>
-          <button className="pull-right" onClick={() => removeResponseSet(rs.id)}><i className='fa fa-close' aria-hidden="true"/><span className="sr-only">Remove Selected Response Set</span></button>
+          <div key={rs.id}>
+          <button className="pull-right" onClick={(event) => {
+            event.preventDefault();
+            removeResponseSet(rs.id);
+          }
+          }><i className='fa fa-close' aria-hidden="true"/><span className="sr-only">Remove Selected Response Set</span></button>
           <DraggableResponseSet type='response_set' result={{Source: rs}} currentUser={{id: -1}} />
           </div>);
         })}


### PR DESCRIPTION
Previously, you could only remove the *last* response set that was added
to a question with a type of choice or open choice. This was because
the remove button is an actual button and will cause the question form
to submit when clicked.

This change catches the click event and then calls preventDefault, which
will prevent the form from submitting.

While this fixes the issue, I still have no idea how you could click the
last item in the list with the previous code and not have it submit the
form.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
