### PR TITLE
[SDP-492] Show added items

### DIFF
--- a/features/edit_forms.feature
+++ b/features/edit_forms.feature
@@ -83,6 +83,7 @@ Feature: Edit Forms
     And I fill in the "search" field with "What"
     And I set search filter to "question"
     And I click on the "search-btn" button
+    And I should not see "Result Already Added"
     And I use the question search to select "What is your gender?"
     And I use the response set search modal to select "Gender Partial"
     When I select the add program variable option for the Question "What is your gender?"
@@ -93,6 +94,7 @@ Feature: Edit Forms
     And I use the question search to select "What is your name?"
     And I move the Question "What is your name?" up
     And I should see "TEST VAR"
+    And I should see "Result Already Added"
     And I click on the "Save" button
     And I should see "What is your gender?"
     Then I wait 1 seconds

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -125,11 +125,13 @@ Feature: Manage Surveys
     And I click on the option to Revise the Survey with the name "Test Survey"
     And I fill in the "search" field with "Form"
     And I click on the "search-btn" button
+    And I should not see "Result Already Added"
     And I use the form search to select "Gender Form"
     And I use the form search to select "Demographics Form"
     And I wait 3 seconds
     And I move the Form "Gender Form" down
     And I move the Form "Gender Form" up
+    And I should see "Result Already Added"
     And I click on the "Save" button
     And I should see "Gender Form"
     And I should see "Demographics Form"

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -15,6 +15,7 @@ export default class SearchResult extends Component {
                             this.props.result.Source,
                             this.props.result.highlight,
                             this.props.handleSelectSearchResult,
+                            this.props.isSelected,
                             this.props.isEditPage,
                             this.props.extraActionName,
                             this.props.extraAction));
@@ -122,13 +123,22 @@ export default class SearchResult extends Component {
     );
   }
 
