### PR TITLE
[SDP-709,712] Update Analytics when item Deleted

### DIFF
--- a/webpack/actions/landing.js
+++ b/webpack/actions/landing.js
@@ -1,7 +1,8 @@
 import axios from 'axios';
 
 import {
-  FETCH_STATS
+  FETCH_STATS,
+  SET_STATS
 } from './types';
 
 export function fetchStats() {
@@ -9,5 +10,12 @@ export function fetchStats() {
     type: FETCH_STATS,
     payload: axios.get('/landing/stats',
                        {headers: {'X-Key-Inflection': 'camel'}})
+  };
+}
+
+export function setStats(stats) {
+  return {
+    type: SET_STATS,
+    payload: stats
   };
 }

--- a/webpack/actions/types.js
+++ b/webpack/actions/types.js
@@ -29,6 +29,8 @@ export const SET_STEPS = 'SET_STEPS';
 // Landing types
 export const FETCH_STATS = 'FETCH_STATS';
 export const FETCH_STATS_FULFILLED = 'FETCH_STATS_FULFILLED';
+export const SET_STATS = 'SET_STATS';
+export const SET_STATS_FULFILLED = 'SET_STATS_FULFILLED';
 
 // Search types
 export const FETCH_SEARCH_RESULTS = 'FETCH_SEARCH_RESULTS';

--- a/webpack/actions/types.js
+++ b/webpack/actions/types.js
@@ -30,7 +30,6 @@ export const SET_STEPS = 'SET_STEPS';
 export const FETCH_STATS = 'FETCH_STATS';
 export const FETCH_STATS_FULFILLED = 'FETCH_STATS_FULFILLED';
 export const SET_STATS = 'SET_STATS';
-export const SET_STATS_FULFILLED = 'SET_STATS_FULFILLED';
 
 // Search types
 export const FETCH_SEARCH_RESULTS = 'FETCH_SEARCH_RESULTS';

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { hashHistory, Link } from 'react-router';
 import Pagination from 'rc-pagination';
-import assign from 'lodash/assign';
 
 import FormQuestionList from './FormQuestionList';
 import Routes from '../routes';

--- a/webpack/components/FormShow.js
+++ b/webpack/components/FormShow.js
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { hashHistory, Link } from 'react-router';
 import Pagination from 'rc-pagination';
+import assign from 'lodash/assign';
 
 import FormQuestionList from './FormQuestionList';
 import Routes from '../routes';
