### PR TITLE
[SDP-648] Create 500 question survey for testing

### DIFF
--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -26,5 +26,20 @@ namespace :data do
       form.form_questions << fq
     end
     form.save!
+
+    survey = Survey.new(name: '500 Question Survey', created_by: user, status: 'draft')
+    ['a', 'b', 'c', 'd', 'e'].each_with_index do |form_letter, survey_position|
+      f = Form.new(name: "Form #{form_letter} - 100 questions", created_by: user, status: 'draft')
+      100.times do |i|
+        position = i + 1
+        q = Question.create(content: "Is your favorite letter #{form_letter} and number #{position}?",
+                            created_by: user, status: 'draft')
+        fq = FormQuestion.new(question: q, position: position)
+        f.form_questions << fq
+      end
+      f.save!
+      survey.survey_forms << SurveyForm.new(form: f, position: survey_position)
+    end
+    survey.save!
   end
 end


### PR DESCRIPTION
Extend the data:load_test task so that it will now also create a survey
that has 500 questions. This is done by creating 5 forms that have 100
questions each.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
