### PR TITLE
[SDP-660, 668] Form edit performance improvements And API fix

### DIFF
--- a/app/controllers/api/forms_controller.rb
+++ b/app/controllers/api/forms_controller.rb
@@ -14,7 +14,7 @@ module Api
     end
 
     def show
-      @form = Form.by_id_and_version(params[:id], params[:version])
+      @form = Form.includes(:published_by, form_questions: [{ response_set: :responses }, :question]).by_id_and_version(params[:id], params[:version])
       if @form.nil?
         not_found
         return

--- a/app/controllers/api/surveys_controller.rb
+++ b/app/controllers/api/surveys_controller.rb
@@ -3,7 +3,11 @@ module Api
     respond_to :json
 
     def index
-      @surveys = params[:search] ? Survey.includes(:forms, :published_by).search(params[:search]) : Survey.all.includes(:forms, :published_by)
+      @surveys = if params[:search]
+                   Survey.includes(:published_by, survey_forms: [form: { form_questions: [:response_set, :question] }]).search(params[:search])
+                 else
+                   Survey.includes(:published_by, survey_forms: [form: { form_questions: [:response_set, :question] }]).all
+                 end
       @surveys = params[:limit] ? @surveys.limit(params[:limit]) : @surveys
       @surveys = @surveys.order(version_independent_id: :asc)
       render json: @surveys, each_serializer: SurveySerializer

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -58,7 +58,7 @@ class FormsController < ApplicationController
         update_successful = @form.update(form_params)
       end
       if update_successful
-        render json: { id: @form.id }, status: :ok
+        render json: @form.to_json, status: :ok
       else
         render json: @form.errors, status: :unprocessable_entity
       end

--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -58,7 +58,7 @@ class FormsController < ApplicationController
         update_successful = @form.update(form_params)
       end
       if update_successful
-        render :show, status: :ok, location: @form
+        render json: { id: @form.id }, status: :ok
       else
         render json: @form.errors, status: :unprocessable_entity
       end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -39,7 +39,7 @@ class SurveysController < ApplicationController
         update_successful = @survey.update(form_params)
       end
       if update_successful
-        render :show, status: :ok, location: @survey
+        render json: { id: @survey.id }, status: :ok
       else
         render json: @survey.errors, status: :unprocessable_entity
       end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -39,7 +39,7 @@ class SurveysController < ApplicationController
         update_successful = @survey.update(form_params)
       end
       if update_successful
-        render json: { id: @survey.id }, status: :ok
+        render json: @survey.to_json, status: :ok
       else
         render json: @survey.errors, status: :unprocessable_entity
       end

--- a/app/jobs/update_index_job.rb
+++ b/app/jobs/update_index_job.rb
@@ -2,8 +2,9 @@ require 'sdp/elastic_search'
 class UpdateIndexJob < ApplicationJob
   queue_as :default
 
-  def perform(type, data)
+  def perform(type, object)
     # call elasticsearch
+    data = "ES#{type.camelize}Serializer".constantize.new(object).as_json
     SDP::Elasticsearch.ensure_index
     SDP::Elasticsearch.with_client do |client|
       if client.exists? index: 'vocabulary', type: type.underscore, id: data[:id]

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -24,7 +24,7 @@ class Form < ApplicationRecord
   after_commit :delete_index, on: :destroy
 
   def index
-    UpdateIndexJob.perform_later('form', ESFormSerializer.new(self).as_json)
+    UpdateIndexJob.perform_later('form', self)
   end
 
   def delete_index

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -14,7 +14,7 @@ class FormQuestion < ApplicationRecord
 
   def reindex_on_update
     # While question can't actually change, previous_changes[:question_id] will exist if this form question was just created
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question)) if previous_changes[:question_id]
+    UpdateIndexJob.perform_later('question', question) if previous_changes[:question_id]
     if response_set && previous_changes[:response_set_id]
       UpdateIndexJob.perform_later('response_set', response_set)
     end

--- a/app/models/form_question.rb
+++ b/app/models/form_question.rb
@@ -8,17 +8,17 @@ class FormQuestion < ApplicationRecord
   after_commit :reindex_on_update, on: [:update]
 
   def reindex
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json) if previous_changes[:question_id]
-    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json) if response_set
+    UpdateIndexJob.perform_later('question', question) if previous_changes[:question_id]
+    UpdateIndexJob.perform_later('response_set', response_set) if response_set
   end
 
   def reindex_on_update
     # While question can't actually change, previous_changes[:question_id] will exist if this form question was just created
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json) if previous_changes[:question_id]
+    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question)) if previous_changes[:question_id]
     if response_set && previous_changes[:response_set_id]
-      UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json)
+      UpdateIndexJob.perform_later('response_set', response_set)
     end
     previous_response_set = ResponseSet.find_by(id: previous_changes[:response_set_id][0]) if previous_changes[:response_set_id]
-    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(previous_response_set).as_json) if previous_response_set
+    UpdateIndexJob.perform_later('response_set', previous_response_set) if previous_response_set
   end
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -23,7 +23,7 @@ class Question < ApplicationRecord
   after_commit :delete_index, on: :destroy
 
   def index
-    UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(self).as_json)
+    UpdateIndexJob.perform_later('question', self)
   end
 
   def delete_index

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -26,7 +26,7 @@ class ResponseSet < ApplicationRecord
   after_commit :delete_index, on: :destroy
 
   def index