@@ -96,6 +97,10 @@ class FormShow extends Component {
               if(confirm('Are you sure you want to delete this Form? This action cannot be undone.')){
                 this.props.deleteForm(form.id, (response) => {
                   if (response.status == 200) {
+                    let stats = Object.assign({}, this.props.stats);
+                    stats.formCount = this.props.stats.formCount - 1;
+                    stats.myFormCount = this.props.stats.myFormCount - 1;
+                    this.props.setStats(stats);
                     this.props.router.push('/');
                   }
                 });
@@ -154,6 +159,8 @@ FormShow.propTypes = {
   currentUser: currentUserProps,
   publishForm: PropTypes.func,
   deleteForm:  PropTypes.func.isRequired,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   publishers: publishersProps
 };
 

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
 import { hashHistory, Link } from 'react-router';
+import assign from 'lodash/assign';
 
 import VersionInfo from "./VersionInfo";
 import ResponseSetList from "./ResponseSetList";
@@ -83,6 +84,10 @@ export default class QuestionDetails extends Component {
                 if(confirm('Are you sure you want to delete this Question? This action cannot be undone.')){
                   this.props.deleteQuestion(question.id, (response) => {
                     if (response.status == 200) {
+                      let stats = Object.assign({}, this.props.stats);
+                      stats.questionCount = this.props.stats.questionCount - 1;
+                      stats.myQuestionCount = this.props.stats.myQuestionCount - 1;
+                      this.props.setStats(stats);
                       this.props.router.push('/');
                     }
                   });
@@ -183,5 +188,7 @@ QuestionDetails.propTypes = {
   responseSets: PropTypes.array,
   handlePublish:  PropTypes.func,
   deleteQuestion: PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   publishers: publishersProps
 };

--- a/webpack/components/QuestionDetails.js
+++ b/webpack/components/QuestionDetails.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
 import { hashHistory, Link } from 'react-router';
-import assign from 'lodash/assign';
 
 import VersionInfo from "./VersionInfo";
 import ResponseSetList from "./ResponseSetList";

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
+import assign from 'lodash/assign';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
 import VersionInfo from './VersionInfo';
@@ -94,6 +95,10 @@ export default class ResponseSetDetails extends Component {
               if(confirm('Are you sure you want to delete this Response Set? This action cannot be undone.')){
                 this.props.deleteResponseSet(responseSet.id, (response) => {
                   if (response.status == 200) {
+                    let stats = Object.assign({}, this.props.stats);
+                    stats.responseSetCount = this.props.stats.responseSetCount - 1;
+                    stats.myResponseSetCount = this.props.stats.myResponseSetCount - 1;
+                    this.props.setStats(stats);
                     this.props.router.push('/');
                   }
                 });
@@ -170,6 +175,8 @@ ResponseSetDetails.propTypes = {
   currentUser: currentUserProps,
   publishResponseSet: PropTypes.func,
   deleteResponseSet:  PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   questions: PropTypes.arrayOf(questionProps),
   publishers: publishersProps
 };

--- a/webpack/components/ResponseSetDetails.js
+++ b/webpack/components/ResponseSetDetails.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
-import assign from 'lodash/assign';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
 import VersionInfo from './VersionInfo';

--- a/webpack/components/ResponseSetDragWidget.js
+++ b/webpack/components/ResponseSetDragWidget.js
@@ -121,7 +121,7 @@ class ResponseSetDragWidget extends Component {
                       currentUser={this.props.currentUser}
                       handleSelectSearchResult={() => this.addRsButtonHandler(rs)} />;
             })}
-            {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+            {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor((searchResults.hits.total-1) / 10) &&
               <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
             }
           </div>

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { hashHistory, Link } from 'react-router';
+import assign from 'lodash/assign';
 
 import VersionInfo from '../VersionInfo';
 import PublisherLookUp from "../shared_show/PublisherLookUp";
@@ -55,6 +56,10 @@ class SurveyShow extends Component{
               if(confirm('Are you sure you want to delete this Survey? This action cannot be undone.')){
                 this.props.deleteSurvey(this.props.survey.id, (response) => {
                   if (response.status == 200) {
+                    let stats = Object.assign({}, this.props.stats);
+                    stats.surveyCount = this.props.stats.surveyCount - 1;
+                    stats.mySurveyCount = this.props.stats.mySurveyCount - 1;
+                    this.props.setStats(stats);
                     this.props.router.push('/');
                   }
                 });
@@ -156,6 +161,8 @@ SurveyShow.propTypes = {
   currentUser: currentUserProps,
   publishSurvey: PropTypes.func,
   deleteSurvey:  PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   publishers: publishersProps
 };
 

--- a/webpack/components/surveys/Show.js
+++ b/webpack/components/surveys/Show.js
@@ -1,7 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { hashHistory, Link } from 'react-router';
-import assign from 'lodash/assign';
 
 import VersionInfo from '../VersionInfo';
 import PublisherLookUp from "../shared_show/PublisherLookUp";

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -183,7 +183,7 @@ class DashboardContainer extends Component {
                 </div>
                 <div className="load-more-search">
                   <SearchResultList searchResults={this.props.searchResults} currentUser={this.props.currentUser} isEditPage={false} />
-                  {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+                  {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor((searchResults.hits.total-1) / 10) &&
                     <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
                   }
                 </div>

--- a/webpack/containers/FormSearchContainer.js
+++ b/webpack/containers/FormSearchContainer.js
@@ -97,7 +97,7 @@ class FormSearchContainer extends Component {
               />
             );
           })}
-          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor((searchResults.hits.total-1) / 10) &&
             <button id="load-more-btn" className="button button-action center-block" onClick={() => this.loadMore()}>LOAD MORE</button>
           }
         </div>

--- a/webpack/containers/FormShowContainer.js
+++ b/webpack/containers/FormShowContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchForm, publishForm, deleteForm } from '../actions/form_actions';
 import { setSteps } from '../actions/tutorial_actions';
+import { setStats } from '../actions/landing';
 import FormShow from '../components/FormShow';
 import { formProps } from '../prop-types/form_props';
 import { questionsProps } from '../prop-types/question_props';
@@ -88,6 +89,8 @@ class FormShowContainer extends Component {
                       router={this.props.router}
                       currentUser={this.props.currentUser}
                       publishForm={this.props.publishForm}
+                      stats={this.props.stats}
+                      setStats={this.props.setStats}
                       deleteForm ={this.props.deleteForm}
                       publishers ={this.props.publishers} />
             <div className="col-md-12 showpage-comments-title">Public Comments:</div>
@@ -104,6 +107,7 @@ function mapStateToProps(state, ownProps) {
     currentUser: state.currentUser,
     responseSets: state.responseSets,
     questions: state.questions,
+    stats: state.stats,
     form: state.forms[ownProps.params.formId],
     publishers: state.publishers
   };
@@ -111,7 +115,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({setSteps, fetchForm, publishForm, deleteForm}, dispatch);
+  return bindActionCreators({setSteps, setStats, fetchForm, publishForm, deleteForm}, dispatch);
 }
 
 FormShowContainer.propTypes = {
@@ -122,6 +126,8 @@ FormShowContainer.propTypes = {
   router: PropTypes.object.isRequired,
   currentUser: currentUserProps,
   setSteps: PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   fetchForm: PropTypes.func,
   deleteForm:  PropTypes.func,
   publishForm: PropTypes.func,

--- a/webpack/containers/QuestionModalContainer.js
+++ b/webpack/containers/QuestionModalContainer.js
@@ -60,7 +60,7 @@ class QuestionModalContainer extends Component {
   }
 
   closeQuestionModal(){
-    this.setState({showResponseSets: true, showResponseSetWidget:false, linkedResponseSets: {}, errors: null});
+    this.setState({showResponseSets: false, showResponseSetWidget:false, linkedResponseSets: {}, errors: null});
     this.props.closeQuestionModal();
   }
 

--- a/webpack/containers/QuestionSearchContainer.js
+++ b/webpack/containers/QuestionSearchContainer.js
@@ -90,7 +90,7 @@ class QuestionSearchContainer extends Component {
                             isSelected={this.props.selectedSearchResults[q.Id]} />
             );
           })}
-          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor(searchResults.hits.total / 10) &&
+          {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor((searchResults.hits.total-1) / 10) &&
             <button id="load-more-btn" className="button button-action center-block" onClick={this.loadMore}>LOAD MORE</button>
           }
         </div>

--- a/webpack/containers/QuestionShowContainer.js
+++ b/webpack/containers/QuestionShowContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchQuestion, publishQuestion, deleteQuestion, fetchQuestionUsage } from '../actions/questions_actions';
 import { setSteps } from '../actions/tutorial_actions';
+import { setStats } from '../actions/landing';
 import { questionProps } from "../prop-types/question_props";
 import QuestionDetails  from '../components/QuestionDetails';
 import CommentList from '../containers/CommentList';
@@ -76,6 +77,8 @@ class QuestionShowContainer extends Component {
           <div className="col-md-12">
             <QuestionDetails question={this.props.question}
                              responseSets={this.props.responseSets}
+                             stats={this.props.stats}
+                             setStats={this.props.setStats}
                              router={this.props.router}
                              currentUser={this.props.currentUser}
                              handlePublish={this.handlePublish.bind(this)}
@@ -95,6 +98,7 @@ function mapStateToProps(state, ownProps) {
   props.question = state.questions[ownProps.params.qId];
   props.currentUser = state.currentUser;
   props.publishers = state.publishers;
+  props.stats = state.stats;
   if (props.question && props.question.responseSets) {
     props.responseSets = props.question.responseSets.map((rsId) => state.responseSets[rsId]);
   }
@@ -102,7 +106,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({fetchQuestion, deleteQuestion, fetchQuestionUsage, setSteps}, dispatch);
+  return bindActionCreators({fetchQuestion, deleteQuestion, fetchQuestionUsage, setSteps, setStats}, dispatch);
 }
 
 // Avoiding a lint error, but if you supply a question when you create this class, it will be ignored and overwritten!
@@ -115,6 +119,8 @@ QuestionShowContainer.propTypes = {
   fetchQuestion: PropTypes.func,
   fetchQuestionUsage: PropTypes.func,
   setSteps: PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   deleteQuestion: PropTypes.func,
   publishers: publishersProps
 };

--- a/webpack/containers/ResponseSetShowContainer.js
+++ b/webpack/containers/ResponseSetShowContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchResponseSet, publishResponseSet, deleteResponseSet, fetchResponseSetUsage } from '../actions/response_set_actions';
 import { setSteps } from '../actions/tutorial_actions';
+import { setStats } from '../actions/landing';
 import ResponseSetDetails from '../components/ResponseSetDetails';
 import { responseSetProps } from '../prop-types/response_set_props';
 import { questionProps } from '../prop-types/question_props';
@@ -85,6 +86,7 @@ function mapStateToProps(state, ownProps) {
   props.currentUser = state.currentUser;
   props.responseSet = state.responseSets[ownProps.params.rsId];
   props.publishers = state.publishers;
+  props.stats = state.stats;
   if (props.responseSet && props.responseSet.questions) {
     props.questions = compact(props.responseSet.questions.map((qId) => state.questions[qId]));
   }
@@ -92,7 +94,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({setSteps, fetchResponseSet, publishResponseSet, deleteResponseSet, fetchResponseSetUsage}, dispatch);
+  return bindActionCreators({setSteps, setStats, fetchResponseSet, publishResponseSet, deleteResponseSet, fetchResponseSetUsage}, dispatch);
 }
 
 ResponseSetShowContainer.propTypes = {
@@ -104,6 +106,8 @@ ResponseSetShowContainer.propTypes = {
   fetchResponseSetUsage: PropTypes.func,
   deleteResponseSet:  PropTypes.func,
   setSteps: PropTypes.func,
+  setStats: PropTypes.func,
+  stats: PropTypes.object,
   params: PropTypes.object,
   router: PropTypes.object.isRequired,
   publishers: publishersProps

--- a/webpack/containers/surveys/ShowContainer.js
+++ b/webpack/containers/surveys/ShowContainer.js
@@ -4,6 +4,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { fetchSurvey, publishSurvey, deleteSurvey } from '../../actions/survey_actions';
 import { setSteps } from '../../actions/tutorial_actions';
+import { setStats } from '../../actions/landing';
 import SurveyShow from '../../components/surveys/Show';
 import { surveyProps } from '../../prop-types/survey_props';
 import { formProps } from '../../prop-types/form_props';
@@ -74,6 +75,7 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   props.currentUser = state.currentUser;
   props.publishers = state.publishers;
+  props.stats = state.stats;
   props.survey = state.surveys[ownProps.params.surveyId];
   if (props.survey) {
     props.forms = props.survey.surveyForms.map((form) => state.forms[form.formId]);
@@ -96,7 +98,7 @@ function mapStateToProps(state, ownProps) {
 }
 
 function mapDispatchToProps(dispatch) {
-  return bindActionCreators({setSteps, publishSurvey, fetchSurvey, deleteSurvey}, dispatch);
+  return bindActionCreators({setSteps, setStats, publishSurvey, fetchSurvey, deleteSurvey}, dispatch);
 }
 
 SurveyShowContainer.propTypes = {
@@ -107,8 +109,10 @@ SurveyShowContainer.propTypes = {
   publishSurvey: PropTypes.func,
   deleteSurvey: PropTypes.func,
   setSteps: PropTypes.func,
+  setStats: PropTypes.func,
   params: PropTypes.object,
   router: PropTypes.object,
+  stats: PropTypes.object,
   publishers: publishersProps
 };
 

--- a/webpack/reducers/stats.js
+++ b/webpack/reducers/stats.js
@@ -1,10 +1,13 @@
 import {
-  FETCH_STATS_FULFILLED
+  FETCH_STATS_FULFILLED,
+  SET_STATS
 } from '../actions/types';
 
 export default function stats(state = {}, action) {
   if (action.type === FETCH_STATS_FULFILLED) {
     return action.payload.data;
+  } else if (action.type === SET_STATS) {
+    return action.payload;
   }
   return state;
 }


### PR DESCRIPTION
If you delete an item the analytics widget and the myStuffCounts now update appropriately before the redirect. This also fixes a one off bug with the load more logic. I tried to also make the delete action remove the deleted item from the store but there is a bit of a race condition in that if the job to remove the item from elastic search isn't completed by the time the redirect to '/' happens the fetch new search results will still return the deleted item.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
