### PR TITLE
[SDP-659] More webpack clean up

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,7 +10,6 @@
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 
     <%= javascript_include_tag *webpack_asset_paths('babel-polyfill', extension: 'js') %>
-    <%= javascript_include_tag *webpack_asset_paths('bootstrap', extension: 'js') %>
   </head>
 
   <body class="body">

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -10,10 +10,8 @@
       <script language="JavaScript" type="text/javascript" src="https://www.cdc.gov/JScript/metrics/s_code_v21_cdcgov.js"></script>
     <% end %>
     <%= csrf_meta_tags %>
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
 
     <%= javascript_include_tag *webpack_asset_paths('babel-polyfill', extension: 'js') %>
-    <%= javascript_include_tag *webpack_asset_paths('bootstrap', extension: 'js') %>
   </head>
 
   <body class="body">

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -18,7 +18,6 @@ var config = {
 
   entry: {
     // Sources are expected to live in $app_root/webpack
-    'application': './webpack/application.js',
     'bootstrap': 'bootstrap-loader',
     'babel-polyfill': 'babel-polyfill',
     'landing': './webpack/landing.js'

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -18,7 +18,6 @@ var config = {
 
   entry: {
     // Sources are expected to live in $app_root/webpack
-    'bootstrap': 'bootstrap-loader',
     'babel-polyfill': 'babel-polyfill',
     'landing': './webpack/landing.js'
   },

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -5,6 +5,7 @@ var path = require('path');
 var webpack = require('webpack');
 var StatsPlugin = require('stats-webpack-plugin');
 var autoprefixer = require('autoprefixer');
+var BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 // must match config.webpack.dev_server.port
 var devServerPort = 3808;
@@ -21,7 +22,7 @@ var config = {
     'bootstrap': 'bootstrap-loader',
     'babel-polyfill': 'babel-polyfill',
     'landing': './webpack/landing.js'
-    },
+  },
 
   output: {
     // Build assets directly in to public/webpack/, let webpack know
@@ -54,7 +55,7 @@ var config = {
       { test: /\.scss$/, loaders: ['style', 'css', 'postcss', 'sass'] }
     ],
     options: {
-	    sourceMap: true
+      sourceMap: true
     }
   },
 
@@ -79,6 +80,7 @@ var config = {
     new webpack.DefinePlugin({
       DISABLE_USER_REGISTRATION: JSON.stringify(process.env.DISABLE_USER_REGISTRATION || 'false')
     }),
+    new BundleAnalyzerPlugin()
   ]
 };
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-react": "^6.16.0",
     "babel-preset-stage-1": "^6.16.0",
-    "bootstrap-loader": "^1.2.1",
     "css-loader": "^0.25.0",
     "date-fns": "^1.28.5",
     "extract-text-webpack-plugin": "^1.0.1",

--- a/webpack/application.js
+++ b/webpack/application.js
@@ -1,5 +1,0 @@
-require("styles/master.scss");
-require("jquery");
-require("jquery-ujs");
-require("./print.js");
-exports.routes = require("routes.js");

--- a/webpack/landing.js
+++ b/webpack/landing.js
@@ -1,4 +1,5 @@
 require("styles/master.scss");
+require("bootstrap-sass/assets/javascripts/bootstrap.js");
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/webpack/styles/base/_fonts.scss
+++ b/webpack/styles/base/_fonts.scss
@@ -1,2 +1,1 @@
-@import url('https://fonts.googleapis.com/css?family=Montserrat');
 @import url('https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,800,300italic,400italic,600italic,700italic,800italic,700');


### PR DESCRIPTION
This is another PR that contains performance improvements for the application that were implemented as I am working on improving survey load.

This removes bootstrap-loader. This package had its own webpack entry point and was loading the JavaScript portions of bootstrap into the application. It was also loading the bootstrap styles. This was redundant as the styles were also being incorporated into the application's scss. This meant that two copies of the bootstrap css styles were being sent to the browser.

Loading of the JavaScript part of bootstrap has been moved to landing.js. References to the bootstrap webpack entry point have been removed.

Removes application.js as it is no longer used.

Removes an unused font.

The application will now launch the webpack bundle analyzer in a browser on start up.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
