### PR TITLE
Removing invalid JS from a test

### DIFF
--- a/test/frontend/components/question_form_test.js
+++ b/test/frontend/components/question_form_test.js
@@ -14,7 +14,6 @@ describe('QuestionForm', () => {
       action: 'new',
       questionSubmitter: ()=>{},
       draftSubmitter: ()=>{},
-      show: {false},
       questionTypes: {},
       responseSets:  {1: {id: 1, name: "Colors", description: "A list of colors", oid: "2.16.840.1.113883.3.1502.3.1"}},
       responseTypes: {1: {id: 1, name: "Integer", description: "A number", code: "integer"},


### PR DESCRIPTION
I've upgraded to node v8.1.3 and the removed line was causing problems.
I'm not sure how it ever worked, but the QuestionForm component does not
need a show property.