-    UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(self).as_json)
+    UpdateIndexJob.perform_later('response_set', self)
   end
 
   def delete_index

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -28,7 +28,7 @@ class Survey < ApplicationRecord
   end
 
   def index
-    UpdateIndexJob.perform_later('survey', ESSurveySerializer.new(self).as_json)
+    UpdateIndexJob.perform_later('survey', self)
   end
 
   def delete_index

--- a/app/models/survey_form.rb
+++ b/app/models/survey_form.rb
@@ -7,14 +7,14 @@ class SurveyForm < ApplicationRecord
 
   def reindex
     if form
-      UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
+      UpdateIndexJob.perform_later('form', form)
       unique_response_sets = []
       form.form_questions.each do |fq|
-        UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(fq.question).as_json)
+        UpdateIndexJob.perform_later('question', fq.question)
         unique_response_sets << fq.response_set if fq.response_set && !unique_response_sets.include?(fq.response_set)
       end
       unique_response_sets.each do |rs|
-        UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(rs).as_json)
+        UpdateIndexJob.perform_later('response_set', rs)
       end
     end
   end

--- a/app/serializers/survey_serializer.rb
+++ b/app/serializers/survey_serializer.rb
@@ -30,5 +30,11 @@ class SurveySerializer < ActiveModel::Serializer
   end
   attribute :version
   attribute :published_by, serializer: UserSerializer
-  has_many :forms, serializer: FormSerializer
+  attribute :forms
+
+  def forms
+    object.survey_forms.includes(form: { form_questions: [:response_set, { question: :concepts }] }).collect do |sf|
+      FormSerializer.new(sf.form)
+    end
+  end
 end

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -135,7 +135,7 @@ module SDP
       with_client do |_client|
         delete_all('form', Form.ids)
         Form.all.each do |form|
-          UpdateIndexJob.perform_later('form', ESFormSerializer.new(form).as_json)
+          UpdateIndexJob.perform_later('form', form)
         end
       end
     end
@@ -145,7 +145,7 @@ module SDP
       with_client do |_client|
         delete_all('question', Question.ids)
         Question.all.each do |question|
-          UpdateIndexJob.perform_later('question', ESQuestionSerializer.new(question).as_json)
+          UpdateIndexJob.perform_later('question', question)
         end
       end
     end
@@ -155,7 +155,7 @@ module SDP
       with_client do |_client|
         delete_all('response_set', ResponseSet.ids)
         ResponseSet.all.each do |response_set|
-          UpdateIndexJob.perform_later('response_set', ESResponseSetSerializer.new(response_set).as_json)
+          UpdateIndexJob.perform_later('response_set', response_set)
         end
       end
     end
@@ -165,7 +165,7 @@ module SDP
       with_client do |_client|
         delete_all('survey', Survey.ids)
         Survey.all.each do |survey|
-          UpdateIndexJob.perform_later('survey', ESSurveySerializer.new(survey).as_json)
+          UpdateIndexJob.perform_later('survey', survey)
         end
       end
     end

--- a/lib/tasks/data.rake
+++ b/lib/tasks/data.rake
@@ -41,5 +41,7 @@ namespace :data do
       survey.survey_forms << SurveyForm.new(form: f, position: survey_position)
     end
     survey.save!
+    #wait for the async job queue to be processed
+    sleep 60
   end
 end

--- a/test/jobs/update_index_job_test.rb
+++ b/test/jobs/update_index_job_test.rb
@@ -1,20 +1,20 @@
 require 'test_helper'
 
 class UpdateIndexJobJobTest < ActiveJob::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
   test 'job calls update index' do
-    UpdateIndexJob.perform_now('form', id: 1)
+    form = forms(:one)
+    UpdateIndexJob.perform_now('form', form)
     req = FakeWeb.last_request
     assert_equal 'POST', req.method
-    assert_equal '/vocabulary/form/1/_update', req.path
+    assert_equal "/vocabulary/form/#{form.id}/_update", req.path
   end
 
   test 'job calls create index' do
-    UpdateIndexJob.perform_now('form', id: 2)
+    form = forms(:two)
+    FakeWeb.register_uri(:head, "http://example.com:9200/vocabulary/form/#{form.id}", status: ['404', 'Not Found'])
+    UpdateIndexJob.perform_now('form', form)
     req = FakeWeb.last_request
     assert_equal 'PUT', req.method
-    assert_equal '/vocabulary/form/2?op_type=create', req.path
+    assert_equal "/vocabulary/form/#{form.id}?op_type=create", req.path
   end
 end

--- a/test/support/fakeweb.rb
+++ b/test/support/fakeweb.rb
@@ -1,4 +1,3 @@
 require 'fakeweb'
 FakeWeb.allow_net_connect = %r{^https?://localhost}
 FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: 'Hello World!')
-FakeWeb.register_uri(:head, 'http://example.com:9200/vocabulary/form/2', status: ['404', 'Not Found'])


### PR DESCRIPTION
Improved Form save performance , by not returning the whole object in response to a save, and by making ES jobs not immediately serialize the object before putting the job in the queue. Also fixed API survey bug where questions were missing.

- [na] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [na] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [na] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
