### PR TITLE
[SDP-728] Removes the "Get Started!" button

### DIFF
--- a/features/session.feature
+++ b/features/session.feature
@@ -6,11 +6,6 @@ Feature: Session Management
     When I click on the "Register" link
     Then I should see "Sign Up"
 
-  Scenario: Navigate to the sign in page through the jumbotron
-    Given I am on the "/" page
-    When I click on the "Get Started!" link
-    Then I should see "Sign Up"
-
   Scenario: Create an account with default program and system
     Given I have a Surveillance System with the name "National Violent Death Reporting System"
     And I have a Surveillance System with the name "National Vital Statistics System"
@@ -76,7 +71,7 @@ Feature: Session Management
   Scenario: Login to an existing account
     Given I am on the "/" page
     And a user "test_author@gmail.com" exists
-    Then I should see "Get Started!"
+    Then I should see "Author Questions, Response Sets, Forms, and Surveys"
     And I should not see "My Stuff"
     When I click on the "Login" link
     And I fill in the "email" field with "test_author@gmail.com"
@@ -84,7 +79,7 @@ Feature: Session Management
     And I click on the "Log In" button
     Then I should see "test_author@gmail.com"
     And I should see "My Stuff"
-    And I should not see "Get Started!"
+    And I should not see "Author Questions, Response Sets, Forms, and Surveys"
 
   Scenario: Edit an existing account
     Given I have a Surveillance System with the name "National Violent Death Reporting System"
@@ -112,7 +107,7 @@ Feature: Session Management
     Then the list "Surveillance Program" should contain the option "Influenza"
     And I select the "Influenza" option in the "Surveillance Program" list
     When I click on the "Update" button
-    Then I wait 1 seconds  
+    Then I wait 1 seconds
     And a user "test_author@gmail.com" should have a last Surveillance System named "National Vital Statistics System"
     And a user "test_author@gmail.com" should have a last Surveillance Program named "Influenza"
 
@@ -172,7 +167,7 @@ Feature: Session Management
     Then my session expires
     And I go to the dashboard
     Then I should not see "My Stuff"
-    And I should see "Get Started!"
+    And I should see "Author Questions, Response Sets, Forms, and Surveys"
 
   Scenario: Accessing content that belongs to another user causes a forbidden error
     Given I am logged in as test_author@gmail.com

--- a/webpack/containers/DashboardContainer.js
+++ b/webpack/containers/DashboardContainer.js
@@ -99,12 +99,6 @@ class DashboardContainer extends Component {
             text: 'If you already have an account you can log in to unlock more features in the top right of the dashboard page.',
             selector: '.log-in-link',
             position: 'left',
-          },
-          {
-            title: 'Sign Up!',
-            text: 'Click the Get Started! button on the banner to register a new account.',
-            selector: '.cdc-promo-banner',
-            position: 'right',
           }]);
       } else {
         steps = steps.concat([
@@ -157,7 +151,6 @@ class DashboardContainer extends Component {
                         <h1 className="banner-title">CDC Vocabulary Service</h1>
                         <h2 className="banner-subtitle">Author Questions, Response Sets, Forms, and Surveys</h2>
                         <p className="lead">The Vocabulary Service allows users to author their own questions and response sets, and to reuse others’ wording for their new data collection needs when applicable. A goal of this service is to increase consistency by reducing the number of different ways that CDC asks for similar information, lowering the reporting burden on partners.</p>
-                        <p><a className="btn btn-lg btn-success" href="#" tabIndex="2" role="button" onClick={this.openSignUpModal}>Get Started!</a></p>
                       </div>
                     </div>
                     <div className="col-md-4"></div>


### PR DESCRIPTION
This button linked to the sign up form. This is a problem when user
registration is disabled. To fix this, the button was simply removed.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
