### PR TITLE
[SDP-677,678,679] Question response type default and other bugs

### DIFF
--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -12,6 +12,7 @@ class Form < ApplicationRecord
   belongs_to :published_by, class_name: 'User'
   belongs_to :parent, class_name: 'Form'
 
+  validates :name, presence: true
   validates :created_by, presence: true
   validates :control_number, allow_blank: true, format: { with: /\A\d{4}-\d{4}\z/,
                                                           message: 'must be a valid OMB Control Number' },

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -16,7 +16,6 @@ class Question < ApplicationRecord
   belongs_to :parent, class_name: 'Question'
 
   validates :content, presence: true
-  validates :response_type, presence: true
   validate :other_allowed_on_when_choice
   accepts_nested_attributes_for :concepts, allow_destroy: true
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -16,6 +16,7 @@ class Question < ApplicationRecord
   belongs_to :parent, class_name: 'Question'
 
   validates :content, presence: true
+  validates :response_type, presence: true
   validate :other_allowed_on_when_choice
   accepts_nested_attributes_for :concepts, allow_destroy: true
 

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -12,6 +12,7 @@ class Survey < ApplicationRecord
   belongs_to :surveillance_system
   belongs_to :surveillance_program
 
+  validates :name, presence: true
   validates :created_by, presence: true
   validates :control_number, allow_blank: true, format: { with: /\A\d{4}-\d{4}\z/,
                                                           message: 'must be a valid OMB Control Number' },

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -78,7 +78,6 @@ var config = {
     new webpack.DefinePlugin({
       DISABLE_USER_REGISTRATION: JSON.stringify(process.env.DISABLE_USER_REGISTRATION || 'false')
     }),
-    new BundleAnalyzerPlugin()
   ]
 };
 
