### PR TITLE
[SDP-659] Reduce webpack bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,13 +22,13 @@
     "babel-preset-stage-1": "^6.16.0",
     "bootstrap-loader": "^1.2.1",
     "css-loader": "^0.25.0",
+    "date-fns": "^1.28.5",
     "extract-text-webpack-plugin": "^1.0.1",
     "file-loader": "^0.9.0",
     "font-awesome": "^4.7.0",
     "jquery": "^3.1.1",
     "jquery-ujs": "^1.2.2",
     "lodash": "^4.17.4",
-    "moment": "^2.17.1",
     "node-sass": "^3.10.1",
     "postcss-loader": "^1.0.0",
     "rails-erb-loader": "3.0.0",
@@ -64,6 +64,7 @@
     "eslint-plugin-react": "^6.7.1",
     "jsdom": "^9.8.3",
     "mocha": "^3.2.0",
-    "react-addons-test-utils": "^15.4.0"
+    "react-addons-test-utils": "^15.4.0",
+    "webpack-bundle-analyzer": "^2.8.2"
   }
 }

--- a/webpack/components/CodedSetTable.js
+++ b/webpack/components/CodedSetTable.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import _ from 'lodash';
+import sortBy from 'lodash/sortBy';
 
 export default class CodedSetTable extends Component {
 
@@ -33,7 +33,7 @@ export default class CodedSetTable extends Component {
   }
 
   sortedItems() {
-    return _.sortBy(this.props.items, ['codeSystem', 'value']);
+    return sortBy(this.props.items, ['codeSystem', 'value']);
   }
 }
 

--- a/webpack/components/Comment.js
+++ b/webpack/components/Comment.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import moment from 'moment';
+import parse from 'date-fns/parse';
+import distanceInWordsToNow from 'date-fns/distance_in_words_to_now';
 import { connect } from 'react-redux';
 import CommentForm from './CommentForm';
 
