### PR TITLE
[SDP 649-653] Feedback 508

### DIFF
--- a/features/help.feature
+++ b/features/help.feature
@@ -10,3 +10,11 @@ Feature: Online Help
     Then I should see "Search Functionality"
     When I click on the "Glossary" link
     Then I should see "Data Collection Instrument"
+
+  Scenario: Step-by-Step
+    When I go to the dashboard
+    And I click on the "Help" link
+    And I click on the "Step-by-Step Walkthrough" link
+    Then I should see "Click next"
+    When I click on the "Next" link
+    Then I should see "Results include items"

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -97,7 +97,7 @@ class DashboardSearch extends Component {
 
   advSearchModal() {
     return (
-      <Modal show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch} aria-label="Advanced Search Filters">
+      <Modal animation={false} show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch} aria-label="Advanced Search Filters">
         <Modal.Header closeButton bsStyle='search'>
           <Modal.Title>Advanced Search Filters</Modal.Title>
         </Modal.Header>

--- a/webpack/components/QuestionItem.js
+++ b/webpack/components/QuestionItem.js
@@ -97,7 +97,7 @@ class QuestionItem extends Component {
 
   searchModal() {
     return (
-      <Modal show={this.state.showSearchModal} onHide={this.hideResponseSetSearch} aria-label="Search Response Sets">
+      <Modal animation={false} show={this.state.showSearchModal} onHide={this.hideResponseSetSearch} aria-label="Search Response Sets">
         <Modal.Header closeButton bsStyle='search'>
           <Modal.Title>Search Response Sets</Modal.Title>
         </Modal.Header>

--- a/webpack/components/ResponseSetModal.js
+++ b/webpack/components/ResponseSetModal.js
@@ -26,7 +26,7 @@ class ResponseSetModal extends Component {
 
   render() {
     return (
-      <Modal bsStyle='response-set' show={this.props.show} onHide={this.props.closeModal} aria-label="New Response Set">
+      <Modal animation={false} bsStyle='response-set' show={this.props.show} onHide={this.props.closeModal} aria-label="New Response Set">
         <Modal.Header closeButton bsStyle='response-set'>
           <Modal.Title>New Response Set</Modal.Title>
         </Modal.Header>

--- a/webpack/components/accounts/LogInModal.js
+++ b/webpack/components/accounts/LogInModal.js
@@ -9,7 +9,7 @@ export default class LogInModal extends Component {
 
   render() {
     return (
-      <Modal show={this.props.show} onHide={this.props.closer} aria-label="Sign In">
+      <Modal animation={false} show={this.props.show} onHide={this.props.closer} aria-label="Sign In">
         <Modal.Header closeButton>
           <Modal.Title>Sign In</Modal.Title>
         </Modal.Header>

--- a/webpack/components/accounts/ProfileEditor.js
+++ b/webpack/components/accounts/ProfileEditor.js
@@ -29,7 +29,7 @@ export default class ProfileEditor extends Component {
 
   render() {
     return (
-      <Modal show={this.props.show} onHide={this.props.closer} aria-label={this.title()}>
+      <Modal animation={false} show={this.props.show} onHide={this.props.closer} aria-label={this.title()}>
         <Modal.Header closeButton>
           <Modal.Title>{this.title()}</Modal.Title>
         </Modal.Header>

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
+import $ from 'jquery';
 
 import Header from './Header';
 import LogInModal from '../components/accounts/LogInModal';
@@ -73,7 +74,10 @@ class App extends Component {
     return (
       <div>
         <text className="sr-only">Welcome to the vocabulary service. Click the next link to skip navigation and go to main content.</text>
-        <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1">Skip to main content</a>
+        <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1" onClick={() => {
+          $('a[tabindex=2]').attr('tabindex', '-1');
+          $('a[tabindex=1]').attr('tabindex', '-1');
+        }}>Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 disableUserRegistration={DISABLE_USER_REGISTRATION}
                 location={this.props.location}

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -135,7 +135,7 @@ class CodedSetTableEditContainer extends Component {
 
   conceptModal(){
     return (
-      <Modal show={this.state.showConceptModal} onHide={this.hideCodeSearch} aria-label="Search Codes">
+      <Modal animation={false} show={this.state.showConceptModal} onHide={this.hideCodeSearch} aria-label="Search Codes">
         <Modal.Header closeButton bsStyle='concept'>
           <Modal.Title>Search Codes</Modal.Title>
         </Modal.Header>

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -61,7 +61,7 @@ class DashboardContainer extends Component {
       let steps = [
         {
           title: 'Help',
-          text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+          text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" id="tutorial-link" tabindex="3" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
           selector: '.help-link',
           position: 'bottom',
         },
@@ -299,7 +299,7 @@ class DashboardContainer extends Component {
           </div>
           </button>
       </ul>
-      {searchType != '' && <a href="#" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
+      {searchType != '' && <a href="#" tabIndex="4" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
     </div>);
   }
 

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -20,7 +20,7 @@ class FormShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -38,7 +38,7 @@ class FormsEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -120,7 +120,7 @@ class Header extends Component {
   constructor(props){
     super(props);
     this.state={
-      joyrideOverlay: true,
+      joyrideOverlay: false,
       joyrideType: 'continuous',
       isReady: false,
       isRunning: false,
@@ -167,11 +167,11 @@ class Header extends Component {
         ref={c => (this.joyride = c)}
         debug={false}
         locale={{
-          back: (<span>Back</span>),
-          close: (<span>Close</span>),
-          last: (<span>End</span>),
-          next: (<span>Next</span>),
-          skip: (<span>Exit Tutorial</span>),
+          back: (<span tabIndex='3'>Back</span>),
+          close: (<span tabIndex='3'>Close</span>),
+          last: (<span tabIndex='3'>End</span>),
+          next: (<span tabIndex='3'>Next</span>),
+          skip: (<span className='darker-text' tabIndex='3'>Exit Tutorial</span>),
         }}
         autoStart={true}
         run={isRunning}
@@ -181,6 +181,8 @@ class Header extends Component {
         stepIndex={stepIndex}
         steps={this.props.steps}
         type={joyrideType}
+        tooltipOffset={0}
+        keyboardNavigation={false}
       />
     );
   }

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -6,13 +6,40 @@ import { setSteps } from '../actions/tutorial_actions';
 class Help extends Component {
   constructor(props){
     super(props);
+    this.selectTab = this.selectTab.bind(this);
+    this.selectInstruction = this.selectInstruction.bind(this);
+    this.state = {
+      selectedTab: 'instructions',
+      selectedInstruction: 'general'
+    };
+  }
+
+  selectTab(tabName) {
+    if(tabName === 'instructions'){
+      this.setState({
+        selectedTab: tabName,
+        selectedInstruction: 'general'
+      });
+    } else {
+      this.setState({
+        selectedTab: tabName,
+        selectedInstruction: ''
+      });
+    }
+  }
+
+  selectInstruction(instrName) {
+    this.setState({
+      selectedTab: 'instructions',
+      selectedInstruction: instrName
+    });
   }
 
   componentDidMount() {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },
@@ -26,14 +53,90 @@ class Help extends Component {
 
   generalInstructions() {
     return(
-      <div className="tab-pane active" id="general" role="tabpanel">
+      <div className="tab-pane active" id="general" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'general'} aria-labelledby="general-tab">
         <h1 id="general">General</h1>
         <p><strong>Navigation and Help Basics:</strong></p>
         <ul>
         <li>Use the top bar to log-in, sign-up, or navigate to various pages.</li>
         <li>Clicking the CDC logo in the top left will return you to the landing page at any time.</li>
-        <li>On most pages the top right navigation bar gives a &quot;Help&quot; option. Click on this option to view documentation for various actions or see step-by-step walk throughs on some pages.</li>
         <li>The footer contains useful links to pages with additional information about the site, including the application version. Please reference this version number in any bug reports.</li>
+        <li>On most pages the top right navigation bar gives a &quot;Help&quot; option. Click on this option to view documentation for various actions or see step-by-step walk throughs on some pages. The step by step walkthroughs are also available below in plain text format.</li>
+        </ul>
+        <h2 id="step-by-step">Step-by-Step Walkthroughs by Page</h2>
+        <h3>Dashboard</h3>
+        <ul>
+        <li>Type in your search term and search across all items by default. Results include items you own and published items.</li>
+        <li>Click on any of the type boxes to highlight them and toggle on filtering by that single item type.</li>
+        <li>Click Advanced Link to see additional filters you can apply to your search.</li>
+        <li>If you already have an account you can log in to unlock more features in the top right of the dashboard page.</li>
+        <li>Click the Get Started! button on the banner to register a new account.</li>
+        <li>Click on any of the rows in the My Stuff Analytics panel to filter by items you authored.</li>
+        <li>Click the create menu and then select an item type to author a new item.</li>
+        <li>Click the alerts dropdown to see any new notifications about your content.</li>
+        <li>Click your e-mail to see various account management options.</li>
+        </ul>
+        <h3>Form Edit Page</h3>
+        <ul>
+        <li>If you need to create a new question without leaving the the form use this button to author a new question from scratch.</li>
+        <li>Type in your search keywords here to search for questions to add to the form.</li>
+        <li>Click Advanced to see additional filters you can apply to your search.</li>
+        <li>Use these search results to find the question you want to add.</li>
+        <li>Click on the add button to select a question for the form.</li>
+        <li>Edit the various form details on the right side of the page. Select save in the top right of the page when done editing to save a draft of the content.</li>
+        </ul>
+        <h3>Form Details Page</h3>
+        <ul>
+        <li>Use the history side bar to switch between revisions of an item if more than one exists</li>
+        <li>See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a className="tutorial-link" href="#help">Help Documentation (linked here).</a></li>
+        <li>At the bottom of each details page is a section for public comments. People can view and respond to these comments in threads on published content</li>
+        </ul>
+        <h3>Question Edit Page</h3>
+        <ul>
+        <li>Use the input fields to edit content of the question. If the response type is open choice this panel will also give you the option to associate response sets with this quesiton at creation time</li>
+        <li>Click the search icon to search for and add tags to the question</li>
+        <li>Alternatively, you can manually add a tag - click the plus sign to add additional tags to associate with the question</li>
+        <li>The Display Name field is what the user will see on the page</li>
+        <li>Optionally, you can enter a code and a code system for the tag you are adding if it belongs to an external system (such as LOINC or SNOWMED)</li>
+        <li>Click save to save a draft of the edited content</li>
+        </ul>
+        <h3>Question Details Page</h3>
+        <ul>
+        <li>Use the history side bar to switch between revisions of an item if more than one exists</li>
+        <li>See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a className="tutorial-link" href="#help">Help Documentation (linked here).</a></li>
+        <li>At the bottom of each details page is a section for public comments. People can view and respond to these comments in threads on published content</li>
+        </ul>
+        <h3>Response Set Edit Page</h3>
+        <ul>
+        <li>Use the input fields to edit content of the response set</li>
+        <li>Click the search icon to search for and add coded responses to the response set</li>
+        <li>Alternatively, you can manually add a response - click the plus sign to add additional responses to associate with the response set</li>
+        <li>The Display Name field is what the user will see on the page</li>
+        <li>Optionally, you can enter a code and a code system for the response you are adding if it belongs to an external system (such as LOINC or SNOWMED)</li>
+        <li>Click save to save a draft of the edited content</li>
+        </ul>
+        <h3>Response Set Details Page</h3>
+        <ul>
+        <li>Use the history side bar to switch between revisions of an item if more than one exists</li>
+        <li>See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a className="tutorial-link" href="#help">Help Documentation (linked here).</a></li>
+        <li>At the bottom of each details page is a section for public comments. People can view and respond to these comments in threads on published content</li>
+        </ul>
+        <h3>Survey Edit Page</h3>
+        <ul>
+        <li>Type in your search keywords here to search for forms to add to the survey</li>
+        <li>Click Advanced to see additional filters you can apply to your search</li>
+        <li>Use these search results to find the form you want to add</li>
+        <li>Click on the add button to select a form for the survey</li>
+        <li>Edit the various survey details on the right side of the page. Select save in the top right of the page when done editing to save a draft of the content</li>
+        </ul>
+        <h3>Survey Details Page</h3>
+        <ul>
+        <li>Use the history side bar to switch between revisions of an item if more than one exists</li>
+        <li>See all of the details including linked items on this section of the page. Use the buttons in the top right to do various actions with the content depending on your user permissions. For full details on what an action does please see the "Create and Edit Content" section of the <a className="tutorial-link" href="#help">Help Documentation (linked here).</a></li>
+        <li>At the bottom of each details page is a section for public comments. People can view and respond to these comments in threads on published content</li>
+        </ul>
+        <h3>Help Page</h3>
+        <ul>
+        <li>Click any item in the left side bar to see instructions on how to perform any of the specified activities</li>
         </ul>
       </div>
     );
@@ -41,7 +144,7 @@ class Help extends Component {
 
   accountInstructions() {
     return(
-      <div className="tab-pane active" id="manage-account" role="tabpanel">
+      <div className="tab-pane" id="manage-account" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'manage-account'} aria-labelledby="manage-account-tab">
         <h1 id="account-management">Account Management</h1>
         <p><strong>Options:</strong></p>
         <ul>
@@ -61,7 +164,7 @@ class Help extends Component {
 
   searchInstructions() {
     return(
-      <div className="tab-pane active" id="search" role="tabpanel">
+      <div className="tab-pane" id="search" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'search'} aria-labelledby="search-tab">
         <h1 id="search-functionality">Search Functionality</h1>
         <p><strong>Features:</strong></p>
         <ul>
@@ -85,7 +188,7 @@ class Help extends Component {
 
   viewInstructions() {
     return(
-      <div className="tab-pane active" id="view" role="tabpanel">
+      <div className="tab-pane" id="view" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'view'} aria-labelledby="view-tab">
         <h1 id="view-content">View Content</h1>
         <p><strong>Options:</strong></p>
         <ul>
@@ -111,7 +214,7 @@ class Help extends Component {
 
   editInstructions() {
     return(
-      <div className="tab-pane active" id="create-and-edit" role="tabpanel">
+      <div className="tab-pane" id="create-and-edit" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'create-and-edit'} aria-labelledby="create-and-edit-tab">
         <h1 id="content-creation-and-editing">Content Creation and Editing</h1>
         <p><strong>Options:</strong></p>
         <ul>
@@ -153,7 +256,7 @@ class Help extends Component {
 
   commentInstructions() {
     return(
-      <div className="tab-pane active" id="comment" role="tabpanel">
+      <div className="tab-pane" id="comment" role="tabpanel" aria-hidden={this.state.selectedInstruction !== 'comment'} aria-labelledby="comment-tab">
         <h1 id="commenting-on-content">Commenting on Content</h1>
         <p><strong>Steps:</strong></p>
         <ul>
@@ -168,7 +271,7 @@ class Help extends Component {
 
   instructionsTab() {
     return(
-      <div className="tab-pane active" id="instructions" role="tabpanel">
+      <div className="tab-pane active" id="instructions" role="tabpanel" aria-hidden={this.state.selectedTab !== 'instructions'} aria-labelledby="instructions-tab">
         <div className="col-md-3 how-to-nav no-print">
           <h2 className="showpage_sidenav_subtitle">
             <text className="sr-only">Version History Navigation Links</text>
@@ -177,13 +280,13 @@ class Help extends Component {
               <li className="subtitle">Learn How To:</li>
             </ul>
           </h2>
-          <ul className="nav nav-pills nav-stacked">
-            <li className="active" role="presentation"><a data-toggle="tab" href="#general">General</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#manage-account">Manage Account</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#search">Search</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#view">View and Export Content</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#create-and-edit">Create and Edit Content</a></li>
-            <li role="presentation"><a data-toggle="tab" href="#comment">Comment on Content</a></li>
+          <ul className="nav nav-pills nav-stacked" role="tablist">
+            <li id="general-tab" className="active" role="tab" onClick={() => this.selectInstruction('general')} aria-selected={this.state.selectedInstruction === 'general'} aria-controls="general"><a data-toggle="tab" href="#general">General</a></li>
+            <li id="manage-account-tab" role="tab" onClick={() => this.selectInstruction('manage-account')} aria-selected={this.state.selectedInstruction === 'manage-account'} aria-controls="manage-account"><a data-toggle="tab" href="#manage-account">Manage Account</a></li>
+            <li id="search-tab" role="tab" onClick={() => this.selectInstruction('search')} aria-selected={this.state.selectedInstruction === 'search'} aria-controls="search"><a data-toggle="tab" href="#search">Search</a></li>
+            <li id="view-tab" role="tab" onClick={() => this.selectInstruction('view')} aria-selected={this.state.selectedInstruction === 'view'} aria-controls="view"><a data-toggle="tab" href="#view">View and Export Content</a></li>
+            <li id="create-and-edit-tab" role="tab" onClick={() => this.selectInstruction('create-and-edit')} aria-selected={this.state.selectedInstruction === 'create-and-edit'} aria-controls="create-and-edit"><a data-toggle="tab" href="#create-and-edit">Create and Edit Content</a></li>
+            <li id="comment-tab" role="tab" onClick={() => this.selectInstruction('comment')} aria-selected={this.state.selectedInstruction === 'comment'} aria-controls="comment"><a data-toggle="tab" href="#comment">Comment on Content</a></li>
           </ul>
         </div>
         <div className="tab-content col-md-8">
@@ -200,7 +303,7 @@ class Help extends Component {
 
   glossaryTab() {
     return (
-      <div className="tab-pane" id="glossary" role="tabpanel">
+      <div className="tab-pane" id="glossary" role="tabpanel" aria-hidden={this.state.selectedTab !== 'glossary'} aria-labelledby="glossary-tab">
         <h1 id="glossary">Glossary</h1>
         <p><strong>Author –</strong> An actor (organization, person, or program) responsible for creating and/or maintaining a data collection item, a code set, a value set, or a data collection instrument</p>
         <p><strong>Code –</strong> a succinct label for a concept, variable, value, or question</p>
@@ -234,19 +337,19 @@ class Help extends Component {
               <div className="row">
                 <div className="col-md-12 nopadding">
                   <ul className="nav nav-tabs" role="tablist">
-                    <li className="nav-item active">
+                    <li id="instructions-tab" className="nav-item active" role="tab" onClick={() => this.selectTab('instructions')} aria-selected={this.state.selectedTab === 'instructions'} aria-controls="instructions">
                       <a className="nav-link" data-toggle="tab" href="#instructions" role="tab">Instructions</a>
                     </li>
-                    <li className="nav-item">
+                    <li id="glossary-tab" className="nav-item" role="tab" onClick={() => this.selectTab('glossary')} aria-selected={this.state.selectedTab === 'glossary'} aria-controls="glossary">
                       <a className="nav-link" data-toggle="tab" href="#glossary" role="tab">Glossary</a>
                     </li>
-                    <li className="nav-item">
+                    <li id="faq-tab" className="nav-item" role="tab" onClick={() => this.selectTab('faq')} aria-selected={this.state.selectedTab === 'faq'} aria-controls="faq">
                       <a className="nav-link" data-toggle="tab" href="#faq" role="tab">FAQs</a>
                     </li>
                   </ul>
                   <div className="tab-content">
                     {this.instructionsTab()}
-                    <div className="tab-pane" id="faq" role="tabpanel">
+                    <div className="tab-pane" id="faq" role="tabpanel" aria-hidden={this.state.selectedTab !== 'faq'} aria-labelledby="faq-tab">
                       <h1 className="help-section-title">FAQs</h1>
                       <p>This section has not been added. Please check back later.</p>
                     </div>

--- a/webpack/containers/QuestionEditContainer.js
+++ b/webpack/containers/QuestionEditContainer.js
@@ -29,7 +29,7 @@ class QuestionEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -24,7 +24,7 @@ class QuestionShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/ResponseSetEditContainer.js
+++ b/webpack/containers/ResponseSetEditContainer.js
@@ -22,7 +22,7 @@ class ResponseSetEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -24,7 +24,7 @@ class ResponseSetShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -34,7 +34,7 @@ class SurveyEditContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/containers/surveys/ShowContainer.js
+++ b/webpack/containers/surveys/ShowContainer.js
@@ -19,7 +19,7 @@ class SurveyShowContainer extends Component {
     this.props.setSteps([
       {
         title: 'Help',
-        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a>',
+        text: 'Click next to see a step by step walkthrough for using this page. To see more detailed information about this application and actions you can take <a class="tutorial-link" href="#help">click here to view the full Help Documentation.</a> Accessible versions of these steps are also duplicated in the help documentation.',
         selector: '.help-link',
         position: 'bottom',
       },

--- a/webpack/styles/elements/_buttons.scss
+++ b/webpack/styles/elements/_buttons.scss
@@ -57,6 +57,14 @@ a.widget-dropdown-toggle{
   margin-right: 0px !important;
 }
 
+.darker-text {
+  color: $dark-gray;
+}
+
+.joyride-tooltip__close {
+  visibility: hidden !important;
+}
+
 caption {
   color: $medium-gray;
 }


### PR DESCRIPTION
First round of 508 feedback changes including:

### 649 Dashboard tab order
See story for details, this involved making it so if a type filter is selected the clear type filter link is in the tab order before the my-stuff sidebar

### 650 Tab Panel Incorrectly marked
This involved 3 sets of changes to the help page according to the document linked in the story:
- Adding labelledby and aria controls to properly associate things
- Setting up state in the help page to add aria-hidden to things that are not on the page
- Setting up state to dynamic use aria-selected on the two sets of tabs

### 651 Step by Step Walkthrough
This issue was addressed in two ways:
1) the actual walkthrough was brought into compliance, enough so that I could write a cucumber test for it and it no longer displayed accessibility audit failures. This included dealing with contrast issues, getting rid of the shadowbox overlay, hiding a button that is not needed but part of the library, and making it so when you are using just a keyboard your focus is set to the tooltip when it pops up.
2) The first step in each walkthrough now points to the help documentation for accessible equivalent. All of the steps were transposed to the help documentation, in addition to the more in depth information already there.

### 652 Skip link not working in I.E.
Now skip link when clicked sets the navigation tabindex to -1 which works in I.E. (this is a known bug and the most common solution found online)

### 653 Weird display issue
In Internet explorer the modals would fade in and the animation would cause a cursor bug. Now the modals where this bug was a problem do not fade in.


Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