@@ -97,6 +96,9 @@ if (production) {
     new webpack.optimize.OccurenceOrderPlugin()
   );
 } else {
+  config.plugins.push(
+    new BundleAnalyzerPlugin()
+  );
   config.devServer = {
     port: devServerPort,
     headers: { 'Access-Control-Allow-Origin': '*' }

--- a/test/controllers/questions_controller_test.rb
+++ b/test/controllers/questions_controller_test.rb
@@ -28,10 +28,10 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'revisions should increment version without needing a param' do
-    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     Question.last.publish(@current_user)
     v1 = Question.last
-    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_response :success
     v2 = Question.last
     assert_equal v1.version_independent_id, v2.version_independent_id
@@ -40,25 +40,25 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'cannot revise something you do not own' do
-    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     Question.last.publish(@current_user)
     sign_in users(:not_admin)
-    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_response :unauthorized
   end
 
   test 'cannot revise a draft' do
-    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'This is now a thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     # Question.last.publish
     assert_equal DRAFT, Question.last.status
-    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { version_independent_id: Question.last.version_independent_id, content: 'This is now a revision thread.', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_response :unprocessable_entity
   end
 
   test 'should create a draft question' do
     assert_enqueued_jobs 0
     assert_difference('Question.count') do
-      post questions_url(format: :json), params: { question: { content: 'Unique content', question_type_id: @question.question_type.id } }
+      post questions_url(format: :json), params: { question: { content: 'Unique content', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     end
     assert_enqueued_jobs 1
     assert_response :created
@@ -67,19 +67,19 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should update a draft question' do
-    post questions_url(format: :json), params: { question: { content: 'TBD content', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'TBD content', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_equal DRAFT, Question.last.status
-    put question_url(Question.last, format: :json), params: { question: { content: 'new content' } }
+    put question_url(Question.last, format: :json), params: { question: { content: 'new content', response_type_id: @question.response_type.id } }
     assert_equal 'new content', Question.last.content
   end
 
   test 'should be unable to update a draft question owned by someone else' do
-    patch question_url(@question5, format: :json), params: { question: { content: 'new content' } }
+    patch question_url(@question5, format: :json), params: { question: { content: 'new content', response_type_id: @question.response_type.id } }
     assert_response :forbidden
   end
 
   test 'should be unable to update a published question' do
-    patch question_url(questions(:one), format: :json), params: { question: { content: 'secret content' } }
+    patch question_url(questions(:one), format: :json), params: { question: { content: 'secret content', response_type_id: @question.response_type.id } }
     assert_response :unprocessable_entity
     assert_nil Question.find_by(content: 'secret content')
   end
@@ -98,7 +98,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy a draft question' do
-    post questions_url(format: :json), params: { question: { content: 'TBD content', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'TBD content', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_equal Question.last.status, 'draft'
     last_id = Question.last.id
     assert_difference('Question.count', -1) do
@@ -109,7 +109,7 @@ class QuestionsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test 'should destroy a draft question and questionForms' do
-    post questions_url(format: :json), params: { question: { content: 'TBD content', question_type_id: @question.question_type.id } }
+    post questions_url(format: :json), params: { question: { content: 'TBD content', response_type_id: @question.response_type.id, question_type_id: @question.question_type.id } }
     assert_equal Question.last.status, 'draft'
     last_id = Question.last.id
     linked_question = { question_id: last_id, response_set_id: nil, position: 1, program_var: 'test' }

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -13,6 +13,7 @@ two:
   content: What is another question example?
   created_by: admin
   question_type: one
+  response_type: one
   version: 1
   version_independent_id: Q-2
 
@@ -20,6 +21,7 @@ three:
   content: What is another question example?
   created_by: admin
   question_type: one
+  response_type: one
   version: 1
   version_independent_id: Q-3
 
@@ -27,6 +29,7 @@ gfv2:
   content: What is another question example?
   created_by: admin
   question_type: one
+  response_type: one
   version: 2
   version_independent_id: Q-3
 
@@ -34,6 +37,7 @@ five:
   content: Who did this?
   created_by: not_admin
   question_type: one
+  response_type: four
   version: 1
   version_independent_id: Q-5
 
@@ -41,6 +45,7 @@ search_1:
   content: Search Question 1
   created_by: admin
   question_type: one
+  response_type: one
   status: published
   version: 1
   version_independent_id: Q-6
@@ -49,6 +54,7 @@ search_2:
   content: Search Question 2
   created_by: admin
   question_type: one
+  response_type: one
   version: 1
   version_independent_id: Q-7
 
@@ -56,5 +62,6 @@ search_3:
   content: Search question 3
   created_by: not_admin
   question_type: one
+  response_type: one
   version: 1
   version_independent_id: Q-8

--- a/test/models/form_test.rb
+++ b/test/models/form_test.rb
@@ -20,40 +20,40 @@ class FormTest < ActiveSupport::TestCase
     user   = users(:admin)
     prefix = Form.oid_prefix
 
-    f1 = Form.new(created_by: user)
+    f1 = Form.new(name: 'Doubly Double1', created_by: user)
     assert f1.save
     assert_equal 1, f1.version
     assert_equal "F-#{f1.id}", f1.version_independent_id
     assert_equal "#{prefix}.#{f1.id}", f1.oid
 
-    f2 = Form.new(created_by: user)
+    f2 = Form.new(name: 'Doubly Double2', created_by: user)
     f2.oid = "#{prefix}.#{f1.id}"
     assert_not f2.valid?
     f2.oid = "#{prefix}.#{f1.id + 1}"
     assert f2.valid?
     assert f2.save
 
-    f3 = Form.new(created_by: user)
+    f3 = Form.new(name: 'Doubly Double3', created_by: user)
     f3.oid = "#{prefix}.#{f2.id + 2}"
     assert f3.save
 
-    f4 = Form.new(created_by: user)
+    f4 = Form.new(name: 'Doubly Double4', created_by: user)
     f4.oid = "#{prefix}.#{f2.id + 4}"
     assert f4.save
 
     # Should find next available oid which is f2.oid+3 NOT f4.oid+1
-    f5 = Form.new(created_by: user)
+    f5 = Form.new(name: 'Doubly Double5', created_by: user)
     assert f5.save
     assert_equal "#{prefix}.#{f2.id + 3}", f5.oid
 
     # Should follow special validation rules for new versions
-    f6 = Form.new(created_by: user)
+    f6 = Form.new(name: 'Doubly Double6', created_by: user)
     f6.version_independent_id = f1.version_independent_id
     f6.version = f1.version + 1
     assert f6.save
     assert_equal f1.oid, f6.oid
 
-    f7 = Form.new(created_by: user)
+    f7 = Form.new(name: 'Doubly Double7', created_by: user)
     f7.version_independent_id = f1.version_independent_id
     f7.version = f1.version + 2
     f7.oid = f1.oid
@@ -80,12 +80,14 @@ class FormTest < ActiveSupport::TestCase
     assert rs.save
     rs2 = ResponseSet.new(name: 'Test publish 2', created_by: user)
     assert rs2.save
-    q = Question.new(content: 'Test publish', created_by: user)
+    rt = ResponseType.new(name: 'choice', code: 'choice')
+    assert rt.save
+    q = Question.new(content: 'Test publish', response_type: rt, created_by: user)
     q.response_sets = [rs]
     assert q.save
-    q2 = Question.new(content: 'Test publish 2', created_by: user)
+    q2 = Question.new(content: 'Test publish 2', response_type: rt, created_by: user)
     assert q2.save
-    q3 = Question.new(content: 'Test publish 3', created_by: user)
+    q3 = Question.new(content: 'Test publish 3', response_type: rt, created_by: user)
     assert q3.save
     f = Form.new(name: 'Test publish', created_by: user)
     f.form_questions = [FormQuestion.new(question_id: q.id, response_set_id: rs.id, position: 0), FormQuestion.new(question_id: q2.id, response_set_id: rs2.id, position: 1), FormQuestion.new(question_id: q3.id, position: 2)]

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class QuestionTest < ActiveSupport::TestCase
   test 'Question should allow type to be set' do
-    question = Question.new(content: 'content')
+    question = Question.new(content: 'content', response_type: ResponseType.new(code: 'date'))
     type = QuestionType.new(name: 'TestName')
     question.question_type = type
     assert question.save
@@ -19,9 +19,9 @@ class QuestionTest < ActiveSupport::TestCase
   end
 
   test 'versions must be unique' do
-    q1 = Question.new(content: 'content')
+    q1 = Question.new(content: 'content', response_type: ResponseType.new(code: 'date'))
     assert q1.save
-    q2 = Question.new(content: 'content', version: 1, version_independent_id: q1.version_independent_id)
+    q2 = Question.new(content: 'content', response_type: ResponseType.new(code: 'date'), version: 1, version_independent_id: q1.version_independent_id)
     assert_not q2.save
     q2.version = 2
     assert q2.save
@@ -66,40 +66,40 @@ class QuestionTest < ActiveSupport::TestCase
   test 'assign_new_oids' do
     prefix = Question.oid_prefix
 
-    q1 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q1 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     assert q1.save
     assert_equal 1, q1.version
     assert_equal "Q-#{q1.id}", q1.version_independent_id
     assert_equal "#{prefix}.#{q1.id}", q1.oid
 
-    q2 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q2 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     q2.oid = "#{prefix}.#{q1.id}"
     assert_not q2.valid?
     q2.oid = "#{prefix}.#{q1.id + 1}"
     assert q2.valid?
     assert q2.save
 
-    q3 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q3 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     q3.oid = "#{prefix}.#{q2.id + 3}"
     assert q3.save
 
-    q4 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q4 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     q4.oid = "#{prefix}.#{q2.id + 5}"
     assert q4.save
 
     # Should find next available oid which is q2.id+4 NOT q2.id+5
-    q5 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q5 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     assert q5.save
     assert_equal "#{prefix}.#{q2.id + 4}", q5.oid
 
     # Should follow special validation rules for new versions
-    q6 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q6 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     q6.version_independent_id = q1.version_independent_id
     q6.version = q1.version + 1
     assert q6.save
     assert_equal q1.oid, q6.oid
 
-    q7 = Question.new(content: 'test', question_type: QuestionType.new(name: 'TestName'))
+    q7 = Question.new(content: 'test', response_type: ResponseType.new(code: 'date'), question_type: QuestionType.new(name: 'TestName'))
     q7.version_independent_id = q1.version_independent_id
     q7.version = q1.version + 2
     q7.oid = q1.oid
@@ -137,7 +137,7 @@ class QuestionTest < ActiveSupport::TestCase
     user = users(:admin)
     rs = ResponseSet.new(name: 'Test publish', created_by: user)
     assert rs.save
-    q = Question.new(content: 'Test publish', created_by: user)
+    q = Question.new(content: 'Test publish', response_type: ResponseType.new(code: 'date'), created_by: user)
     q.response_sets = [rs]
     assert q.save
     q.publish(user)

--- a/test/models/survey_test.rb
+++ b/test/models/survey_test.rb
@@ -24,7 +24,7 @@ class SurveyTest < ActiveSupport::TestCase
     user = users(:admin)
     rs = ResponseSet.new(name: 'Test publish', created_by: user)
     assert rs.save
-    q = Question.new(content: 'Test publish', created_by: user)
+    q = Question.new(content: 'Test publish', response_type: ResponseType.new(name: 'choice', code: 'choice'), created_by: user)
     q.response_sets = [rs]
     assert q.save
     f = Form.new(name: 'Test publish', created_by: user)

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -152,7 +152,7 @@ class DashboardSearch extends Component {
             {(this.state.progFilters.length > 0 || this.state.sysFilters.length > 0) && <a href="#" tabIndex="4" className="adv-search-link pull-right" onClick={(e) => {
               e.preventDefault();
               this.clearAdvSearch();
-            }}>Clear Filters</a>}
+            }}>Clear Programs & Systems</a>}
             <a className="adv-search-link pull-right" title="Advanced Search" href="#" tabIndex="4" onClick={(e) => {
               e.preventDefault();
               this.showAdvSearch();

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -36,6 +36,14 @@ class QuestionForm extends Component{
     this.unsavedState = false;
   }
 
+  componentWillReceiveProps(nextProps) {
+    if(this.props.responseTypes !== nextProps.responseTypes && (this.state.responseTypeId === null || this.state.responseTypeId === undefined)) {
+      const sortedRT = this.sortedResponseTypes(nextProps.responseTypes);
+      let rtid = sortedRT[0] ? sortedRT[0].id : null;
+      this.setState({ responseTypeId: rtid });
+    }
+  }
+
   componentDidMount() {
     if(this.props.route && this.props.router){
       this.unbindHook = this.props.router.setRouteLeaveHook(this.props.route, this.routerWillLeave.bind(this));
@@ -188,9 +196,8 @@ class QuestionForm extends Component{
                 <div className="col-md-4 question-form-group">
                   <label className="input-label" htmlFor="responseTypeId">Response Type</label>
                     <select name="responseTypeId" id="responseTypeId" className="input-select" defaultValue={ question ? question.responseTypeId :state.responseTypeId} onChange={this.handleResponseTypeChange()} >
-                      {this.sortedResponseTypes().map((rt) => {
+                      {this.sortedResponseTypes(this.props.responseTypes).map((rt) => {
                         return (<option key={rt.id} value={rt.id} >{rt.name} - {rt.description}</option>);
-
                       })}
                     </select>
                   </div>
@@ -250,8 +257,8 @@ class QuestionForm extends Component{
     }
   }
 
-  sortedResponseTypes(){
-    return values(this.props.responseTypes).sort((a,b) => {
+  sortedResponseTypes(responseTypes){
+    return values(responseTypes).sort((a,b) => {
       if(a.name == b.name ){
         return 0;
       }else if(a.name < b.name){

--- a/webpack/components/QuestionForm.js
+++ b/webpack/components/QuestionForm.js
@@ -37,7 +37,7 @@ class QuestionForm extends Component{
   }
 
   componentWillReceiveProps(nextProps) {
-    if(this.props.responseTypes !== nextProps.responseTypes && (this.state.responseTypeId === null || this.state.responseTypeId === undefined)) {
+    if(this.state.responseTypeId === null || this.state.responseTypeId === undefined) {
       const sortedRT = this.sortedResponseTypes(nextProps.responseTypes);
       let rtid = sortedRT[0] ? sortedRT[0].id : null;
       this.setState({ responseTypeId: rtid });

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -301,7 +301,7 @@ class DashboardContainer extends Component {
           </div>
           </button>
       </ul>
-      {searchType != '' && <a href="#" tabIndex="4" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
+      {(searchType !== '' && searchType !== undefined)&& <a href="#" tabIndex="4" onClick={() => this.selectType(searchType)}>Clear Type Filter</a>}
     </div>);
   }
 


### PR DESCRIPTION
Does the following:
- Makes analyzer plugin not run in production
- Makes it so creating a question and not changing response type behaves as expected / as displayed (saves with first response type in the list instead of as undefined / null)
- Update wording for clearing advanced filters as per a discussion with ammu concerning feedback from UAT
- Adds validation on names for all object creation, will also add validation on response_type for questions once I can figure out issues it causes with redcap import

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