-  selectResultButton(result, handleSelectSearchResult) {
-    return (
-      <a title="Select Search Result" href="#" id={`select-${result.name}`} onClick={(e) => {
-        e.preventDefault();
-        handleSelectSearchResult(result);
-      }}><i className="fa fa-plus-square fa-2x"></i><span className="sr-only">Add or Select Result</span></a>
-    );
+  selectResultButton(result, isSelected, handleSelectSearchResult) {
+    if(isSelected){
+      return (
+        <div>
+          <i className="fa fa-check-square fa-2x" title="Result Already Added"></i>
+          <span className="sr-only">Result Already Added</span>
+        </div>
+      );
+    } else {
+      return (
+        <a title="Select Search Result" href="#" id={`select-${result.name}`} onClick={(e) => {
+          e.preventDefault();
+          handleSelectSearchResult(result);
+        }}><i className="fa fa-plus-square fa-2x"></i><span className="sr-only">Add or Select Result</span></a>
+      );
+    }
   }
 
   questionCollapsable(result) {
@@ -266,7 +276,7 @@ export default class SearchResult extends Component {
     }
   }
 
-  baseResult(type, result, highlight, handleSelectSearchResult, isEditPage, actionName, action) {
+  baseResult(type, result, highlight, handleSelectSearchResult, isSelected, isEditPage, actionName, action) {
     const iconMap = {'response_set': 'fa-list', 'question': 'fa-tasks', 'form_question': 'fa-tasks', 'form': 'fa-list-alt', 'survey_form': 'fa-list-alt', 'survey': 'fa-clipboard'};
     return (
       <ul className="u-result-group u-result u-result-content" id={`${type}_id_${result.id}`} aria-label="Summary of a search result or linked object's attributes.">
@@ -303,7 +313,7 @@ export default class SearchResult extends Component {
           <div className="result-nav-item"><Link to={`/${type.replace('_s','S')}s/${result.id}`}><i className="fa fa-eye fa-lg" aria-hidden="true"></i><span className="sr-only">View Item Details</span></Link></div>
           <div className="result-nav-item">
             {handleSelectSearchResult ? (
-              this.selectResultButton(result, handleSelectSearchResult)
+              this.selectResultButton(result, isSelected, handleSelectSearchResult)
             ) : (
               <div className="dropdown">
                 <a id={`${type}_${result.id}_menu`} role="navigation" href="#item-menu" className="dropdown-toggle widget-dropdown-toggle" data-toggle="dropdown">
@@ -334,5 +344,6 @@ SearchResult.propTypes = {
   selectedResponseSetId: PropTypes.number,
   showResponseSetSearch: PropTypes.func,
   handleResponseSetChange:  PropTypes.func,
-  handleSelectSearchResult: PropTypes.func
+  handleSelectSearchResult: PropTypes.func,
+  isSelected: PropTypes.bool
 };

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -91,8 +91,10 @@ class FormSearchContainer extends Component {
             return (
               <SearchResult key={`${f.Source.versionIndependentId}-${f.Source.updatedAt}-${i}`}
               type={f.Type} result={f} currentUser={this.props.currentUser}
+              isEditPage={true}
               handleSelectSearchResult={() => this.props.addForm(this.props.survey, f.Source)}
-              isEditPage={true}/>
+              isSelected={this.props.selectedSearchResults[f.Id]}
+              />
             );
           })}
           {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
@@ -125,6 +127,7 @@ FormSearchContainer.propTypes = {
   fetchMoreSearchResults: PropTypes.func,
   currentUser: currentUserProps,
   searchResults: PropTypes.object,
+  isSelected: PropTypes.bool,
   surveillanceSystems: surveillanceSystemsProps,
   surveillancePrograms: surveillanceProgramsProps
 };

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -127,7 +127,7 @@ FormSearchContainer.propTypes = {
   fetchMoreSearchResults: PropTypes.func,
   currentUser: currentUserProps,
   searchResults: PropTypes.object,
-  isSelected: PropTypes.bool,
+  selectedSearchResults: PropTypes.object,
   surveillanceSystems: surveillanceSystemsProps,
   surveillancePrograms: surveillanceProgramsProps
 };

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -126,6 +126,7 @@ class FormsEditContainer extends Component {
         <div>Loading...</div>
       );
     }
+
     return (
       <div className="form-edit-container">
         <QuestionModalContainer route ={this.props.route}
@@ -147,7 +148,8 @@ class FormsEditContainer extends Component {
                 <div className="row add-question">
                   <Button tabIndex="4" onClick={this.showQuestionModal} bsStyle="primary">Add New Question</Button>
                 </div>
-                <QuestionSearchContainer handleSelectSearchResult={this.handleSelectSearchResult} />
+                <QuestionSearchContainer selectedSearchResults={this.props.selectedSearchResults}
+                                         handleSelectSearchResult={this.handleSelectSearchResult} />
               </div>
               <FormEdit ref ='form'
                         form={this.props.form}
@@ -175,10 +177,18 @@ function mapDispatchToProps(dispatch) {
 }
 
 function mapStateToProps(state, ownProps) {
+  const form = state.forms[ownProps.params.formId || 0];
+  var selectedSearchResults = {};
+  if(form){
+    form.formQuestions.map((fq)=>{
+      selectedSearchResults[fq.questionId] = true;
+    });
+  }
   return {
-    form: state.forms[ownProps.params.formId||0],
+    form: form,
     questions: state.questions,
-    responseSets: state.responseSets
+    responseSets: state.responseSets,
+    selectedSearchResults: selectedSearchResults
   };
 }
 
@@ -197,7 +207,8 @@ FormsEditContainer.propTypes = {
   saveDraftForm: PropTypes.func,
   fetchQuestion: PropTypes.func,
   removeQuestion: PropTypes.func,
-  reorderQuestion: PropTypes.func
+  reorderQuestion: PropTypes.func,
+  selectedSearchResults: PropTypes.object
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(FormsEditContainer);

--- a/webpack/containers/FormsEditContainer.js
+++ b/webpack/containers/FormsEditContainer.js
@@ -179,7 +179,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
   const form = state.forms[ownProps.params.formId || 0];
   var selectedSearchResults = {};
-  if(form){
+  if(form && form.formQuestions){
     form.formQuestions.map((fq)=>{
       selectedSearchResults[fq.questionId] = true;
     });

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -86,7 +86,8 @@ class QuestionSearchContainer extends Component {
                             result={q}
                             isEditPage={true}
                             currentUser={this.props.currentUser}
-                            handleSelectSearchResult={this.props.handleSelectSearchResult} />
+                            handleSelectSearchResult={this.props.handleSelectSearchResult}
+                            isSelected={this.props.selectedSearchResults[q.Id]} />
             );
           })}
           {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
@@ -113,6 +114,7 @@ function mapDispatchToProps(dispatch) {
 
 QuestionSearchContainer.propTypes = {
   handleSelectSearchResult: PropTypes.func.isRequired,
+  selectedSearchResults: PropTypes.object.isRequired,
   fetchSearchResults: PropTypes.func,
   fetchMoreSearchResults: PropTypes.func,
   currentUser: currentUserProps,

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -99,7 +99,7 @@ class SurveyEditContainer extends Component {
               <div className="col-md-5">
                 <FormSearchContainer survey  ={this.props.survey}
                                      allForms={values(this.props.forms)}
-                                     currentUser={this.props.currentUser} 
+                                     currentUser={this.props.currentUser}
                                      selectedSearchResults={this.props.selectedSearchResults} />
               </div>
               <SurveyEdit ref='survey' survey={this.props.survey}

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -127,7 +127,7 @@ function mapDispatchToProps(dispatch) {
 function mapStateToProps(state, ownProps) {
   const survey = state.surveys[ownProps.params.surveyId||0];
   var selectedSearchResults = {};
-  if(survey){
+  if(survey && survey.surveyForms){
     survey.surveyForms.map((sf)=>{
       selectedSearchResults[sf.formId] = true;
     });

--- a/webpack/containers/SurveyEditContainer.js
+++ b/webpack/containers/SurveyEditContainer.js
@@ -99,7 +99,8 @@ class SurveyEditContainer extends Component {
               <div className="col-md-5">
                 <FormSearchContainer survey  ={this.props.survey}
                                      allForms={values(this.props.forms)}
-                                     currentUser={this.props.currentUser} />
+                                     currentUser={this.props.currentUser} 
+                                     selectedSearchResults={this.props.selectedSearchResults} />
               </div>
               <SurveyEdit ref='survey' survey={this.props.survey}
                           action={this.props.params.action || 'new'}
@@ -124,11 +125,19 @@ function mapDispatchToProps(dispatch) {
 }
 
 function mapStateToProps(state, ownProps) {
+  const survey = state.surveys[ownProps.params.surveyId||0];
+  var selectedSearchResults = {};
+  if(survey){
+    survey.surveyForms.map((sf)=>{
+      selectedSearchResults[sf.formId] = true;
+    });
+  }
   return {
-    survey: state.surveys[ownProps.params.surveyId||0],
+    survey: survey,
     forms:  state.forms,
     questions: state.questions,
-    currentUser: state.currentUser
+    currentUser: state.currentUser,
+    selectedSearchResults: selectedSearchResults
   };
 }
 
@@ -146,7 +155,8 @@ SurveyEditContainer.propTypes = {
   removeForm:  PropTypes.func,
   reorderForm: PropTypes.func,
   currentUser: currentUserProps,
-  saveDraftSurvey: PropTypes.func
+  saveDraftSurvey: PropTypes.func,
+  selectedSearchResults: PropTypes.object
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(SurveyEditContainer);


### PR DESCRIPTION
When you add a question to a form or form to a survey, the add button becomes a  grey checkmark to let you know it can't be added again.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [na] If any database changes were made, run `rake generate_erd` to update the README.md
- [na] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