@@ -17,7 +18,7 @@ class Comment extends Component {
               <span className="glyphicon glyphicon-minus" aria-hidden="true"></span>
             </button>
             <span className="label label-info">{this.props.comment.id}</span>
-            {moment(this.props.comment.createdAt,'').fromNow()} by {this.props.comment.userName}
+            {distanceInWordsToNow(parse(this.props.comment.createdAt,''), {addSuffix: true})} by {this.props.comment.userName}
           </div>
 
           <div className="panel-collapse collapse in" id={"comment_id_"+this.props.comment.id}>

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -3,7 +3,8 @@ import { Link } from 'react-router';
 import { Modal, Button } from 'react-bootstrap';
 import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
 import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
-import _ from 'lodash';
+import values from 'lodash/values';
+import isEmpty from 'lodash/isEmpty';
 import $ from 'jquery';
 
 class DashboardSearch extends Component {
@@ -62,14 +63,14 @@ class DashboardSearch extends Component {
   }
 
   surveillanceProgramsSelect() {
-    if (_.isEmpty(this.props.surveillancePrograms)) {
+    if (isEmpty(this.props.surveillancePrograms)) {
       return <p>No surveillance programs loaded in the database</p>;
     } else {
       return (
         <div className="form-group">
           <label htmlFor="select-prog">Select Programs:</label>
           <select multiple className="form-control" id="select-prog" value={this.state.progFilters} onChange={(e) => this.selectFilters(e, 'progFilters')}>
-            {this.props.surveillancePrograms && _.values(this.props.surveillancePrograms).map((sp) => {
+            {this.props.surveillancePrograms && values(this.props.surveillancePrograms).map((sp) => {
               return <option key={sp.id} value={sp.id}>{sp.name}</option>;
             })}
           </select>
@@ -79,14 +80,14 @@ class DashboardSearch extends Component {
   }
 
   surveillanceSystemsSelect() {
-    if (_.isEmpty(this.props.surveillanceSystems)) {
+    if (isEmpty(this.props.surveillanceSystems)) {
       return <p>No surveillance systems loaded in the database</p>;
     } else {
       return (
         <div className="form-group">
           <label htmlFor="select-sys">Select Systems:</label>
           <select multiple className="form-control" id="select-sys" value={this.state.sysFilters} onChange={(e) => this.selectFilters(e, 'sysFilters')}>
-            {this.props.surveillanceSystems && _.values(this.props.surveillanceSystems).map((ss) => {
+            {this.props.surveillanceSystems && values(this.props.surveillanceSystems).map((ss) => {
               return <option key={ss.id} value={ss.id}>{ss.name}</option>;
             })}
           </select>

--- a/webpack/components/Errors.js
+++ b/webpack/components/Errors.js
@@ -1,13 +1,18 @@
 import React, { Component, PropTypes } from 'react';
-import _ from 'lodash';
+import keys from 'lodash/keys';
+import map from 'lodash/map';
+import reduce from 'lodash/reduce';
+import flatten from 'lodash/flatten';
+import values from 'lodash/values';
+
 export default class Errors extends Component {
   render() {
-    if (_.keys(this.props.errors).length > 0) {
+    if (keys(this.props.errors).length > 0) {
       return (
         <div id="error_explanation">
           <h1>{this.errorCount()} error(s) prohibited this form from being saved:</h1>
           <ul>
-          {_.map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
+          {map(this.errorList(), (e, i) => <li key={i}>{e}</li>)}
           </ul>
         </div>
       );
@@ -17,11 +22,11 @@ export default class Errors extends Component {
   }
 
   errorCount() {
-    return _.reduce(_.values(this.props.errors), (sum, v) => sum + v.length, 0);
+    return reduce(values(this.props.errors), (sum, v) => sum + v.length, 0);
   }
 
   errorList() {
-    return _.flatten(_.keys(this.props.errors).map((k) => {
+    return flatten(keys(this.props.errors).map((k) => {
       return this.props.errors[k].map((e) => `${k} - ${e}`);
     }));
   }

--- a/webpack/components/FormEdit.js
+++ b/webpack/components/FormEdit.js
@@ -1,13 +1,17 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
+import { Button } from 'react-bootstrap';
+import compact from 'lodash/compact';
+import union from 'lodash/union';
+
 import { formProps } from '../prop-types/form_props';
 import { responseSetsProps } from '../prop-types/response_set_props';
 import { questionsProps } from '../prop-types/question_props';
-import { Button } from 'react-bootstrap';
+
 import QuestionItem from './QuestionItem';
 import ModalDialog  from './ModalDialog';
 import Errors from './Errors';
-import _ from 'lodash';
+
 
 class FormEdit extends Component {
 
@@ -57,7 +61,7 @@ class FormEdit extends Component {
     }
     this.unsavedState = false;
     this.lastQuestionCount = this.state.formQuestions.length;
-    this.addedResponseSets = _.compact(this.state.formQuestions.map((fq) => fq.responseSetId));
+    this.addedResponseSets = compact(this.state.formQuestions.map((fq) => fq.responseSetId));
     this.handleSelectSearchResult = this.handleSelectSearchResult.bind(this);
     this.handleResponseSetChangeEvent = this.handleResponseSetChangeEvent.bind(this);
     this.handleSubmit = this.handleSubmit.bind(this);
@@ -184,7 +188,7 @@ class FormEdit extends Component {
     if(this.state.formQuestions[questionIndex].responseSetId == responseSet.id){
       return;
     }
-    this.addedResponseSets = _.union(this.addedResponseSets, [responseSet.id]);
+    this.addedResponseSets = union(this.addedResponseSets, [responseSet.id]);
     var newState = Object.assign({}, this.state);
     newState.formQuestions[questionIndex].responseSetId = responseSet.id;
     this.setState(newState);
@@ -195,8 +199,8 @@ class FormEdit extends Component {
     if(this.props.questions[qId] && this.props.questions[qId].responseSets && this.props.questions[qId].responseSets.length > 0) {
       linkedResponseSets = this.props.questions[qId].responseSets || [];
     }
-    linkedResponseSets = _.union(linkedResponseSets, this.addedResponseSets, this.state.formQuestions.map((fq) => fq.responseSetId));
-    return _.compact(linkedResponseSets.map((rsId) => this.props.responseSets[rsId]));
+    linkedResponseSets = union(linkedResponseSets, this.addedResponseSets, this.state.formQuestions.map((fq) => fq.responseSetId));
+    return compact(linkedResponseSets.map((rsId) => this.props.responseSets[rsId]));
   }
 
   handleSelectSearchResult(i, responseSet){

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -1,5 +1,6 @@
 import React, { Component, PropTypes } from 'react';
-import moment from 'moment';
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
 import { hashHistory, Link } from 'react-router';
 
 import VersionInfo from "./VersionInfo";
@@ -103,7 +104,7 @@ export default class QuestionDetails extends Component {
             </div>
             <div className="box-content">
               <strong>Created: </strong>
-              { moment(question.createdAt,'').format('MMMM Do YYYY, h:mm:ss a') }
+              { format(parse(question.createdAt,''), 'MMMM Do YYYY, h:mm:ss a') }
             </div>
             { question.parent &&
               <div className="box-content">

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -1,13 +1,17 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
+import forOwn from 'lodash/forOwn';
+import values from 'lodash/values';
+
 import { questionProps } from '../prop-types/question_props';
 import { responseSetsProps } from '../prop-types/response_set_props';
+
 import Errors from './Errors';
 import ModalDialog from './ModalDialog';
 import ResponseSetModal from './ResponseSetModal';
 import ResponseSetDragWidget from './ResponseSetDragWidget';
 import CodedSetTableEditContainer from '../containers/CodedSetTableEditContainer';
-import _ from 'lodash';
+
 
 class QuestionForm extends Component{
 
@@ -75,7 +79,7 @@ class QuestionForm extends Component{
 
   stateForRevise(question) {
     var reviseState = {};
-    _.forOwn(this.stateForNew(), (v, k) => reviseState[k] = question[k] || v);
+    forOwn(this.stateForNew(), (v, k) => reviseState[k] = question[k] || v);
     reviseState.conceptsAttributes = filterConcepts(question.concepts);
     reviseState.linkedResponseSets = question.responseSets;
     if (this.props.action === 'revise') {
@@ -106,7 +110,7 @@ class QuestionForm extends Component{
   //not working because of map => questionType
   stateForExtend(question) {
     var extendState = {};
-    _.forOwn(this.stateForNew(), (v, k) => extendState[k] = question[k] || v);
+    forOwn(this.stateForNew(), (v, k) => extendState[k] = question[k] || v);
     extendState.conceptsAttributes = filterConcepts(question.concepts);
     extendState.linkedResponseSets = question.responseSets || [];
     extendState.version = 1;
@@ -168,7 +172,7 @@ class QuestionForm extends Component{
                       <label className="input-label" htmlFor="questionTypeId">Category</label>
                       <select className="input-select" name="questionTypeId" id="questionTypeId" defaultValue={state.questionTypeId} onChange={this.handleChange('questionTypeId')} >
                         <option value=""></option>
-                        {questionTypes && _.values(questionTypes).map((qt) => {
+                        {questionTypes && values(questionTypes).map((qt) => {
                           return <option key={qt.id} value={qt.id}>{qt.name}</option>;
                         })}
                       </select>
@@ -238,7 +242,7 @@ class QuestionForm extends Component{
 
 
   isChoiceType(){
-    let rt = _.values(this.props.responseTypes).find((a) => {
+    let rt = values(this.props.responseTypes).find((a) => {
       return a.id == this.state.responseTypeId;
     });
     if(rt && (rt.code == "choice" || rt.code == "open-choice")){
@@ -247,7 +251,7 @@ class QuestionForm extends Component{
   }
 
   sortedResponseTypes(){
-    return _.values(this.props.responseTypes).sort((a,b) => {
+    return values(this.props.responseTypes).sort((a,b) => {
       if(a.name == b.name ){
         return 0;
       }else if(a.name < b.name){

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -1,6 +1,7 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import moment from 'moment';
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
 import VersionInfo from './VersionInfo';
@@ -114,7 +115,7 @@ export default class ResponseSetDetails extends Component {
             </div>
             <div className="box-content">
               <strong>Created: </strong>
-              { moment(responseSet.createdAt,'').format('MMMM Do YYYY, h:mm:ss a') }
+              { format(parse(responseSet.createdAt,''), 'MMMM Do YYYY, h:mm:ss a') }
             </div>
             { responseSet.parent &&
               <div className="box-content">

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -2,7 +2,8 @@
 
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
-import moment from 'moment';
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
 import currentUserProps from "../prop-types/current_user_props";
 import { responseSetProps } from "../prop-types/response_set_props";
 
@@ -285,7 +286,7 @@ export default class SearchResult extends Component {
                 {result.surveillanceSystems && this.systemsInfo(result)}
                 {this.resultStatus(result.status)}
                 <li className={`result-timestamp pull-right ${this.props.programVar && 'list-program-var'}`}>
-                  <p>{ moment(result.createdAt,'').format('MMMM Do, YYYY') }</p>
+                  <p>{ format(parse(result.createdAt,''), 'MMMM Do, YYYY') }</p>
                   <p><text className="sr-only">Item Version Number: </text>version {result.version && result.version} | <text className="sr-only">Item type: </text>{type}</p>
                   {this.props.programVar && (<p><text className="sr-only">Item program defined Variable: </text>{this.props.programVar}</p>)}
                 </li>

--- a/webpack/components/accounts/ProfileEditor.js
+++ b/webpack/components/accounts/ProfileEditor.js
@@ -1,6 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { Modal } from 'react-bootstrap';
-import _ from 'lodash';
+import values from 'lodash/values';
+import filter from 'lodash/filter';
+import clone from 'lodash/clone';
+import isEmpty from 'lodash/isEmpty';
 
 import Errors from '../Errors.js';
 import NestedSearchBar from '../NestedSearchBar';
@@ -18,8 +21,8 @@ export default class ProfileEditor extends Component {
   }
 
   componentWillReceiveProps(nextProps){
-    var surveillanceSystems  =  _.values(nextProps.surveillanceSystems);
-    var surveillancePrograms =  _.values(nextProps.surveillancePrograms);
+    var surveillanceSystems  =  values(nextProps.surveillanceSystems);
+    var surveillancePrograms =  values(nextProps.surveillancePrograms);
     this.setState({surveillanceSystems:  surveillanceSystems,
       surveillancePrograms: surveillancePrograms,
       defaultProgramId: (surveillancePrograms[0] && surveillancePrograms[0].id) || -1,
@@ -74,23 +77,23 @@ export default class ProfileEditor extends Component {
   }
 
   programSearch(programSearchTerm){
-    var surveillancePrograms = _.values(this.props.surveillancePrograms);
+    var surveillancePrograms = values(this.props.surveillancePrograms);
     if(programSearchTerm && programSearchTerm.length > 1){
-      surveillancePrograms = _.filter(surveillancePrograms, (sp) => sp.name.toLowerCase().includes(programSearchTerm.toLowerCase()) || sp.id === this.state.lastProgramId || sp.id.toString() === this.state.lastProgramId);
+      surveillancePrograms = filter(surveillancePrograms, (sp) => sp.name.toLowerCase().includes(programSearchTerm.toLowerCase()) || sp.id === this.state.lastProgramId || sp.id.toString() === this.state.lastProgramId);
     }
     this.setState({surveillancePrograms: surveillancePrograms, defaultProgramId: (surveillancePrograms[0] && surveillancePrograms[0].id) || -1});
   }
 
   systemSearch(systemSearchTerm){
-    var surveillanceSystems = _.values(this.props.surveillanceSystems);
+    var surveillanceSystems = values(this.props.surveillanceSystems);
     if(systemSearchTerm && systemSearchTerm.length > 1){
-      surveillanceSystems = _.filter(surveillanceSystems, (ss) => ss.name.toLowerCase().includes(systemSearchTerm.toLowerCase()) || ss.id === this.state.lastSystemId || ss.id.toString() === this.state.lastSystemId);
+      surveillanceSystems = filter(surveillanceSystems, (ss) => ss.name.toLowerCase().includes(systemSearchTerm.toLowerCase()) || ss.id === this.state.lastSystemId || ss.id.toString() === this.state.lastSystemId);
     }
     this.setState({surveillanceSystems: surveillanceSystems, defaultSystemId:(surveillanceSystems[0] && surveillanceSystems[0].id) || -1});
   }
 
   surveillanceProgramsField() {
-    if (_.isEmpty(this.props.surveillancePrograms)) {
+    if (isEmpty(this.props.surveillancePrograms)) {
       return <p>No surveillance programs loaded in the database</p>;
     } else {
       return (<div id="search-programs">
@@ -106,7 +109,7 @@ export default class ProfileEditor extends Component {
   }
 
   surveillanceSystemsField() {
-    if (_.isEmpty(this.props.surveillanceSystems)) {
+    if (isEmpty(this.props.surveillanceSystems)) {
       return <p>No surveillance systems loaded in the database</p>;
     } else {
       return (<div id="search-systems">
@@ -122,7 +125,7 @@ export default class ProfileEditor extends Component {
   }
 
   profileInformation() {
-    let profileInformation = _.clone(this.state);
+    let profileInformation = clone(this.state);
     delete profileInformation.errors;
     if (profileInformation.lastSystemId === -1) {
       if (profileInformation.defaultSystemId !== -1){

--- a/webpack/components/shared_show/ProgramsAndSystems.js
+++ b/webpack/components/shared_show/ProgramsAndSystems.js
@@ -1,5 +1,5 @@
 import React, { Component, PropTypes } from 'react';
-import _ from 'lodash';
+import join from 'lodash/join';
 
 class ProgramsAndSystems extends Component {
   render() {
@@ -19,7 +19,7 @@ class ProgramsAndSystems extends Component {
   surveillancePrograms(item) {
     if (item.surveillancePrograms) {
       return <span>{item.surveillancePrograms.length}
-       {item.surveillancePrograms.length > 0 ? ` - ${_.join(item.surveillancePrograms)}` : ''}</span>;
+       {item.surveillancePrograms.length > 0 ? ` - ${join(item.surveillancePrograms)}` : ''}</span>;
     } else {
       return 'Loading';
     }
@@ -28,7 +28,7 @@ class ProgramsAndSystems extends Component {
   surveillanceSystems(item) {
     if (item.surveillanceSystems) {
       return <span>{item.surveillanceSystems.length}
-       {item.surveillanceSystems.length > 0 ? ` - ${_.join(item.surveillanceSystems)}` : ''}</span>;
+       {item.surveillanceSystems.length > 0 ? ` - ${join(item.surveillanceSystems)}` : ''}</span>;
     } else {
       return 'Loading';
     }

--- a/webpack/components/shared_show/PublisherLookUp.js
+++ b/webpack/components/shared_show/PublisherLookUp.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import { publishersProps } from '../../prop-types/publisher_props';
-import _ from 'lodash';
+import values from 'lodash/values';
 import strictUriEncode from 'strict-uri-encode';
 
 class PublisherLookUp extends Component {
@@ -11,7 +11,7 @@ class PublisherLookUp extends Component {
               </button>
               <ul className="dropdown-menu">
                 <li key="header" className="dropdown-header">Publishers</li>
-                {_.values(this.props.publishers).map((p, i) => {
+                {values(this.props.publishers).map((p, i) => {
                   return <li key={i}><a href={this.link(p)}>{p.name} &lt;{p.email}&gt;</a></li>;
                 })}
               </ul>

--- a/webpack/containers/CodedSetTableEditContainer.js
+++ b/webpack/containers/CodedSetTableEditContainer.js
@@ -2,9 +2,13 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import {Modal, Checkbox, Button, ControlLabel, FormGroup, InputGroup, DropdownButton, MenuItem} from 'react-bootstrap';
+import values from 'lodash/values';
+import filter from 'lodash/filter';
+import concat from 'lodash/concat';
+
 import NestedSearchBar from '../components/NestedSearchBar';
 import { fetchConcepts, fetchConceptSystems } from '../actions/concepts_actions';
-import _ from 'lodash';
+
 
 class CodedSetTableEditContainer extends Component {
   constructor(props) {
@@ -20,7 +24,7 @@ class CodedSetTableEditContainer extends Component {
   }
 
   addItemRow(displayName='', codeSystem='', value='') {
-    let newItems = _.concat(this.state.items, [{displayName: displayName, codeSystem: codeSystem, value: value}]);
+    let newItems = concat(this.state.items, [{displayName: displayName, codeSystem: codeSystem, value: value}]);
     this.setState({items: newItems});
     if (this.props.itemWatcher) {
       this.props.itemWatcher(newItems);
@@ -28,7 +32,7 @@ class CodedSetTableEditContainer extends Component {
   }
 
   addItemRows(items) {
-    let newItems = _.concat(this.state.items, items);
+    let newItems = concat(this.state.items, items);
     newItems = newItems.filter((i) => (i.displayName!=='' || i.codeSystem!=='' || i.value!==''));
     this.setState({items: newItems});
     if (this.props.itemWatcher) {
@@ -88,9 +92,9 @@ class CodedSetTableEditContainer extends Component {
     var newConcepts = [];
     var selectedConcept = this.props.concepts[this.state.selectedSystem][i];
     if(e.target.checked){
-      newConcepts = _.concat(this.state.selectedConcepts, selectedConcept);
+      newConcepts = concat(this.state.selectedConcepts, selectedConcept);
     }else{
-      newConcepts = _.filter(this.state.selectedConcepts, (c) => {
+      newConcepts = filter(this.state.selectedConcepts, (c) => {
         return (c.code !== selectedConcept.code);
       });
     }
@@ -117,7 +121,7 @@ class CodedSetTableEditContainer extends Component {
         <div className='table-scrolling-div'>
           <table className="table table-striped scroll-table-body">
             <tbody>
-              {_.values(this.props.concepts[this.state.selectedSystem]).map((c, i) => {
+              {values(this.props.concepts[this.state.selectedSystem]).map((c, i) => {
                 return (
                   <tr key={i}>
                     <td headers="add-code-checkboxes-column"><ControlLabel bsClass='checkbox-label'><Checkbox onChange={(e) => this.selectConcept(e,i)} name={`checkbox_${i}`}></Checkbox></ControlLabel></td>
@@ -147,7 +151,7 @@ class CodedSetTableEditContainer extends Component {
                 id="system-select-dropdown"
                 title={this.state.selectedSystem ? this.state.selectedSystem : 'Code System'} onSelect={(key, e) => this.searchConcepts(e.target.text)} >
                 <MenuItem key={0} value={''}>None</MenuItem>
-                {_.values(this.props.conceptSystems).map((s, i) => {
+                {values(this.props.conceptSystems).map((s, i) => {
                   if(s.name) {
                     return <MenuItem key={i} value={s.name}>{s.name}</MenuItem>;
                   }

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -1,6 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import isEmpty from 'lodash/isEmpty';
+
 import { setSteps } from '../actions/tutorial_actions';
 import { fetchSearchResults, fetchMoreSearchResults, setLastSearch } from '../actions/search_results_actions';
 import DashboardSearch from '../components/DashboardSearch';
@@ -10,7 +12,7 @@ import currentUserProps from '../prop-types/current_user_props';
 import { surveillanceSystemsProps }from '../prop-types/surveillance_system_props';
 import { surveillanceProgramsProps } from '../prop-types/surveillance_program_props';
 import { signUp } from '../actions/current_user_actions';
-import _ from 'lodash';
+
 
 const DASHBOARD_CONTEXT = 'DASHBOARD_CONTEXT';
 const NO_SEARCH_RESULTS = {};
@@ -83,7 +85,7 @@ class DashboardContainer extends Component {
           selector: '.adv-search-link',
           position: 'right',
         }];
-      if(_.isEmpty(this.props.currentUser)) {
+      if(isEmpty(this.props.currentUser)) {
         steps = steps.concat([
           {
             title: 'Log In',
@@ -129,7 +131,7 @@ class DashboardContainer extends Component {
   }
 
   render() {
-    let loggedIn = ! _.isEmpty(this.props.currentUser);
+    let loggedIn = ! isEmpty(this.props.currentUser);
     const searchResults = this.props.searchResults;
     return (
       <div className="container-fluid">

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -12,7 +12,7 @@ import { formProps } from '../prop-types/form_props';
 import { questionsProps } from '../prop-types/question_props';
 import { responseSetsProps } from '../prop-types/response_set_props';
 import {Button} from 'react-bootstrap';
-import _ from 'lodash';
+import capitalize from 'lodash/capitalize';
 
 class FormsEditContainer extends Component {
 
@@ -139,7 +139,7 @@ class FormsEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Form </h1>
+              <h1 className="panel-title">{capitalize(this.props.params.action)} Form </h1>
             </div>
             <div className="panel-body">
               <div className="col-md-5">

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -1,6 +1,6 @@
 import React, { Component, PropTypes } from 'react';
 import Joyride from 'react-joyride';
-import _ from 'lodash';
+import isEmpty from 'lodash/isEmpty';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Link } from 'react-router';
@@ -10,7 +10,7 @@ import NotificationMenu from '../components/NotificationMenu';
 import { fetchNotifications } from '../actions/notification_actions';
 
 let LoginMenu = ({disableUserRegistration, logInOpener, signUpOpener, currentUser}) => {
-  let loggedIn = ! _.isEmpty(currentUser);
+  let loggedIn = ! isEmpty(currentUser);
   if(!loggedIn) {
     if(disableUserRegistration == 'true') {
       return (
@@ -50,7 +50,7 @@ LoginMenu.propTypes = {
 };
 
 let ContentMenu = ({settingsOpener, currentUser}) => {
-  let loggedIn = ! _.isEmpty(currentUser);
+  let loggedIn = ! isEmpty(currentUser);
   if(loggedIn) {
     let {email} = currentUser;
     return(
@@ -78,7 +78,7 @@ ContentMenu.propTypes = {
 
 
 let SignedInMenu = ({currentUser, location, notifications, notificationCount}) => {
-  let loggedIn = ! _.isEmpty(currentUser);
+  let loggedIn = ! isEmpty(currentUser);
   if(loggedIn) {
     return (
       <ul className="cdc-nav cdc-utlt-navbar-nav">

--- a/webpack/containers/QuestionModalContainer.js
+++ b/webpack/containers/QuestionModalContainer.js
@@ -1,6 +1,12 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import { Modal, Button } from 'react-bootstrap';
+import values from 'lodash/values';
+import keys from 'lodash/keys';
+import keyBy from 'lodash/keyBy';
+import $ from 'jquery';
+
 import { saveQuestion } from '../actions/questions_actions';
 import Errors from '../components/Errors';
 import QuestionForm from '../components/QuestionForm';
@@ -11,9 +17,6 @@ import { fetchResponseTypes } from '../actions/response_type_actions';
 import { fetchQuestionTypes } from '../actions/question_type_actions';
 import { fetchResponseSets }  from '../actions/response_set_actions';
 import { getMostRecentResponseSets } from '../selectors/response_set_selectors';
-import {Modal, Button} from 'react-bootstrap';
-import _ from 'lodash';
-import $ from 'jquery';
 
 class QuestionModalContainer extends Component {
 
@@ -34,7 +37,7 @@ class QuestionModalContainer extends Component {
 
   handleResponseSetsChange(newResponseSets){
     this.unsavedState = true;
-    this.setState({linkedResponseSets: _.keyBy(newResponseSets, 'id')});
+    this.setState({linkedResponseSets: keyBy(newResponseSets, 'id')});
   }
 
   handleResponseTypeChange(newResponseType){
@@ -46,7 +49,7 @@ class QuestionModalContainer extends Component {
   }
 
   saveNewQuestion(newQuestion){
-    newQuestion.linkedResponseSets = _.values(this.state.linkedResponseSets).map((r) => r.id);
+    newQuestion.linkedResponseSets = values(this.state.linkedResponseSets).map((r) => r.id);
     this.props.saveQuestion(newQuestion, (successResponse) => {
       this.setState({showResponseSetWidget: false, linkedResponseSets: {}, errors: null});
       this.props.handleSaveQuestionSuccess(successResponse);
@@ -73,7 +76,7 @@ class QuestionModalContainer extends Component {
             </div>
           </div>
           <ResponseSetDragWidget responseSets={this.props.responseSets}
-                                 selectedResponseSets={_.values(this.state.linkedResponseSets)}
+                                 selectedResponseSets={values(this.state.linkedResponseSets)}
                                  handleResponseSetsChange={this.handleResponseSetsChange} />
         </Modal.Body>
         <Modal.Footer>
@@ -116,7 +119,7 @@ class QuestionModalContainer extends Component {
           <div className="col-md-8">
               <div className="panel panel-default">
                 <div className="panel-body">
-                  {_.keys(this.state.linkedResponseSets).length > 0 ? <ResponseSetList responseSets={_.values(this.state.linkedResponseSets)} /> : 'No Response Sets selected'}
+                  {keys(this.state.linkedResponseSets).length > 0 ? <ResponseSetList responseSets={values(this.state.linkedResponseSets)} /> : 'No Response Sets selected'}
                 </div>
               </div>
           </div>

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -9,7 +9,7 @@ import { questionProps } from '../prop-types/question_props';
 import CommentList from '../containers/CommentList';
 import currentUserProps from "../prop-types/current_user_props";
 import { publishersProps } from "../prop-types/publisher_props";
-import _ from 'lodash';
+import compact from 'lodash/compact';
 
 class ResponseSetShowContainer extends Component {
   componentWillMount() {
@@ -85,7 +85,7 @@ function mapStateToProps(state, ownProps) {
   props.responseSet = state.responseSets[ownProps.params.rsId];
   props.publishers = state.publishers;
   if (props.responseSet && props.responseSet.questions) {
-    props.questions = _.compact(props.responseSet.questions.map((qId) => state.questions[qId]));
+    props.questions = compact(props.responseSet.questions.map((qId) => state.questions[qId]));
   }
   return props;
 }

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -1,6 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import values from 'lodash/values';
+import capitalize from 'lodash/capitalize';
+
 import { fetchQuestions } from '../actions/questions_actions';
 import { setSteps } from '../actions/tutorial_actions';
 import { newSurvey, fetchSurvey, saveSurvey, saveDraftSurvey } from '../actions/survey_actions';
@@ -11,7 +14,6 @@ import { surveyProps } from '../prop-types/survey_props';
 import SurveyEdit from '../components/SurveyEdit';
 import currentUserProps from "../prop-types/current_user_props";
 import FormSearchContainer from './FormSearchContainer';
-import _ from 'lodash';
 
 class SurveyEditContainer extends Component {
   constructor(props) {
@@ -90,12 +92,12 @@ class SurveyEditContainer extends Component {
         <div className="row">
           <div className="panel panel-default">
             <div className="panel-heading">
-              <h1 className="panel-title">{_.capitalize(this.props.params.action)} Survey </h1>
+              <h1 className="panel-title">{capitalize(this.props.params.action)} Survey </h1>
             </div>
             <div className="panel-body">
               <div className="col-md-5">
                 <FormSearchContainer survey  ={this.props.survey}
-                                     allForms={_.values(this.props.forms)}
+                                     allForms={values(this.props.forms)}
                                      currentUser={this.props.currentUser} />
               </div>
               <SurveyEdit ref='survey' survey={this.props.survey}

--- a/webpack/reducers/concept_systems_reducer.js
+++ b/webpack/reducers/concept_systems_reducer.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
 import {
   FETCH_CONCEPT_SYSTEMS_FULFILLED,
   FETCH_CONCEPT_SYSTEMS_REJECTED
@@ -7,7 +7,7 @@ import {
 export default function conceptSystems(state = {}, action) {
   switch (action.type) {
     case FETCH_CONCEPT_SYSTEMS_FULFILLED:
-      return _.keyBy(action.payload.data, 'id');
+      return keyBy(action.payload.data, 'id');
     case FETCH_CONCEPT_SYSTEMS_REJECTED:
       return {error: 'Concept Service could not be reached, please try again later.'};
     default:

--- a/webpack/reducers/forms_reducer.js
+++ b/webpack/reducers/forms_reducer.js
@@ -8,15 +8,15 @@ import {
   REMOVE_QUESTION,
   REORDER_QUESTION,
   CREATE_FORM
-
 } from '../actions/types';
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
+import omitBy from 'lodash/omitBy';
 
 export default function forms(state = {}, action) {
   let form , index, newState, newForm, direction, question, responseSetId;
   switch (action.type) {
     case FETCH_FORMS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
+      return Object.assign({}, state, keyBy(action.payload.data, 'id'));
     case PUBLISH_FORM_FULFILLED:
     case SAVE_DRAFT_FORM_FULFILLED:
     case FETCH_FORM_FULFILLED:
@@ -67,7 +67,7 @@ export default function forms(state = {}, action) {
       newState[form.id||0] = newForm;
       return newState;
     case DELETE_FORM_FULFILLED:
-      return _.omitBy(state,(v, k)=>{
+      return omitBy(state,(v, k)=>{
         return action.payload.data.id==k;
       });
     default:

--- a/webpack/reducers/questions_reducer.js
+++ b/webpack/reducers/questions_reducer.js
@@ -1,4 +1,6 @@
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
+import omitBy from 'lodash/omitBy';
+import assign from 'lodash/assign';
 
 import {
   SAVE_QUESTION_FULFILLED,
@@ -13,7 +15,7 @@ function addQuestionToState(action, state){
   const id = action.payload.data.id;
   const existingQuestion = questionsClone[action.payload.data.id];
   if (existingQuestion) {
-    questionsClone[id] = _.assign(existingQuestion, action.payload.data);
+    questionsClone[id] = assign(existingQuestion, action.payload.data);
   } else {
     questionsClone[id] = action.payload.data;
   }
@@ -23,12 +25,12 @@ function addQuestionToState(action, state){
 export default function questions(state = {}, action) {
   switch (action.type) {
     case FETCH_QUESTIONS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
+      return Object.assign({}, state, keyBy(action.payload.data, 'id'));
     case SAVE_QUESTION_FULFILLED:
     case FETCH_QUESTION_FULFILLED:
       return addQuestionToState(action, state);
     case DELETE_QUESTION_FULFILLED:
-      return _.omitBy(state,(v, k)=>{
+      return omitBy(state,(v, k)=>{
         return action.payload.data.id==k;
       });
     case FETCH_QUESTION_USAGE_FULFILLED:

--- a/webpack/reducers/reducer_generator.js
+++ b/webpack/reducers/reducer_generator.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
 
 // Returns a reducer function. This function will listen for the passed in
 // successType and it it finds it will return an object where the keys are the
@@ -8,7 +8,7 @@ import _ from 'lodash';
 export function byIdReducer(successType) {
   return (state = {}, action) => {
     if (action.type === successType) {
-      return _.keyBy(action.payload.data, 'id');
+      return keyBy(action.payload.data, 'id');
     } else {
       return state;
     }
@@ -29,7 +29,7 @@ export function byIdWithIndividualReducer(batchSuccessType, individualSuccessTyp
         stateClone[action.payload.data.id] = action.payload.data;
         return stateClone;
       case batchSuccessType:
-        return _.keyBy(action.payload.data, 'id');
+        return keyBy(action.payload.data, 'id');
       default:
         return state;
     }

--- a/webpack/reducers/response_sets_reducer.js
+++ b/webpack/reducers/response_sets_reducer.js
@@ -1,4 +1,5 @@
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
+import assign from 'lodash/assign';
 
 import {
   FETCH_RESPONSE_SETS_FULFILLED,
@@ -14,7 +15,7 @@ export default function responseSets(state = {}, action) {
   switch (action.type) {
     case FETCH_RESPONSE_SETS_FULFILLED:
       responseSetClone = Object.assign({}, state);
-      return _.assign(responseSetClone, _.keyBy(action.payload.data, 'id'));
+      return assign(responseSetClone, keyBy(action.payload.data, 'id'));
     case FETCH_RESPONSE_SET_FULFILLED:
     case SAVE_DRAFT_RESPONSE_SET_FULFILLED:
     case PUBLISH_RESPONSE_SET_FULFILLED:
@@ -23,7 +24,7 @@ export default function responseSets(state = {}, action) {
       const id = action.payload.data.id;
       const existingRs = responseSetClone[action.payload.data.id];
       if (existingRs) {
-        responseSetClone[id] = _.assign(existingRs, action.payload.data);
+        responseSetClone[id] = assign(existingRs, action.payload.data);
       } else {
         responseSetClone[id] = action.payload.data;
       }

--- a/webpack/reducers/search_results_reducer.js
+++ b/webpack/reducers/search_results_reducer.js
@@ -3,7 +3,7 @@ import {
   FETCH_MORE_SEARCH_RESULTS_FULFILLED
 } from '../actions/types';
 
-import _ from 'lodash';
+import cloneDeep from 'lodash/cloneDeep';
 
 export default function searchResults(state = {}, action) {
   switch (action.type) {
@@ -12,7 +12,7 @@ export default function searchResults(state = {}, action) {
       stateClone[action.meta.context] = action.payload.data;
       return stateClone;
     case FETCH_MORE_SEARCH_RESULTS_FULFILLED:
-      const newStateClone = _.cloneDeep(state);
+      const newStateClone = cloneDeep(state);
       const hits = newStateClone[action.meta.context].hits;
       hits.hits = hits.hits.concat(action.payload.data.hits.hits);
       return newStateClone;

--- a/webpack/reducers/surveys_reducer.js
+++ b/webpack/reducers/surveys_reducer.js
@@ -8,13 +8,13 @@ import {
   REORDER_FORM,
   CREATE_SURVEY
 } from '../actions/types';
-import _ from 'lodash';
+import keyBy from 'lodash/keyBy';
 
 export default function surveys(state = {}, action) {
   let survey , index, newState, newSurvey, direction, form;
   switch (action.type) {
     case FETCH_SURVEYS_FULFILLED:
-      return Object.assign({}, state, _.keyBy(action.payload.data, 'id'));
+      return Object.assign({}, state, keyBy(action.payload.data, 'id'));
     case PUBLISH_SURVEY_FULFILLED:
     case SAVE_DRAFT_SURVEY_FULFILLED:
     case FETCH_SURVEY_FULFILLED:

--- a/webpack/selectors/response_set_selectors.js
+++ b/webpack/selectors/response_set_selectors.js
@@ -1,10 +1,10 @@
 import { createSelector } from 'reselect';
-import _ from 'lodash';
+import pickBy from 'lodash/pickBy';
 
 const getResponseSets = (state) => state.responseSets;
 
 export const getMostRecentResponseSets = createSelector(
   getResponseSets, (responseSets) => {
-    return _.pickBy(responseSets, (rs) => rs.mostRecent === rs.version);
+    return pickBy(responseSets, (rs) => rs.mostRecent === rs.version);
   }
 );


### PR DESCRIPTION
Although I have tagged this with SDP-659, this should improve performance across the application.

Two major changes to reduce the size of the JavaScript that is sent to
the browser. First, instead of including all of lodash, including the
individual functions needed. Next, replacing moment with date-fns.
moment does not play nicely with webpack and includes locale files for
everywhere it supports. Webpack can be configured to ignore these, but
the resulting library is still pretty big. date-fns is significantly
smaller and works well with webpack.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop