### PR TITLE
[SDP-723] Add NPM Shrinkwrap to specify versions

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,14330 @@
+{
+  "name": "SDP",
+  "version": "0.0.1",
+  "dependencies": {
+    "autoprefixer": {
+      "version": "6.7.7",
+      "from": "autoprefixer@>=6.5.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
+      "dependencies": {
+        "browserslist": {
+          "version": "1.7.7",
+          "from": "browserslist@>=1.5.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+          "dependencies": {
+            "electron-to-chromium": {
+              "version": "1.3.16",
+              "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+              "resolved": "http://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
+            }
+          }
+        },
+        "caniuse-db": {
+          "version": "1.0.30000706",
+          "from": "caniuse-db@>=1.0.30000634 <2.0.0",
+          "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
+        },
+        "normalize-range": {
+          "version": "0.1.2",
+          "from": "normalize-range@>=0.1.2 <0.2.0",
+          "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+        },
+        "num2fraction": {
+          "version": "1.2.2",
+          "from": "num2fraction@>=1.2.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "postcss@>=5.2.16 <6.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.9 <3.0.0",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.6 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "supports-color@>=3.2.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss-value-parser": {
+          "version": "3.3.0",
+          "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+        }
+      }
+    },
+    "axios": {
+      "version": "0.13.1",
+      "from": "axios@>=0.13.1 <0.14.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.13.1.tgz",
+      "dependencies": {
+        "follow-redirects": {
+          "version": "0.0.7",
+          "from": "follow-redirects@0.0.7",
+          "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "stream-consume": {
+              "version": "0.1.0",
+              "from": "stream-consume@>=0.1.0 <0.2.0",
+              "resolved": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "babel-core": {
+      "version": "6.25.0",
+      "from": "babel-core@>=6.17.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "babel-generator": {
+          "version": "6.25.0",
+          "from": "babel-generator@>=6.25.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
+          "dependencies": {
+            "detect-indent": {
+              "version": "4.0.0",
+              "from": "detect-indent@>=4.0.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
+              "dependencies": {
+                "repeating": {
+                  "version": "2.0.1",
+                  "from": "repeating@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                  "dependencies": {
+                    "is-finite": {
+                      "version": "1.0.2",
+                      "from": "is-finite@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "jsesc": {
+              "version": "1.3.0",
+              "from": "jsesc@>=1.3.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
+            },
+            "trim-right": {
+              "version": "1.0.1",
+              "from": "trim-right@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+            }
+          }
+        },
+        "babel-helpers": {
+          "version": "6.24.1",
+          "from": "babel-helpers@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
+        },
+        "babel-messages": {
+          "version": "6.23.0",
+          "from": "babel-messages@>=6.23.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+        },
+        "babel-template": {
+          "version": "6.25.0",
+          "from": "babel-template@>=6.25.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        },
+        "babel-register": {
+          "version": "6.24.1",
+          "from": "babel-register@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "home-or-tmp": {
+              "version": "2.0.0",
+              "from": "home-or-tmp@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                }
+              }
+            },
+            "mkdirp": {
+              "version": "0.5.1",
+              "from": "mkdirp@>=0.5.1 <0.6.0",
+              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+              "dependencies": {
+                "minimist": {
+                  "version": "0.0.8",
+                  "from": "minimist@0.0.8",
+                  "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                }
+              }
+            },
+            "source-map-support": {
+              "version": "0.4.15",
+              "from": "source-map-support@>=0.4.2 <0.5.0",
+              "resolved": "http://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+            }
+          }
+        },
+        "babel-traverse": {
+          "version": "6.25.0",
+          "from": "babel-traverse@>=6.25.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+          "dependencies": {
+            "globals": {
+              "version": "9.18.0",
+              "from": "globals@>=9.0.0 <10.0.0",
+              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+            },
+            "invariant": {
+              "version": "2.2.2",
+              "from": "invariant@>=2.2.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+              "dependencies": {
+                "loose-envify": {
+                  "version": "1.3.1",
+                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                  "dependencies": {
+                    "js-tokens": {
+                      "version": "3.0.2",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-types": {
+          "version": "6.25.0",
+          "from": "babel-types@>=6.25.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "to-fast-properties": {
+              "version": "1.0.3",
+              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+            }
+          }
+        },
+        "babylon": {
+          "version": "6.17.4",
+          "from": "babylon@>=6.17.2 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "from": "convert-source-map@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+        },
+        "debug": {
+          "version": "2.6.8",
+          "from": "debug@>=2.2.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            }
+          }
+        },
+        "json5": {
+          "version": "0.5.1",
+          "from": "json5@>=0.5.0 <0.6.0",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@>=3.0.2 <4.0.0",
+          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "dependencies": {
+            "brace-expansion": {
+              "version": "1.1.8",
+              "from": "brace-expansion@>=1.1.7 <2.0.0",
+              "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+              "dependencies": {
+                "balanced-match": {
+                  "version": "1.0.0",
+                  "from": "balanced-match@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                },
+                "concat-map": {
+                  "version": "0.0.1",
+                  "from": "concat-map@0.0.1",
+                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "path-is-absolute@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "private": {
+          "version": "0.1.7",
+          "from": "private@>=0.1.6 <0.2.0",
+          "resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz"
+        },
+        "slash": {
+          "version": "1.0.0",
+          "from": "slash@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.5.6",
+          "from": "source-map@>=0.5.0 <0.6.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+        }
+      }
+    },
+    "babel-loader": {
+      "version": "6.4.1",
+      "from": "babel-loader@>=6.2.5 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
+      "dependencies": {
+        "find-cache-dir": {
+          "version": "0.1.1",
+          "from": "find-cache-dir@>=0.1.1 <0.2.0",
+          "resolved": "http://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
+          "dependencies": {
+            "commondir": {
+              "version": "1.0.1",
+              "from": "commondir@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
+            },
+            "pkg-dir": {
+              "version": "1.0.0",
+              "from": "pkg-dir@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.15 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "babel-polyfill": {
+      "version": "6.23.0",
+      "from": "babel-polyfill@>=6.16.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
+      "dependencies": {
+        "core-js": {
+          "version": "2.4.1",
+          "from": "core-js@>=2.4.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+        },
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
+        },
+        "regenerator-runtime": {
+          "version": "0.10.5",
+          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+        }
+      }
+    },
+    "babel-preset-es2015": {
+      "version": "6.24.1",
+      "from": "babel-preset-es2015@>=6.16.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
+      "dependencies": {
+        "babel-plugin-check-es2015-constants": {
+          "version": "6.22.0",
+          "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-arrow-functions": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoped-functions": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-block-scoping": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.2",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "globals@>=9.0.0 <10.0.0",
+                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-classes": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-optimise-call-expression": {
+              "version": "6.24.1",
+              "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+            },
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                }
+              }
+            },
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                }
+              }
+            },
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.2",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                    }
+                  }
+                },
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "globals@>=9.0.0 <10.0.0",
+                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-define-map": {
+              "version": "6.24.1",
+              "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
+            },
+            "babel-messages": {
+              "version": "6.23.0",
+              "from": "babel-messages@>=6.23.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-computed-properties": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-destructuring": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-duplicate-keys": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-for-of": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-function-name": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-function-name": {
+              "version": "6.24.1",
+              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+              "dependencies": {
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-helper-get-function-arity": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-amd": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-commonjs": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-strict-mode": {
+              "version": "6.24.1",
+              "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-systemjs": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-hoist-variables": {
+              "version": "6.24.1",
+              "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-modules-umd": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-object-super": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-replace-supers": {
+              "version": "6.24.1",
+              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-optimise-call-expression": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-parameters": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
+          "dependencies": {
+            "babel-traverse": {
+              "version": "6.25.0",
+              "from": "babel-traverse@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+              "dependencies": {
+                "babel-code-frame": {
+                  "version": "6.22.0",
+                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                  "dependencies": {
+                    "chalk": {
+                      "version": "1.1.3",
+                      "from": "chalk@>=1.1.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.2.1",
+                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.5",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "2.0.0",
+                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "3.0.1",
+                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "2.1.1",
+                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "2.0.0",
+                          "from": "supports-color@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "js-tokens": {
+                      "version": "3.0.2",
+                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                    }
+                  }
+                },
+                "babel-messages": {
+                  "version": "6.23.0",
+                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                },
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "debug": {
+                  "version": "2.6.8",
+                  "from": "debug@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "globals": {
+                  "version": "9.18.0",
+                  "from": "globals@>=9.0.0 <10.0.0",
+                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                },
+                "invariant": {
+                  "version": "2.2.2",
+                  "from": "invariant@>=2.2.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                  "dependencies": {
+                    "loose-envify": {
+                      "version": "1.3.1",
+                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                      "dependencies": {
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-helper-call-delegate": {
+              "version": "6.24.1",
+              "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-hoist-variables": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+                }
+              }
+            },
+            "babel-helper-get-function-arity": {
+              "version": "6.24.1",
+              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+            },
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                }
+              }
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-shorthand-properties": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
+          "dependencies": {
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-spread": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-sticky-regex": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
+            },
+            "babel-types": {
+              "version": "6.25.0",
+              "from": "babel-types@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+              "dependencies": {
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.2 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                },
+                "to-fast-properties": {
+                  "version": "1.0.3",
+                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-template-literals": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-typeof-symbol": {
+          "version": "6.23.0",
+          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-es2015-unicode-regex": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
+          "dependencies": {
+            "babel-helper-regex": {
+              "version": "6.24.1",
+              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "regexpu-core": {
+              "version": "2.0.0",
+              "from": "regexpu-core@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-regenerator": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
+          "dependencies": {
+            "regenerator-transform": {
+              "version": "0.9.11",
+              "from": "regenerator-transform@0.9.11",
+              "resolved": "http://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
+              "dependencies": {
+                "babel-runtime": {
+                  "version": "6.23.0",
+                  "from": "babel-runtime@>=6.18.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.5",
+                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.19.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.7",
+                  "from": "private@>=0.1.6 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "babel-preset-react": {
+      "version": "6.24.1",
+      "from": "babel-preset-react@>=6.16.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+      "dependencies": {
+        "babel-preset-flow": {
+          "version": "6.23.0",
+          "from": "babel-preset-flow@>=6.23.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+          "dependencies": {
+            "babel-plugin-transform-flow-strip-types": {
+              "version": "6.22.0",
+              "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+              "dependencies": {
+                "babel-runtime": {
+                  "version": "6.23.0",
+                  "from": "babel-runtime@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.5",
+                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-syntax-flow": {
+                  "version": "6.18.0",
+                  "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-syntax-jsx": {
+          "version": "6.18.0",
+          "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz"
+        },
+        "babel-plugin-transform-react-display-name": {
+          "version": "6.25.0",
+          "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-jsx": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            },
+            "babel-helper-builder-react-jsx": {
+              "version": "6.24.1",
+              "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                },
+                "esutils": {
+                  "version": "2.0.2",
+                  "from": "esutils@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+          "dependencies": {
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "babel-preset-stage-1": {
+      "version": "6.24.1",
+      "from": "babel-preset-stage-1@>=6.16.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+      "dependencies": {
+        "babel-plugin-transform-class-constructor-call": {
+          "version": "6.24.1",
+          "from": "babel-plugin-transform-class-constructor-call@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
+          "dependencies": {
+            "babel-template": {
+              "version": "6.25.0",
+              "from": "babel-template@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+              "dependencies": {
+                "babylon": {
+                  "version": "6.17.4",
+                  "from": "babylon@>=6.17.2 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                },
+                "babel-traverse": {
+                  "version": "6.25.0",
+                  "from": "babel-traverse@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                  "dependencies": {
+                    "babel-code-frame": {
+                      "version": "6.22.0",
+                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                      "dependencies": {
+                        "chalk": {
+                          "version": "1.1.3",
+                          "from": "chalk@>=1.1.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                          "dependencies": {
+                            "ansi-styles": {
+                              "version": "2.2.1",
+                              "from": "ansi-styles@>=2.2.1 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                            },
+                            "escape-string-regexp": {
+                              "version": "1.0.5",
+                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                            },
+                            "has-ansi": {
+                              "version": "2.0.0",
+                              "from": "has-ansi@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "strip-ansi": {
+                              "version": "3.0.1",
+                              "from": "strip-ansi@>=3.0.0 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                              "dependencies": {
+                                "ansi-regex": {
+                                  "version": "2.1.1",
+                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                }
+                              }
+                            },
+                            "supports-color": {
+                              "version": "2.0.0",
+                              "from": "supports-color@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "js-tokens": {
+                          "version": "3.0.2",
+                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                        }
+                      }
+                    },
+                    "babel-messages": {
+                      "version": "6.23.0",
+                      "from": "babel-messages@>=6.23.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "globals": {
+                      "version": "9.18.0",
+                      "from": "globals@>=9.0.0 <10.0.0",
+                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                    },
+                    "invariant": {
+                      "version": "2.2.2",
+                      "from": "invariant@>=2.2.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                      "dependencies": {
+                        "loose-envify": {
+                          "version": "1.3.1",
+                          "from": "loose-envify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                          "dependencies": {
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.25.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-syntax-class-constructor-call": {
+              "version": "6.18.0",
+              "from": "babel-plugin-syntax-class-constructor-call@>=6.18.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-plugin-transform-export-extensions": {
+          "version": "6.22.0",
+          "from": "babel-plugin-transform-export-extensions@>=6.22.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
+          "dependencies": {
+            "babel-plugin-syntax-export-extensions": {
+              "version": "6.13.0",
+              "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz"
+            },
+            "babel-runtime": {
+              "version": "6.23.0",
+              "from": "babel-runtime@>=6.22.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "2.4.1",
+                  "from": "core-js@>=2.4.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                },
+                "regenerator-runtime": {
+                  "version": "0.10.5",
+                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "babel-preset-stage-2": {
+          "version": "6.24.1",
+          "from": "babel-preset-stage-2@>=6.24.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
+          "dependencies": {
+            "babel-plugin-transform-class-properties": {
+              "version": "6.24.1",
+              "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
+              "dependencies": {
+                "babel-helper-function-name": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+                  "dependencies": {
+                    "babel-types": {
+                      "version": "6.25.0",
+                      "from": "babel-types@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                      "dependencies": {
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.3",
+                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "babel-traverse": {
+                      "version": "6.25.0",
+                      "from": "babel-traverse@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.22.0",
+                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.23.0",
+                          "from": "babel-messages@>=6.23.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.17.4",
+                          "from": "babylon@>=6.17.2 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "from": "ms@2.0.0",
+                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "9.18.0",
+                          "from": "globals@>=9.0.0 <10.0.0",
+                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.2",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.3.1",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-helper-get-function-arity": {
+                      "version": "6.24.1",
+                      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-syntax-class-properties": {
+                  "version": "6.13.0",
+                  "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
+                },
+                "babel-runtime": {
+                  "version": "6.23.0",
+                  "from": "babel-runtime@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.5",
+                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                    }
+                  }
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "babel-traverse": {
+                      "version": "6.25.0",
+                      "from": "babel-traverse@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.22.0",
+                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.23.0",
+                          "from": "babel-messages@>=6.23.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "from": "ms@2.0.0",
+                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "9.18.0",
+                          "from": "globals@>=9.0.0 <10.0.0",
+                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.2",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.3.1",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-types": {
+                      "version": "6.25.0",
+                      "from": "babel-types@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                      "dependencies": {
+                        "esutils": {
+                          "version": "2.0.2",
+                          "from": "esutils@>=2.0.2 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                        },
+                        "to-fast-properties": {
+                          "version": "1.0.3",
+                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-transform-decorators": {
+              "version": "6.24.1",
+              "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
+              "dependencies": {
+                "babel-types": {
+                  "version": "6.25.0",
+                  "from": "babel-types@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                  "dependencies": {
+                    "esutils": {
+                      "version": "2.0.2",
+                      "from": "esutils@>=2.0.2 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                    },
+                    "to-fast-properties": {
+                      "version": "1.0.3",
+                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                    }
+                  }
+                },
+                "babel-plugin-syntax-decorators": {
+                  "version": "6.13.0",
+                  "from": "babel-plugin-syntax-decorators@>=6.13.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz"
+                },
+                "babel-helper-explode-class": {
+                  "version": "6.24.1",
+                  "from": "babel-helper-explode-class@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
+                  "dependencies": {
+                    "babel-traverse": {
+                      "version": "6.25.0",
+                      "from": "babel-traverse@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.22.0",
+                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.23.0",
+                          "from": "babel-messages@>=6.23.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                        },
+                        "babylon": {
+                          "version": "6.17.4",
+                          "from": "babylon@>=6.17.2 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "from": "ms@2.0.0",
+                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "9.18.0",
+                          "from": "globals@>=9.0.0 <10.0.0",
+                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.2",
+                          "from": "invariant@>=2.2.1 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.3.1",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-helper-bindify-decorators": {
+                      "version": "6.24.1",
+                      "from": "babel-helper-bindify-decorators@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz"
+                    }
+                  }
+                },
+                "babel-template": {
+                  "version": "6.25.0",
+                  "from": "babel-template@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                  "dependencies": {
+                    "babylon": {
+                      "version": "6.17.4",
+                      "from": "babylon@>=6.17.2 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                    },
+                    "babel-traverse": {
+                      "version": "6.25.0",
+                      "from": "babel-traverse@>=6.25.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                      "dependencies": {
+                        "babel-code-frame": {
+                          "version": "6.22.0",
+                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "js-tokens": {
+                              "version": "3.0.2",
+                              "from": "js-tokens@>=3.0.0 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                            }
+                          }
+                        },
+                        "babel-messages": {
+                          "version": "6.23.0",
+                          "from": "babel-messages@>=6.23.0 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                        },
+                        "debug": {
+                          "version": "2.6.8",
+                          "from": "debug@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                          "dependencies": {
+                            "ms": {
+                              "version": "2.0.0",
+                              "from": "ms@2.0.0",
+                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                            }
+                          }
+                        },
+                        "globals": {
+                          "version": "9.18.0",
+                          "from": "globals@>=9.0.0 <10.0.0",
+                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                        },
+                        "invariant": {
+                          "version": "2.2.2",
+                          "from": "invariant@>=2.2.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                          "dependencies": {
+                            "loose-envify": {
+                              "version": "1.3.1",
+                              "from": "loose-envify@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                              "dependencies": {
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-runtime": {
+                  "version": "6.23.0",
+                  "from": "babel-runtime@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                  "dependencies": {
+                    "core-js": {
+                      "version": "2.4.1",
+                      "from": "core-js@>=2.4.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                    },
+                    "regenerator-runtime": {
+                      "version": "0.10.5",
+                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "babel-plugin-syntax-dynamic-import": {
+              "version": "6.18.0",
+              "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
+            },
+            "babel-preset-stage-3": {
+              "version": "6.24.1",
+              "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
+              "dependencies": {
+                "babel-plugin-syntax-trailing-function-commas": {
+                  "version": "6.22.0",
+                  "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
+                },
+                "babel-plugin-transform-async-generator-functions": {
+                  "version": "6.24.1",
+                  "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
+                  "dependencies": {
+                    "babel-helper-remap-async-to-generator": {
+                      "version": "6.24.1",
+                      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+                      "dependencies": {
+                        "babel-template": {
+                          "version": "6.25.0",
+                          "from": "babel-template@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                          "dependencies": {
+                            "babylon": {
+                              "version": "6.17.4",
+                              "from": "babylon@>=6.17.2 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.25.0",
+                          "from": "babel-types@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                          "dependencies": {
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.3",
+                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "babel-traverse": {
+                          "version": "6.25.0",
+                          "from": "babel-traverse@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.22.0",
+                              "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.3",
+                                  "from": "chalk@>=1.1.0 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.2.1",
+                                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.5",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.1.1",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.1",
+                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.1.1",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "from": "supports-color@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "from": "esutils@>=2.0.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                },
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.23.0",
+                              "from": "babel-messages@>=6.23.0 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                            },
+                            "babylon": {
+                              "version": "6.17.4",
+                              "from": "babylon@>=6.17.2 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                            },
+                            "debug": {
+                              "version": "2.6.8",
+                              "from": "debug@>=2.2.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "2.0.0",
+                                  "from": "ms@2.0.0",
+                                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "9.18.0",
+                              "from": "globals@>=9.0.0 <10.0.0",
+                              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                            },
+                            "invariant": {
+                              "version": "2.2.2",
+                              "from": "invariant@>=2.2.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.3.1",
+                                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "3.0.2",
+                                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-helper-function-name": {
+                          "version": "6.24.1",
+                          "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+                          "dependencies": {
+                            "babel-helper-get-function-arity": {
+                              "version": "6.24.1",
+                              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-plugin-syntax-async-generators": {
+                      "version": "6.13.0",
+                      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
+                    },
+                    "babel-runtime": {
+                      "version": "6.23.0",
+                      "from": "babel-runtime@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "2.4.1",
+                          "from": "core-js@>=2.4.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                        },
+                        "regenerator-runtime": {
+                          "version": "0.10.5",
+                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-async-to-generator": {
+                  "version": "6.24.1",
+                  "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
+                  "dependencies": {
+                    "babel-helper-remap-async-to-generator": {
+                      "version": "6.24.1",
+                      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
+                      "dependencies": {
+                        "babel-template": {
+                          "version": "6.25.0",
+                          "from": "babel-template@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
+                          "dependencies": {
+                            "babylon": {
+                              "version": "6.17.4",
+                              "from": "babylon@>=6.17.2 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.25.0",
+                          "from": "babel-types@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                          "dependencies": {
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.3",
+                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "babel-traverse": {
+                          "version": "6.25.0",
+                          "from": "babel-traverse@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                          "dependencies": {
+                            "babel-code-frame": {
+                              "version": "6.22.0",
+                              "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                              "dependencies": {
+                                "chalk": {
+                                  "version": "1.1.3",
+                                  "from": "chalk@>=1.1.0 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                  "dependencies": {
+                                    "ansi-styles": {
+                                      "version": "2.2.1",
+                                      "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                    },
+                                    "escape-string-regexp": {
+                                      "version": "1.0.5",
+                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                    },
+                                    "has-ansi": {
+                                      "version": "2.0.0",
+                                      "from": "has-ansi@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.1.1",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "strip-ansi": {
+                                      "version": "3.0.1",
+                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                      "dependencies": {
+                                        "ansi-regex": {
+                                          "version": "2.1.1",
+                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                        }
+                                      }
+                                    },
+                                    "supports-color": {
+                                      "version": "2.0.0",
+                                      "from": "supports-color@>=2.0.0 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "esutils": {
+                                  "version": "2.0.2",
+                                  "from": "esutils@>=2.0.2 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                },
+                                "js-tokens": {
+                                  "version": "3.0.2",
+                                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                }
+                              }
+                            },
+                            "babel-messages": {
+                              "version": "6.23.0",
+                              "from": "babel-messages@>=6.23.0 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                            },
+                            "babylon": {
+                              "version": "6.17.4",
+                              "from": "babylon@>=6.17.2 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                            },
+                            "debug": {
+                              "version": "2.6.8",
+                              "from": "debug@>=2.2.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                              "dependencies": {
+                                "ms": {
+                                  "version": "2.0.0",
+                                  "from": "ms@2.0.0",
+                                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                }
+                              }
+                            },
+                            "globals": {
+                              "version": "9.18.0",
+                              "from": "globals@>=9.0.0 <10.0.0",
+                              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                            },
+                            "invariant": {
+                              "version": "2.2.2",
+                              "from": "invariant@>=2.2.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                              "dependencies": {
+                                "loose-envify": {
+                                  "version": "1.3.1",
+                                  "from": "loose-envify@>=1.0.0 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                                  "dependencies": {
+                                    "js-tokens": {
+                                      "version": "3.0.2",
+                                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-helper-function-name": {
+                          "version": "6.24.1",
+                          "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
+                          "dependencies": {
+                            "babel-helper-get-function-arity": {
+                              "version": "6.24.1",
+                              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-plugin-syntax-async-functions": {
+                      "version": "6.13.0",
+                      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+                    },
+                    "babel-runtime": {
+                      "version": "6.23.0",
+                      "from": "babel-runtime@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "2.4.1",
+                          "from": "core-js@>=2.4.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                        },
+                        "regenerator-runtime": {
+                          "version": "0.10.5",
+                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-exponentiation-operator": {
+                  "version": "6.24.1",
+                  "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
+                  "dependencies": {
+                    "babel-plugin-syntax-exponentiation-operator": {
+                      "version": "6.13.0",
+                      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+                    },
+                    "babel-helper-builder-binary-assignment-operator-visitor": {
+                      "version": "6.24.1",
+                      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
+                      "dependencies": {
+                        "babel-helper-explode-assignable-expression": {
+                          "version": "6.24.1",
+                          "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
+                          "dependencies": {
+                            "babel-traverse": {
+                              "version": "6.25.0",
+                              "from": "babel-traverse@>=6.24.1 <7.0.0",
+                              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
+                              "dependencies": {
+                                "babel-code-frame": {
+                                  "version": "6.22.0",
+                                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
+                                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+                                  "dependencies": {
+                                    "chalk": {
+                                      "version": "1.1.3",
+                                      "from": "chalk@>=1.1.0 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                                      "dependencies": {
+                                        "ansi-styles": {
+                                          "version": "2.2.1",
+                                          "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                        },
+                                        "escape-string-regexp": {
+                                          "version": "1.0.5",
+                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                        },
+                                        "has-ansi": {
+                                          "version": "2.0.0",
+                                          "from": "has-ansi@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.1.1",
+                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "strip-ansi": {
+                                          "version": "3.0.1",
+                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                          "dependencies": {
+                                            "ansi-regex": {
+                                              "version": "2.1.1",
+                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                            }
+                                          }
+                                        },
+                                        "supports-color": {
+                                          "version": "2.0.0",
+                                          "from": "supports-color@>=2.0.0 <3.0.0",
+                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "esutils": {
+                                      "version": "2.0.2",
+                                      "from": "esutils@>=2.0.2 <3.0.0",
+                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                                    },
+                                    "js-tokens": {
+                                      "version": "3.0.2",
+                                      "from": "js-tokens@>=3.0.0 <4.0.0",
+                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                    }
+                                  }
+                                },
+                                "babel-messages": {
+                                  "version": "6.23.0",
+                                  "from": "babel-messages@>=6.23.0 <7.0.0",
+                                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+                                },
+                                "babylon": {
+                                  "version": "6.17.4",
+                                  "from": "babylon@>=6.17.2 <7.0.0",
+                                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+                                },
+                                "debug": {
+                                  "version": "2.6.8",
+                                  "from": "debug@>=2.2.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+                                  "dependencies": {
+                                    "ms": {
+                                      "version": "2.0.0",
+                                      "from": "ms@2.0.0",
+                                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                                    }
+                                  }
+                                },
+                                "globals": {
+                                  "version": "9.18.0",
+                                  "from": "globals@>=9.0.0 <10.0.0",
+                                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+                                },
+                                "invariant": {
+                                  "version": "2.2.2",
+                                  "from": "invariant@>=2.2.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+                                  "dependencies": {
+                                    "loose-envify": {
+                                      "version": "1.3.1",
+                                      "from": "loose-envify@>=1.0.0 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+                                      "dependencies": {
+                                        "js-tokens": {
+                                          "version": "3.0.2",
+                                          "from": "js-tokens@>=3.0.0 <4.0.0",
+                                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "babel-types": {
+                          "version": "6.25.0",
+                          "from": "babel-types@>=6.24.1 <7.0.0",
+                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
+                          "dependencies": {
+                            "esutils": {
+                              "version": "2.0.2",
+                              "from": "esutils@>=2.0.2 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+                            },
+                            "to-fast-properties": {
+                              "version": "1.0.3",
+                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "babel-runtime": {
+                      "version": "6.23.0",
+                      "from": "babel-runtime@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "2.4.1",
+                          "from": "core-js@>=2.4.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                        },
+                        "regenerator-runtime": {
+                          "version": "0.10.5",
+                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "babel-plugin-transform-object-rest-spread": {
+                  "version": "6.23.0",
+                  "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
+                  "dependencies": {
+                    "babel-plugin-syntax-object-rest-spread": {
+                      "version": "6.13.0",
+                      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
+                    },
+                    "babel-runtime": {
+                      "version": "6.23.0",
+                      "from": "babel-runtime@>=6.22.0 <7.0.0",
+                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+                      "dependencies": {
+                        "core-js": {
+                          "version": "2.4.1",
+                          "from": "core-js@>=2.4.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+                        },
+                        "regenerator-runtime": {
+                          "version": "0.10.5",
+                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "bootstrap-sass": {
+      "version": "3.3.7",
+      "from": "bootstrap-sass@>=3.3.7 <4.0.0",
+      "resolved": "http://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz"
+    },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@>=3.5.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
+      "dependencies": {
+        "assertion-error": {
+          "version": "1.0.2",
+          "from": "assertion-error@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
+        },
+        "deep-eql": {
+          "version": "0.1.3",
+          "from": "deep-eql@>=0.1.3 <0.2.0",
+          "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+          "dependencies": {
+            "type-detect": {
+              "version": "0.1.1",
+              "from": "type-detect@0.1.1",
+              "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
+            }
+          }
+        },
+        "type-detect": {
+          "version": "1.0.0",
+          "from": "type-detect@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
+        }
+      }
+    },
+    "chai-jquery": {
+      "version": "2.0.0",
+      "from": "chai-jquery@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz"
+    },
+    "chai-spies": {
+      "version": "0.7.1",
+      "from": "chai-spies@latest",
+      "resolved": "http://registry.npmjs.org/chai-spies/-/chai-spies-0.7.1.tgz"
+    },
+    "css-loader": {
+      "version": "0.25.0",
+      "from": "css-loader@>=0.25.0 <0.26.0",
+      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "babel-code-frame@>=6.11.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "css-selector-tokenizer": {
+          "version": "0.6.0",
+          "from": "css-selector-tokenizer@>=0.6.0 <0.7.0",
+          "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
+          "dependencies": {
+            "cssesc": {
+              "version": "0.1.0",
+              "from": "cssesc@>=0.1.0 <0.2.0",
+              "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+            },
+            "fastparse": {
+              "version": "1.1.1",
+              "from": "fastparse@>=1.1.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+            },
+            "regexpu-core": {
+              "version": "1.0.0",
+              "from": "regexpu-core@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+              "dependencies": {
+                "regenerate": {
+                  "version": "1.3.2",
+                  "from": "regenerate@>=1.2.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                },
+                "regjsgen": {
+                  "version": "0.2.0",
+                  "from": "regjsgen@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                },
+                "regjsparser": {
+                  "version": "0.1.5",
+                  "from": "regjsparser@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                  "dependencies": {
+                    "jsesc": {
+                      "version": "0.5.0",
+                      "from": "jsesc@>=0.5.0 <0.6.0",
+                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "cssnano": {
+          "version": "3.10.0",
+          "from": "cssnano@>=2.6.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
+          "dependencies": {
+            "decamelize": {
+              "version": "1.2.0",
+              "from": "decamelize@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+            },
+            "defined": {
+              "version": "1.0.0",
+              "from": "defined@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+            },
+            "has": {
+              "version": "1.0.1",
+              "from": "has@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
+              "dependencies": {
+                "function-bind": {
+                  "version": "1.1.0",
+                  "from": "function-bind@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                }
+              }
+            },
+            "postcss-calc": {
+              "version": "5.3.1",
+              "from": "postcss-calc@>=5.2.0 <6.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
+              "dependencies": {
+                "postcss-message-helpers": {
+                  "version": "2.0.0",
+                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+                },
+                "reduce-css-calc": {
+                  "version": "1.3.0",
+                  "from": "reduce-css-calc@>=1.2.6 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@>=0.4.2 <0.5.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "math-expression-evaluator": {
+                      "version": "1.2.17",
+                      "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz"
+                    },
+                    "reduce-function-call": {
+                      "version": "1.0.2",
+                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-colormin": {
+              "version": "2.2.2",
+              "from": "postcss-colormin@>=2.1.8 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
+              "dependencies": {
+                "colormin": {
+                  "version": "1.1.2",
+                  "from": "colormin@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
+                  "dependencies": {
+                    "color": {
+                      "version": "0.11.4",
+                      "from": "color@>=0.11.0 <0.12.0",
+                      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
+                      "dependencies": {
+                        "clone": {
+                          "version": "1.0.2",
+                          "from": "clone@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+                        },
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "color-convert@>=1.3.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.1.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        },
+                        "color-string": {
+                          "version": "0.3.0",
+                          "from": "color-string@>=0.3.0 <0.4.0",
+                          "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "css-color-names": {
+                      "version": "0.0.4",
+                      "from": "css-color-names@0.0.4",
+                      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-convert-values": {
+              "version": "2.6.1",
+              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz"
+            },
+            "postcss-discard-comments": {
+              "version": "2.0.4",
+              "from": "postcss-discard-comments@>=2.0.4 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
+            },
+            "postcss-discard-duplicates": {
+              "version": "2.1.0",
+              "from": "postcss-discard-duplicates@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz"
+            },
+            "postcss-discard-empty": {
+              "version": "2.1.0",
+              "from": "postcss-discard-empty@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
+            },
+            "postcss-discard-overridden": {
+              "version": "0.1.1",
+              "from": "postcss-discard-overridden@>=0.1.1 <0.2.0",
+              "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz"
+            },
+            "postcss-discard-unused": {
+              "version": "2.2.3",
+              "from": "postcss-discard-unused@>=2.2.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
+              "dependencies": {
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-filter-plugins": {
+              "version": "2.0.2",
+              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
+              "dependencies": {
+                "uniqid": {
+                  "version": "4.1.1",
+                  "from": "uniqid@>=4.0.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
+                  "dependencies": {
+                    "macaddress": {
+                      "version": "0.2.8",
+                      "from": "macaddress@>=0.2.8 <0.3.0",
+                      "resolved": "http://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-merge-idents": {
+              "version": "2.1.7",
+              "from": "postcss-merge-idents@>=2.1.5 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz"
+            },
+            "postcss-merge-longhand": {
+              "version": "2.0.2",
+              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz"
+            },
+            "postcss-merge-rules": {
+              "version": "2.1.2",
+              "from": "postcss-merge-rules@>=2.0.3 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
+              "dependencies": {
+                "browserslist": {
+                  "version": "1.7.7",
+                  "from": "browserslist@>=1.5.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
+                  "dependencies": {
+                    "caniuse-db": {
+                      "version": "1.0.30000706",
+                      "from": "caniuse-db@>=1.0.30000639 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
+                    },
+                    "electron-to-chromium": {
+                      "version": "1.3.16",
+                      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
+                    }
+                  }
+                },
+                "caniuse-api": {
+                  "version": "1.6.1",
+                  "from": "caniuse-api@>=1.5.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
+                  "dependencies": {
+                    "caniuse-db": {
+                      "version": "1.0.30000706",
+                      "from": "caniuse-db@>=1.0.30000529 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
+                    },
+                    "lodash.memoize": {
+                      "version": "4.1.2",
+                      "from": "lodash.memoize@>=4.1.2 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+                    },
+                    "lodash.uniq": {
+                      "version": "4.5.0",
+                      "from": "lodash.uniq@>=4.5.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+                    }
+                  }
+                },
+                "postcss-selector-parser": {
+                  "version": "2.2.3",
+                  "from": "postcss-selector-parser@>=2.2.2 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "dependencies": {
+                    "flatten": {
+                      "version": "1.0.2",
+                      "from": "flatten@>=1.0.2 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+                    },
+                    "indexes-of": {
+                      "version": "1.0.1",
+                      "from": "indexes-of@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+                    },
+                    "uniq": {
+                      "version": "1.0.1",
+                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                    }
+                  }
+                },
+                "vendors": {
+                  "version": "1.0.1",
+                  "from": "vendors@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+                }
+              }
+            },
+            "postcss-minify-font-values": {
+              "version": "1.0.5",
+              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz"
+            },
+            "postcss-minify-gradients": {
+              "version": "1.0.5",
+              "from": "postcss-minify-gradients@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz"
+            },
+            "postcss-minify-params": {
+              "version": "1.2.2",
+              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-minify-selectors": {
+              "version": "2.1.1",
+              "from": "postcss-minify-selectors@>=2.0.4 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "postcss-selector-parser": {
+                  "version": "2.2.3",
+                  "from": "postcss-selector-parser@>=2.2.2 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
+                  "dependencies": {
+                    "flatten": {
+                      "version": "1.0.2",
+                      "from": "flatten@>=1.0.2 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+                    },
+                    "indexes-of": {
+                      "version": "1.0.1",
+                      "from": "indexes-of@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+                    },
+                    "uniq": {
+                      "version": "1.0.1",
+                      "from": "uniq@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-normalize-charset": {
+              "version": "1.1.1",
+              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz"
+            },
+            "postcss-normalize-url": {
+              "version": "3.0.8",
+              "from": "postcss-normalize-url@>=3.0.7 <4.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
+              "dependencies": {
+                "is-absolute-url": {
+                  "version": "2.1.0",
+                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
+                },
+                "normalize-url": {
+                  "version": "1.9.1",
+                  "from": "normalize-url@>=1.4.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+                  "dependencies": {
+                    "prepend-http": {
+                      "version": "1.0.4",
+                      "from": "prepend-http@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+                    },
+                    "query-string": {
+                      "version": "4.3.4",
+                      "from": "query-string@>=4.1.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz"
+                    },
+                    "sort-keys": {
+                      "version": "1.1.2",
+                      "from": "sort-keys@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
+                      "dependencies": {
+                        "is-plain-obj": {
+                          "version": "1.1.0",
+                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-ordered-values": {
+              "version": "2.2.3",
+              "from": "postcss-ordered-values@>=2.1.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz"
+            },
+            "postcss-reduce-idents": {
+              "version": "2.4.0",
+              "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz"
+            },
+            "postcss-reduce-initial": {
+              "version": "1.0.1",
+              "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz"
+            },
+            "postcss-reduce-transforms": {
+              "version": "1.0.4",
+              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz"
+            },
+            "postcss-svgo": {
+              "version": "2.1.6",
+              "from": "postcss-svgo@>=2.1.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
+              "dependencies": {
+                "is-svg": {
+                  "version": "2.1.0",
+                  "from": "is-svg@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
+                  "dependencies": {
+                    "html-comment-regex": {
+                      "version": "1.1.1",
+                      "from": "html-comment-regex@>=1.1.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+                    }
+                  }
+                },
+                "svgo": {
+                  "version": "0.7.2",
+                  "from": "svgo@>=0.7.0 <0.8.0",
+                  "resolved": "http://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
+                  "dependencies": {
+                    "sax": {
+                      "version": "1.2.4",
+                      "from": "sax@>=1.2.1 <1.3.0",
+                      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+                    },
+                    "coa": {
+                      "version": "1.0.4",
+                      "from": "coa@>=1.0.1 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
+                      "dependencies": {
+                        "q": {
+                          "version": "1.5.0",
+                          "from": "q@>=1.1.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
+                        }
+                      }
+                    },
+                    "js-yaml": {
+                      "version": "3.7.0",
+                      "from": "js-yaml@>=3.7.0 <3.8.0",
+                      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
+                      "dependencies": {
+                        "argparse": {
+                          "version": "1.0.9",
+                          "from": "argparse@>=1.0.7 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                          "dependencies": {
+                            "sprintf-js": {
+                              "version": "1.0.3",
+                              "from": "sprintf-js@>=1.0.2 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "esprima": {
+                          "version": "2.7.3",
+                          "from": "esprima@>=2.6.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+                        }
+                      }
+                    },
+                    "colors": {
+                      "version": "1.1.2",
+                      "from": "colors@>=1.1.2 <1.2.0",
+                      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+                    },
+                    "whet.extend": {
+                      "version": "0.9.9",
+                      "from": "whet.extend@>=0.9.9 <0.10.0",
+                      "resolved": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@>=0.5.1 <0.6.0",
+                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "0.0.8",
+                          "from": "minimist@0.0.8",
+                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                        }
+                      }
+                    },
+                    "csso": {
+                      "version": "2.3.2",
+                      "from": "csso@>=2.3.1 <2.4.0",
+                      "resolved": "http://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
+                      "dependencies": {
+                        "clap": {
+                          "version": "1.2.0",
+                          "from": "clap@>=1.0.9 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
+                          "dependencies": {
+                            "chalk": {
+                              "version": "1.1.3",
+                              "from": "chalk@>=1.1.3 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                              "dependencies": {
+                                "ansi-styles": {
+                                  "version": "2.2.1",
+                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                                },
+                                "escape-string-regexp": {
+                                  "version": "1.0.5",
+                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                                },
+                                "has-ansi": {
+                                  "version": "2.0.0",
+                                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "strip-ansi": {
+                                  "version": "3.0.1",
+                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                                  "dependencies": {
+                                    "ansi-regex": {
+                                      "version": "2.1.1",
+                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                                    }
+                                  }
+                                },
+                                "supports-color": {
+                                  "version": "2.0.0",
+                                  "from": "supports-color@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "source-map": {
+                          "version": "0.5.6",
+                          "from": "source-map@>=0.5.3 <0.6.0",
+                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss-unique-selectors": {
+              "version": "2.0.2",
+              "from": "postcss-unique-selectors@>=2.0.2 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
+              "dependencies": {
+                "alphanum-sort": {
+                  "version": "1.0.2",
+                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+                },
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            },
+            "postcss-value-parser": {
+              "version": "3.3.0",
+              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+            },
+            "postcss-zindex": {
+              "version": "2.2.0",
+              "from": "postcss-zindex@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
+              "dependencies": {
+                "uniqs": {
+                  "version": "2.0.0",
+                  "from": "uniqs@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.2 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "lodash.camelcase": {
+          "version": "3.0.1",
+          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
+          "dependencies": {
+            "lodash._createcompounder": {
+              "version": "3.0.0",
+              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
+              "dependencies": {
+                "lodash.deburr": {
+                  "version": "3.2.0",
+                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash.words": {
+                  "version": "3.2.0",
+                  "from": "lodash.words@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._root": {
+                      "version": "3.0.1",
+                      "from": "lodash._root@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.0.1 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "postcss@>=5.0.6 <6.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.9 <3.0.0",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.6 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "supports-color@>=3.2.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-extract-imports": {
+          "version": "1.1.0",
+          "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+          "dependencies": {
+            "postcss": {
+              "version": "6.0.8",
+              "from": "postcss@>=6.0.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "2.0.1",
+                  "from": "chalk@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "from": "ansi-styles@>=3.1.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "color-convert@>=1.9.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.1.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.6 <0.6.0",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "4.2.1",
+                  "from": "supports-color@>=4.2.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "from": "has-flag@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-local-by-default": {
+          "version": "1.2.0",
+          "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.7.0",
+              "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
+              "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "dependencies": {
+                "cssesc": {
+                  "version": "0.1.0",
+                  "from": "cssesc@>=0.1.0 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+                },
+                "fastparse": {
+                  "version": "1.1.1",
+                  "from": "fastparse@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+                },
+                "regexpu-core": {
+                  "version": "1.0.0",
+                  "from": "regexpu-core@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "dependencies": {
+                    "regenerate": {
+                      "version": "1.3.2",
+                      "from": "regenerate@>=1.2.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "regjsgen@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "regjsparser@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "jsesc@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss": {
+              "version": "6.0.8",
+              "from": "postcss@>=6.0.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "2.0.1",
+                  "from": "chalk@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "from": "ansi-styles@>=3.1.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "color-convert@>=1.9.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.1.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.6 <0.6.0",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "4.2.1",
+                  "from": "supports-color@>=4.2.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "from": "has-flag@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-scope": {
+          "version": "1.1.0",
+          "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+          "dependencies": {
+            "css-selector-tokenizer": {
+              "version": "0.7.0",
+              "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
+              "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
+              "dependencies": {
+                "cssesc": {
+                  "version": "0.1.0",
+                  "from": "cssesc@>=0.1.0 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+                },
+                "fastparse": {
+                  "version": "1.1.1",
+                  "from": "fastparse@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+                },
+                "regexpu-core": {
+                  "version": "1.0.0",
+                  "from": "regexpu-core@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
+                  "dependencies": {
+                    "regenerate": {
+                      "version": "1.3.2",
+                      "from": "regenerate@>=1.2.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+                    },
+                    "regjsgen": {
+                      "version": "0.2.0",
+                      "from": "regjsgen@>=0.2.0 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+                    },
+                    "regjsparser": {
+                      "version": "0.1.5",
+                      "from": "regjsparser@>=0.1.4 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+                      "dependencies": {
+                        "jsesc": {
+                          "version": "0.5.0",
+                          "from": "jsesc@>=0.5.0 <0.6.0",
+                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "postcss": {
+              "version": "6.0.8",
+              "from": "postcss@>=6.0.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "2.0.1",
+                  "from": "chalk@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "from": "ansi-styles@>=3.1.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "color-convert@>=1.9.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.1.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.6 <0.6.0",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "4.2.1",
+                  "from": "supports-color@>=4.2.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "from": "has-flag@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "postcss-modules-values": {
+          "version": "1.3.0",
+          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+          "dependencies": {
+            "icss-replace-symbols": {
+              "version": "1.1.0",
+              "from": "icss-replace-symbols@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz"
+            },
+            "postcss": {
+              "version": "6.0.8",
+              "from": "postcss@>=6.0.1 <7.0.0",
+              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
+              "dependencies": {
+                "chalk": {
+                  "version": "2.0.1",
+                  "from": "chalk@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
+                  "dependencies": {
+                    "ansi-styles": {
+                      "version": "3.2.0",
+                      "from": "ansi-styles@>=3.1.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+                      "dependencies": {
+                        "color-convert": {
+                          "version": "1.9.0",
+                          "from": "color-convert@>=1.9.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
+                          "dependencies": {
+                            "color-name": {
+                              "version": "1.1.3",
+                              "from": "color-name@>=1.1.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "escape-string-regexp": {
+                      "version": "1.0.5",
+                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                    }
+                  }
+                },
+                "source-map": {
+                  "version": "0.5.6",
+                  "from": "source-map@>=0.5.6 <0.6.0",
+                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+                },
+                "supports-color": {
+                  "version": "4.2.1",
+                  "from": "supports-color@>=4.2.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
+                  "dependencies": {
+                    "has-flag": {
+                      "version": "2.0.0",
+                      "from": "has-flag@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "source-list-map": {
+          "version": "0.1.8",
+          "from": "source-list-map@>=0.1.4 <0.2.0",
+          "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+        }
+      }
+    },
+    "date-fns": {
+      "version": "1.28.5",
+      "from": "date-fns@>=1.28.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz"
+    },
+    "enzyme": {
+      "version": "2.9.1",
+      "from": "enzyme@2.9.1",
+      "resolved": "http://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+      "dependencies": {
+        "cheerio": {
+          "version": "0.22.0",
+          "from": "cheerio@>=0.22.0 <0.23.0",
+          "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+          "dependencies": {
+            "css-select": {
+              "version": "1.2.0",
+              "from": "css-select@>=1.2.0 <1.3.0",
+              "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+              "dependencies": {
+                "css-what": {
+                  "version": "2.1.0",
+                  "from": "css-what@>=2.1.0 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
+                },
+                "domutils": {
+                  "version": "1.5.1",
+                  "from": "domutils@1.5.1",
+                  "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+                  "dependencies": {
+                    "domelementtype": {
+                      "version": "1.3.0",
+                      "from": "domelementtype@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                    }
+                  }
+                },
+                "boolbase": {
+                  "version": "1.0.0",
+                  "from": "boolbase@>=1.0.0 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
+                },
+                "nth-check": {
+                  "version": "1.0.1",
+                  "from": "nth-check@>=1.0.1 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
+                }
+              }
+            },
+            "dom-serializer": {
+              "version": "0.1.0",
+              "from": "dom-serializer@>=0.1.0 <0.2.0",
+              "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.1.3",
+                  "from": "domelementtype@>=1.1.1 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
+                }
+              }
+            },
+            "entities": {
+              "version": "1.1.1",
+              "from": "entities@>=1.1.1 <1.2.0",
+              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
+            },
+            "htmlparser2": {
+              "version": "3.9.2",
+              "from": "htmlparser2@>=3.9.1 <4.0.0",
+              "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+              "dependencies": {
+                "domelementtype": {
+                  "version": "1.3.0",
+                  "from": "domelementtype@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
+                },
+                "domhandler": {
+                  "version": "2.4.1",
+                  "from": "domhandler@>=2.3.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
+                },
+                "domutils": {
+                  "version": "1.6.2",
+                  "from": "domutils@>=1.5.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "from": "readable-stream@>=2.0.2 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.assignin": {
+              "version": "4.2.0",
+              "from": "lodash.assignin@>=4.0.9 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz"
+            },
+            "lodash.bind": {
+              "version": "4.2.1",
+              "from": "lodash.bind@>=4.1.4 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz"
+            },
+            "lodash.defaults": {
+              "version": "4.2.0",
+              "from": "lodash.defaults@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+            },
+            "lodash.filter": {
+              "version": "4.6.0",
+              "from": "lodash.filter@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz"
+            },
+            "lodash.flatten": {
+              "version": "4.4.0",
+              "from": "lodash.flatten@>=4.2.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
+            },
+            "lodash.foreach": {
+              "version": "4.5.0",
+              "from": "lodash.foreach@>=4.3.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
+            },
+            "lodash.map": {
+              "version": "4.6.0",
+              "from": "lodash.map@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz"
+            },
+            "lodash.merge": {
+              "version": "4.6.0",
+              "from": "lodash.merge@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz"
+            },
+            "lodash.pick": {
+              "version": "4.4.0",
+              "from": "lodash.pick@>=4.2.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
+            },
+            "lodash.reduce": {
+              "version": "4.6.0",
+              "from": "lodash.reduce@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz"
+            },
+            "lodash.reject": {
+              "version": "4.6.0",
+              "from": "lodash.reject@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz"
+            },
+            "lodash.some": {
+              "version": "4.6.0",
+              "from": "lodash.some@>=4.4.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
+            }
+          }
+        },
+        "function.prototype.name": {
+          "version": "1.0.3",
+          "from": "function.prototype.name@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.11",
+                  "from": "object-keys@>=1.0.8 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+                }
+              }
+            },
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            },
+            "is-callable": {
+              "version": "1.1.3",
+              "from": "is-callable@>=1.1.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+            }
+          }
+        },
+        "is-subset": {
+          "version": "0.1.1",
+          "from": "is-subset@>=0.1.1 <0.2.0",
+          "resolved": "http://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
+        },
+        "object-is": {
+          "version": "1.0.1",
+          "from": "object-is@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
+        },
+        "object.assign": {
+          "version": "4.0.4",
+          "from": "object.assign@>=4.0.4 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            },
+            "object-keys": {
+              "version": "1.0.11",
+              "from": "object-keys@>=1.0.10 <2.0.0",
+              "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+            },
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object.entries": {
+          "version": "1.0.4",
+          "from": "object.entries@>=1.0.4 <2.0.0",
+          "resolved": "http://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.11",
+                  "from": "object-keys@>=1.0.8 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.7.0",
+              "from": "es-abstract@>=1.6.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+              "dependencies": {
+                "is-callable": {
+                  "version": "1.1.3",
+                  "from": "is-callable@>=1.1.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+                },
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1",
+                      "from": "is-date-object@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1",
+                      "from": "is-symbol@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-regex": {
+                  "version": "1.0.4",
+                  "from": "is-regex@>=1.0.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
+                }
+              }
+            },
+            "has": {
+              "version": "1.0.1",
+              "from": "has@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz"
+            },
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            }
+          }
+        },
+        "object.values": {
+          "version": "1.0.4",
+          "from": "object.values@>=1.0.4 <2.0.0",
+          "resolved": "http://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.11",
+                  "from": "object-keys@>=1.0.8 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.7.0",
+              "from": "es-abstract@>=1.6.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+              "dependencies": {
+                "is-callable": {
+                  "version": "1.1.3",
+                  "from": "is-callable@>=1.1.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+                },
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1",
+                      "from": "is-date-object@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1",
+                      "from": "is-symbol@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-regex": {
+                  "version": "1.0.4",
+                  "from": "is-regex@>=1.0.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
+                }
+              }
+            },
+            "has": {
+              "version": "1.0.1",
+              "from": "has@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz"
+            },
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            }
+          }
+        },
+        "uuid": {
+          "version": "3.1.0",
+          "from": "uuid@>=3.0.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+        }
+      }
+    },
+    "eslint": {
+      "version": "3.19.0",
+      "from": "eslint@>=3.10.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "dependencies": {
+        "babel-code-frame": {
+          "version": "6.22.0",
+          "from": "babel-code-frame@>=6.16.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "concat-stream": {
+          "version": "1.6.0",
+          "from": "concat-stream@>=1.5.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+          "dependencies": {
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.3 <3.0.0",
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "typedarray": {
+              "version": "0.0.6",
+              "from": "typedarray@>=0.0.6 <0.0.7",
+              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@>=2.2.2 <3.0.0",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "from": "debug@>=2.1.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "2.0.0",
+              "from": "ms@2.0.0",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+            }
+          }
+        },
+        "doctrine": {
+          "version": "2.0.0",
+          "from": "doctrine@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+          "dependencies": {
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "escope": {
+          "version": "3.6.0",
+          "from": "escope@>=3.6.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+          "dependencies": {
+            "es6-map": {
+              "version": "0.1.5",
+              "from": "es6-map@>=0.1.3 <0.2.0",
+              "resolved": "http://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "from": "d@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.24",
+                  "from": "es5-ext@>=0.10.14 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "from": "es6-iterator@>=2.0.1 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                },
+                "es6-set": {
+                  "version": "0.1.5",
+                  "from": "es6-set@>=0.1.5 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "from": "es6-symbol@>=3.1.1 <3.2.0",
+                  "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                },
+                "event-emitter": {
+                  "version": "0.3.5",
+                  "from": "event-emitter@>=0.3.5 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
+                }
+              }
+            },
+            "es6-weak-map": {
+              "version": "2.0.2",
+              "from": "es6-weak-map@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+              "dependencies": {
+                "d": {
+                  "version": "1.0.0",
+                  "from": "d@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz"
+                },
+                "es5-ext": {
+                  "version": "0.10.24",
+                  "from": "es5-ext@>=0.10.14 <0.11.0",
+                  "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
+                },
+                "es6-iterator": {
+                  "version": "2.0.1",
+                  "from": "es6-iterator@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
+                },
+                "es6-symbol": {
+                  "version": "3.1.1",
+                  "from": "es6-symbol@>=3.1.1 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
+                }
+              }
+            },
+            "esrecurse": {
+              "version": "4.2.0",
+              "from": "esrecurse@>=4.1.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.0.1 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "espree": {
+          "version": "3.4.3",
+          "from": "espree@>=3.4.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+          "dependencies": {
+            "acorn": {
+              "version": "5.1.1",
+              "from": "acorn@>=5.0.1 <6.0.0",
+              "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
+            },
+            "acorn-jsx": {
+              "version": "3.0.1",
+              "from": "acorn-jsx@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+              "dependencies": {
+                "acorn": {
+                  "version": "3.3.0",
+                  "from": "acorn@>=3.0.4 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "esquery": {
+          "version": "1.0.0",
+          "from": "esquery@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz"
+        },
+        "estraverse": {
+          "version": "4.2.0",
+          "from": "estraverse@>=4.2.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+        },
+        "esutils": {
+          "version": "2.0.2",
+          "from": "esutils@>=2.0.2 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+        },
+        "file-entry-cache": {
+          "version": "2.0.0",
+          "from": "file-entry-cache@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+          "dependencies": {
+            "flat-cache": {
+              "version": "1.2.2",
+              "from": "flat-cache@>=1.2.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+              "dependencies": {
+                "circular-json": {
+                  "version": "0.3.3",
+                  "from": "circular-json@>=0.3.1 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz"
+                },
+                "del": {
+                  "version": "2.2.2",
+                  "from": "del@>=2.0.2 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/del/-/del-2.2.2.tgz",
+                  "dependencies": {
+                    "globby": {
+                      "version": "5.0.0",
+                      "from": "globby@>=5.0.0 <6.0.0",
+                      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+                      "dependencies": {
+                        "array-union": {
+                          "version": "1.0.2",
+                          "from": "array-union@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                          "dependencies": {
+                            "array-uniq": {
+                              "version": "1.0.3",
+                              "from": "array-uniq@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "arrify": {
+                          "version": "1.0.1",
+                          "from": "arrify@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-path-cwd": {
+                      "version": "1.0.0",
+                      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
+                    },
+                    "is-path-in-cwd": {
+                      "version": "1.0.0",
+                      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+                      "dependencies": {
+                        "is-path-inside": {
+                          "version": "1.0.0",
+                          "from": "is-path-inside@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "pify": {
+                      "version": "2.3.0",
+                      "from": "pify@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        }
+                      }
+                    },
+                    "rimraf": {
+                      "version": "2.6.1",
+                      "from": "rimraf@>=2.2.8 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                    }
+                  }
+                },
+                "graceful-fs": {
+                  "version": "4.1.11",
+                  "from": "graceful-fs@>=4.1.2 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                },
+                "write": {
+                  "version": "0.2.1",
+                  "from": "write@>=0.2.1 <0.3.0",
+                  "resolved": "http://registry.npmjs.org/write/-/write-0.2.1.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.4 <4.0.0",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "globals": {
+          "version": "9.18.0",
+          "from": "globals@>=9.14.0 <10.0.0",
+          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+        },
+        "ignore": {
+          "version": "3.3.3",
+          "from": "ignore@>=3.2.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz"
+        },
+        "imurmurhash": {
+          "version": "0.1.4",
+          "from": "imurmurhash@>=0.1.4 <0.2.0",
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+        },
+        "inquirer": {
+          "version": "0.12.0",
+          "from": "inquirer@>=0.12.0 <0.13.0",
+          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+          "dependencies": {
+            "ansi-escapes": {
+              "version": "1.4.0",
+              "from": "ansi-escapes@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
+            },
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            },
+            "cli-cursor": {
+              "version": "1.0.2",
+              "from": "cli-cursor@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+              "dependencies": {
+                "restore-cursor": {
+                  "version": "1.0.1",
+                  "from": "restore-cursor@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+                  "dependencies": {
+                    "exit-hook": {
+                      "version": "1.1.1",
+                      "from": "exit-hook@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
+                    },
+                    "onetime": {
+                      "version": "1.1.0",
+                      "from": "onetime@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "cli-width": {
+              "version": "2.1.0",
+              "from": "cli-width@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
+            },
+            "figures": {
+              "version": "1.7.0",
+              "from": "figures@>=1.3.5 <2.0.0",
+              "resolved": "http://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+              "dependencies": {
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            },
+            "readline2": {
+              "version": "1.0.1",
+              "from": "readline2@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                    }
+                  }
+                },
+                "mute-stream": {
+                  "version": "0.0.5",
+                  "from": "mute-stream@0.0.5",
+                  "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
+                }
+              }
+            },
+            "run-async": {
+              "version": "0.1.0",
+              "from": "run-async@>=0.1.0 <0.2.0",
+              "resolved": "http://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+              "dependencies": {
+                "once": {
+                  "version": "1.4.0",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                  "dependencies": {
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "rx-lite": {
+              "version": "3.1.2",
+              "from": "rx-lite@>=3.1.2 <4.0.0",
+              "resolved": "http://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
+            },
+            "string-width": {
+              "version": "1.0.2",
+              "from": "string-width@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "dependencies": {
+                "code-point-at": {
+                  "version": "1.1.0",
+                  "from": "code-point-at@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                },
+                "is-fullwidth-code-point": {
+                  "version": "1.0.0",
+                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+            },
+            "through": {
+              "version": "2.3.8",
+              "from": "through@>=2.3.6 <3.0.0",
+              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+            }
+          }
+        },
+        "is-my-json-valid": {
+          "version": "2.16.0",
+          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+          "dependencies": {
+            "generate-function": {
+              "version": "2.0.0",
+              "from": "generate-function@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+            },
+            "generate-object-property": {
+              "version": "1.2.0",
+              "from": "generate-object-property@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+              "dependencies": {
+                "is-property": {
+                  "version": "1.0.2",
+                  "from": "is-property@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                }
+              }
+            },
+            "jsonpointer": {
+              "version": "4.0.1",
+              "from": "jsonpointer@>=4.0.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
+            },
+            "xtend": {
+              "version": "4.0.1",
+              "from": "xtend@>=4.0.0 <5.0.0",
+              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+            }
+          }
+        },
+        "is-resolvable": {
+          "version": "1.0.0",
+          "from": "is-resolvable@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+          "dependencies": {
+            "tryit": {
+              "version": "1.0.3",
+              "from": "tryit@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
+            }
+          }
+        },
+        "js-yaml": {
+          "version": "3.9.0",
+          "from": "js-yaml@>=3.5.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+          "dependencies": {
+            "argparse": {
+              "version": "1.0.9",
+              "from": "argparse@>=1.0.7 <2.0.0",
+              "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+              "dependencies": {
+                "sprintf-js": {
+                  "version": "1.0.3",
+                  "from": "sprintf-js@>=1.0.2 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                }
+              }
+            },
+            "esprima": {
+              "version": "4.0.0",
+              "from": "esprima@>=4.0.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+            }
+          }
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "dependencies": {
+            "jsonify": {
+              "version": "0.0.0",
+              "from": "jsonify@>=0.0.0 <0.1.0",
+              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+            }
+          }
+        },
+        "levn": {
+          "version": "0.3.0",
+          "from": "levn@>=0.3.0 <0.4.0",
+          "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2",
+              "from": "prelude-ls@>=1.1.2 <1.2.0",
+              "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "from": "type-check@>=0.3.2 <0.4.0",
+              "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "natural-compare": {
+          "version": "1.4.0",
+          "from": "natural-compare@>=1.4.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+        },
+        "optionator": {
+          "version": "0.8.2",
+          "from": "optionator@>=0.8.2 <0.9.0",
+          "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+          "dependencies": {
+            "prelude-ls": {
+              "version": "1.1.2",
+              "from": "prelude-ls@>=1.1.2 <1.2.0",
+              "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+            },
+            "deep-is": {
+              "version": "0.1.3",
+              "from": "deep-is@>=0.1.3 <0.2.0",
+              "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+            },
+            "wordwrap": {
+              "version": "1.0.0",
+              "from": "wordwrap@>=1.0.0 <1.1.0",
+              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+            },
+            "type-check": {
+              "version": "0.3.2",
+              "from": "type-check@>=0.3.2 <0.4.0",
+              "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+            },
+            "fast-levenshtein": {
+              "version": "2.0.6",
+              "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+              "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+            }
+          }
+        },
+        "path-is-inside": {
+          "version": "1.0.2",
+          "from": "path-is-inside@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
+        },
+        "pluralize": {
+          "version": "1.2.1",
+          "from": "pluralize@>=1.2.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
+        },
+        "progress": {
+          "version": "1.1.8",
+          "from": "progress@>=1.1.8 <2.0.0",
+          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+        },
+        "require-uncached": {
+          "version": "1.0.3",
+          "from": "require-uncached@>=1.0.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+          "dependencies": {
+            "caller-path": {
+              "version": "0.1.0",
+              "from": "caller-path@>=0.1.0 <0.2.0",
+              "resolved": "http://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+              "dependencies": {
+                "callsites": {
+                  "version": "0.2.0",
+                  "from": "callsites@>=0.2.0 <0.3.0",
+                  "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
+                }
+              }
+            },
+            "resolve-from": {
+              "version": "1.0.1",
+              "from": "resolve-from@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.7.8",
+          "from": "shelljs@>=0.7.5 <0.8.0",
+          "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+          "dependencies": {
+            "interpret": {
+              "version": "1.0.3",
+              "from": "interpret@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
+            },
+            "rechoir": {
+              "version": "0.6.2",
+              "from": "rechoir@>=0.6.2 <0.7.0",
+              "resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+              "dependencies": {
+                "resolve": {
+                  "version": "1.3.3",
+                  "from": "resolve@>=1.1.6 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+                  "dependencies": {
+                    "path-parse": {
+                      "version": "1.0.5",
+                      "from": "path-parse@>=1.0.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "from": "strip-bom@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@>=2.0.1 <2.1.0",
+          "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+        },
+        "table": {
+          "version": "3.8.3",
+          "from": "table@>=3.7.8 <4.0.0",
+          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+          "dependencies": {
+            "ajv": {
+              "version": "4.11.8",
+              "from": "ajv@>=4.7.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+              "dependencies": {
+                "co": {
+                  "version": "4.6.0",
+                  "from": "co@>=4.6.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                }
+              }
+            },
+            "ajv-keywords": {
+              "version": "1.5.1",
+              "from": "ajv-keywords@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
+            },
+            "slice-ansi": {
+              "version": "0.0.4",
+              "from": "slice-ansi@0.0.4",
+              "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
+            },
+            "string-width": {
+              "version": "2.1.1",
+              "from": "string-width@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+              "dependencies": {
+                "is-fullwidth-code-point": {
+                  "version": "2.0.0",
+                  "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "4.0.0",
+                  "from": "strip-ansi@>=4.0.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "3.0.0",
+                      "from": "ansi-regex@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "text-table": {
+          "version": "0.2.0",
+          "from": "text-table@>=0.2.0 <0.3.0",
+          "resolved": "http://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+        },
+        "user-home": {
+          "version": "2.0.0",
+          "from": "user-home@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+          "dependencies": {
+            "os-homedir": {
+              "version": "1.0.2",
+              "from": "os-homedir@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "eslint-plugin-react": {
+      "version": "6.10.3",
+      "from": "eslint-plugin-react@>=6.7.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "from": "doctrine@>=1.2.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "dependencies": {
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "isarray": {
+              "version": "1.0.0",
+              "from": "isarray@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+            }
+          }
+        },
+        "has": {
+          "version": "1.0.1",
+          "from": "has@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            }
+          }
+        },
+        "jsx-ast-utils": {
+          "version": "1.4.1",
+          "from": "jsx-ast-utils@>=1.3.4 <2.0.0",
+          "resolved": "http://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz"
+        },
+        "array.prototype.find": {
+          "version": "2.0.4",
+          "from": "array.prototype.find@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+          "dependencies": {
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                },
+                "object-keys": {
+                  "version": "1.0.11",
+                  "from": "object-keys@>=1.0.8 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+                }
+              }
+            },
+            "es-abstract": {
+              "version": "1.7.0",
+              "from": "es-abstract@>=1.7.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+              "dependencies": {
+                "function-bind": {
+                  "version": "1.1.0",
+                  "from": "function-bind@>=1.1.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+                },
+                "is-callable": {
+                  "version": "1.1.3",
+                  "from": "is-callable@>=1.1.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
+                },
+                "es-to-primitive": {
+                  "version": "1.1.1",
+                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+                  "dependencies": {
+                    "is-date-object": {
+                      "version": "1.0.1",
+                      "from": "is-date-object@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
+                    },
+                    "is-symbol": {
+                      "version": "1.0.1",
+                      "from": "is-symbol@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
+                    }
+                  }
+                },
+                "is-regex": {
+                  "version": "1.0.4",
+                  "from": "is-regex@>=1.0.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
+                }
+              }
+            }
+          }
+        },
+        "object.assign": {
+          "version": "4.0.4",
+          "from": "object.assign@>=4.0.4 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+          "dependencies": {
+            "function-bind": {
+              "version": "1.1.0",
+              "from": "function-bind@>=1.1.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+            },
+            "object-keys": {
+              "version": "1.0.11",
+              "from": "object-keys@>=1.0.10 <2.0.0",
+              "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
+            },
+            "define-properties": {
+              "version": "1.1.2",
+              "from": "define-properties@>=1.1.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+              "dependencies": {
+                "foreach": {
+                  "version": "2.0.5",
+                  "from": "foreach@>=2.0.5 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "extract-text-webpack-plugin": {
+      "version": "1.0.1",
+      "from": "extract-text-webpack-plugin@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.5.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.3 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "webpack-sources": {
+          "version": "0.1.5",
+          "from": "webpack-sources@>=0.1.0 <0.2.0",
+          "resolved": "http://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.3 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "source-list-map": {
+              "version": "0.1.8",
+              "from": "source-list-map@>=0.1.7 <0.2.0",
+              "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "file-loader": {
+      "version": "0.9.0",
+      "from": "file-loader@>=0.9.0 <0.10.0",
+      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.5 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "font-awesome": {
+      "version": "4.7.0",
+      "from": "font-awesome@>=4.7.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz"
+    },
+    "jquery": {
+      "version": "3.2.1",
+      "from": "jquery@>=3.1.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/jquery/-/jquery-3.2.1.tgz"
+    },
+    "jquery-ujs": {
+      "version": "1.2.2",
+      "from": "jquery-ujs@>=1.2.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.2.2.tgz"
+    },
+    "jsdom": {
+      "version": "9.12.0",
+      "from": "jsdom@>=9.8.3 <10.0.0",
+      "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "dependencies": {
+        "abab": {
+          "version": "1.0.3",
+          "from": "abab@>=1.0.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
+        },
+        "acorn": {
+          "version": "4.0.13",
+          "from": "acorn@>=4.0.4 <5.0.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
+        },
+        "acorn-globals": {
+          "version": "3.1.0",
+          "from": "acorn-globals@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz"
+        },
+        "array-equal": {
+          "version": "1.0.0",
+          "from": "array-equal@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
+        },
+        "content-type-parser": {
+          "version": "1.0.1",
+          "from": "content-type-parser@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz"
+        },
+        "cssom": {
+          "version": "0.3.2",
+          "from": "cssom@>=0.3.2 <0.4.0",
+          "resolved": "http://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
+        },
+        "cssstyle": {
+          "version": "0.2.37",
+          "from": "cssstyle@>=0.2.37 <0.3.0",
+          "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
+        },
+        "escodegen": {
+          "version": "1.8.1",
+          "from": "escodegen@>=1.6.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+          "dependencies": {
+            "estraverse": {
+              "version": "1.9.3",
+              "from": "estraverse@>=1.9.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
+            },
+            "esutils": {
+              "version": "2.0.2",
+              "from": "esutils@>=2.0.2 <3.0.0",
+              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+            },
+            "esprima": {
+              "version": "2.7.3",
+              "from": "esprima@>=2.7.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+            },
+            "optionator": {
+              "version": "0.8.2",
+              "from": "optionator@>=0.8.1 <0.9.0",
+              "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+              "dependencies": {
+                "prelude-ls": {
+                  "version": "1.1.2",
+                  "from": "prelude-ls@>=1.1.2 <1.2.0",
+                  "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+                },
+                "deep-is": {
+                  "version": "0.1.3",
+                  "from": "deep-is@>=0.1.3 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+                },
+                "wordwrap": {
+                  "version": "1.0.0",
+                  "from": "wordwrap@>=1.0.0 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+                },
+                "type-check": {
+                  "version": "0.3.2",
+                  "from": "type-check@>=0.3.2 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+                },
+                "levn": {
+                  "version": "0.3.0",
+                  "from": "levn@>=0.3.0 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+                },
+                "fast-levenshtein": {
+                  "version": "2.0.6",
+                  "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+                }
+              }
+            },
+            "source-map": {
+              "version": "0.2.0",
+              "from": "source-map@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "html-encoding-sniffer": {
+          "version": "1.0.1",
+          "from": "html-encoding-sniffer@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz"
+        },
+        "nwmatcher": {
+          "version": "1.4.1",
+          "from": "nwmatcher@>=1.3.9 <2.0.0",
+          "resolved": "http://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz"
+        },
+        "parse5": {
+          "version": "1.5.1",
+          "from": "parse5@>=1.5.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@>=2.61.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "caseless@>=0.12.0 <0.13.0",
+              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "http://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "har-validator@>=4.2.1 <4.3.0",
+              "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "dependencies": {
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "ajv@>=4.9.1 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@>=4.6.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.16",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@>=6.4.0 <6.5.0",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@>=5.0.1 <6.0.0",
+              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "tunnel-agent@>=0.6.0 <0.7.0",
+              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+            }
+          }
+        },
+        "sax": {
+          "version": "1.2.4",
+          "from": "sax@>=1.2.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+        },
+        "symbol-tree": {
+          "version": "3.2.2",
+          "from": "symbol-tree@>=3.2.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@>=2.3.2 <3.0.0",
+          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@>=1.4.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            }
+          }
+        },
+        "webidl-conversions": {
+          "version": "4.0.1",
+          "from": "webidl-conversions@>=4.0.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz"
+        },
+        "whatwg-encoding": {
+          "version": "1.0.1",
+          "from": "whatwg-encoding@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+          "dependencies": {
+            "iconv-lite": {
+              "version": "0.4.13",
+              "from": "iconv-lite@0.4.13",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+            }
+          }
+        },
+        "whatwg-url": {
+          "version": "4.8.0",
+          "from": "whatwg-url@>=4.3.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+          "dependencies": {
+            "tr46": {
+              "version": "0.0.3",
+              "from": "tr46@>=0.0.3 <0.1.0",
+              "resolved": "http://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
+            },
+            "webidl-conversions": {
+              "version": "3.0.1",
+              "from": "webidl-conversions@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
+            }
+          }
+        },
+        "xml-name-validator": {
+          "version": "2.0.1",
+          "from": "xml-name-validator@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+        }
+      }
+    },
+    "lodash": {
+      "version": "4.17.4",
+      "from": "lodash@>=4.17.4 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+    },
+    "mocha": {
+      "version": "3.4.2",
+      "from": "mocha@>=3.2.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "dependencies": {
+        "browser-stdout": {
+          "version": "1.3.0",
+          "from": "browser-stdout@1.3.0",
+          "resolved": "http://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
+        },
+        "commander": {
+          "version": "2.9.0",
+          "from": "commander@2.9.0",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+          "dependencies": {
+            "graceful-readlink": {
+              "version": "1.0.1",
+              "from": "graceful-readlink@>=1.0.0",
+              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.0",
+          "from": "debug@2.6.0",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.7.2",
+              "from": "ms@0.7.2",
+              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
+            }
+          }
+        },
+        "diff": {
+          "version": "3.2.0",
+          "from": "diff@3.2.0",
+          "resolved": "http://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "from": "escape-string-regexp@1.0.5",
+          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+        },
+        "glob": {
+          "version": "7.1.1",
+          "from": "glob@7.1.1",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "growl": {
+          "version": "1.9.2",
+          "from": "growl@1.9.2",
+          "resolved": "http://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
+        },
+        "json3": {
+          "version": "3.3.2",
+          "from": "json3@3.3.2",
+          "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+        },
+        "lodash.create": {
+          "version": "3.1.1",
+          "from": "lodash.create@3.1.1",
+          "resolved": "http://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+          "dependencies": {
+            "lodash._baseassign": {
+              "version": "3.2.0",
+              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._basecopy": {
+                  "version": "3.0.1",
+                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash._basecreate": {
+              "version": "3.0.3",
+              "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
+            },
+            "lodash._isiterateecall": {
+              "version": "3.0.9",
+              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@3.1.2",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "node-sass": {
+      "version": "3.13.1",
+      "from": "node-sass@>=3.10.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+      "dependencies": {
+        "async-foreach": {
+          "version": "0.1.3",
+          "from": "async-foreach@>=0.1.3 <0.2.0",
+          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "cross-spawn": {
+          "version": "3.0.1",
+          "from": "cross-spawn@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "4.1.1",
+              "from": "lru-cache@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
+              "dependencies": {
+                "pseudomap": {
+                  "version": "1.0.2",
+                  "from": "pseudomap@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+                },
+                "yallist": {
+                  "version": "2.1.2",
+                  "from": "yallist@>=2.1.2 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.14",
+              "from": "which@>=1.2.9 <2.0.0",
+              "resolved": "http://registry.npmjs.org/which/-/which-1.2.14.tgz",
+              "dependencies": {
+                "isexe": {
+                  "version": "2.0.0",
+                  "from": "isexe@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "gaze": {
+          "version": "1.1.2",
+          "from": "gaze@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
+          "dependencies": {
+            "globule": {
+              "version": "1.2.0",
+              "from": "globule@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
+              "dependencies": {
+                "minimatch": {
+                  "version": "3.0.4",
+                  "from": "minimatch@>=3.0.2 <3.1.0",
+                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                  "dependencies": {
+                    "brace-expansion": {
+                      "version": "1.1.8",
+                      "from": "brace-expansion@>=1.1.7 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                      "dependencies": {
+                        "balanced-match": {
+                          "version": "1.0.0",
+                          "from": "balanced-match@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                        },
+                        "concat-map": {
+                          "version": "0.0.1",
+                          "from": "concat-map@0.0.1",
+                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "get-stdin": {
+          "version": "4.0.1",
+          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@>=7.0.3 <8.0.0",
+          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "dependencies": {
+            "fs.realpath": {
+              "version": "1.0.0",
+              "from": "fs.realpath@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+            },
+            "inflight": {
+              "version": "1.0.6",
+              "from": "inflight@>=1.0.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.4 <4.0.0",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.4.0",
+              "from": "once@>=1.3.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.2",
+                  "from": "wrappy@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                }
+              }
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            }
+          }
+        },
+        "in-publish": {
+          "version": "2.0.0",
+          "from": "in-publish@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
+        },
+        "lodash.assign": {
+          "version": "4.2.0",
+          "from": "lodash.assign@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+        },
+        "lodash.clonedeep": {
+          "version": "4.5.0",
+          "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
+          "resolved": "http://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+        },
+        "meow": {
+          "version": "3.7.0",
+          "from": "meow@>=3.7.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "dependencies": {
+            "camelcase-keys": {
+              "version": "2.1.0",
+              "from": "camelcase-keys@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "2.1.1",
+                  "from": "camelcase@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                }
+              }
+            },
+            "decamelize": {
+              "version": "1.2.0",
+              "from": "decamelize@>=1.1.2 <2.0.0",
+              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+            },
+            "loud-rejection": {
+              "version": "1.6.0",
+              "from": "loud-rejection@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+              "dependencies": {
+                "currently-unhandled": {
+                  "version": "0.4.1",
+                  "from": "currently-unhandled@>=0.4.1 <0.5.0",
+                  "resolved": "http://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                  "dependencies": {
+                    "array-find-index": {
+                      "version": "1.0.2",
+                      "from": "array-find-index@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+                    }
+                  }
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "from": "signal-exit@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                }
+              }
+            },
+            "map-obj": {
+              "version": "1.0.1",
+              "from": "map-obj@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+            },
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@>=1.1.3 <2.0.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+            },
+            "normalize-package-data": {
+              "version": "2.4.0",
+              "from": "normalize-package-data@>=2.3.4 <3.0.0",
+              "resolved": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+              "dependencies": {
+                "hosted-git-info": {
+                  "version": "2.5.0",
+                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                },
+                "is-builtin-module": {
+                  "version": "1.0.0",
+                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                  "dependencies": {
+                    "builtin-modules": {
+                      "version": "1.1.1",
+                      "from": "builtin-modules@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                    }
+                  }
+                },
+                "semver": {
+                  "version": "5.4.1",
+                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                  "resolved": "http://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                },
+                "validate-npm-package-license": {
+                  "version": "3.0.1",
+                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                  "dependencies": {
+                    "spdx-correct": {
+                      "version": "1.0.2",
+                      "from": "spdx-correct@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                      "dependencies": {
+                        "spdx-license-ids": {
+                          "version": "1.2.2",
+                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                        }
+                      }
+                    },
+                    "spdx-expression-parse": {
+                      "version": "1.0.4",
+                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            },
+            "read-pkg-up": {
+              "version": "1.0.1",
+              "from": "read-pkg-up@>=1.0.1 <2.0.0",
+              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+              "dependencies": {
+                "find-up": {
+                  "version": "1.1.2",
+                  "from": "find-up@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                  "dependencies": {
+                    "path-exists": {
+                      "version": "2.1.0",
+                      "from": "path-exists@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                    },
+                    "pinkie-promise": {
+                      "version": "2.0.1",
+                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                      "dependencies": {
+                        "pinkie": {
+                          "version": "2.0.4",
+                          "from": "pinkie@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg": {
+                  "version": "1.1.0",
+                  "from": "read-pkg@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                  "dependencies": {
+                    "load-json-file": {
+                      "version": "1.1.0",
+                      "from": "load-json-file@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                        },
+                        "parse-json": {
+                          "version": "2.2.0",
+                          "from": "parse-json@>=2.2.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                          "dependencies": {
+                            "error-ex": {
+                              "version": "1.3.1",
+                              "from": "error-ex@>=1.2.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                              "dependencies": {
+                                "is-arrayish": {
+                                  "version": "0.2.1",
+                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "from": "pify@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        },
+                        "strip-bom": {
+                          "version": "2.0.0",
+                          "from": "strip-bom@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                          "dependencies": {
+                            "is-utf8": {
+                              "version": "0.2.1",
+                              "from": "is-utf8@>=0.2.0 <0.3.0",
+                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "path-type": {
+                      "version": "1.1.0",
+                      "from": "path-type@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "4.1.11",
+                          "from": "graceful-fs@>=4.1.2 <5.0.0",
+                          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                        },
+                        "pify": {
+                          "version": "2.3.0",
+                          "from": "pify@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "redent": {
+              "version": "1.0.0",
+              "from": "redent@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+              "dependencies": {
+                "indent-string": {
+                  "version": "2.1.0",
+                  "from": "indent-string@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                  "dependencies": {
+                    "repeating": {
+                      "version": "2.0.1",
+                      "from": "repeating@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                      "dependencies": {
+                        "is-finite": {
+                          "version": "1.0.2",
+                          "from": "is-finite@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                          "dependencies": {
+                            "number-is-nan": {
+                              "version": "1.0.1",
+                              "from": "number-is-nan@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-indent": {
+                  "version": "1.0.1",
+                  "from": "strip-indent@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                }
+              }
+            },
+            "trim-newlines": {
+              "version": "1.0.0",
+              "from": "trim-newlines@>=1.0.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "nan": {
+          "version": "2.6.2",
+          "from": "nan@>=2.3.2 <3.0.0",
+          "resolved": "http://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+        },
+        "node-gyp": {
+          "version": "3.6.2",
+          "from": "node-gyp@>=3.3.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+          "dependencies": {
+            "fstream": {
+              "version": "1.0.11",
+              "from": "fstream@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            },
+            "minimatch": {
+              "version": "3.0.4",
+              "from": "minimatch@>=3.0.2 <4.0.0",
+              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.8",
+                  "from": "brace-expansion@>=1.1.7 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "1.0.0",
+                      "from": "balanced-match@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "nopt": {
+              "version": "3.0.6",
+              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.1.0",
+                  "from": "abbrev@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                }
+              }
+            },
+            "osenv": {
+              "version": "0.1.4",
+              "from": "osenv@>=0.0.0 <1.0.0",
+              "resolved": "http://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+              "dependencies": {
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "os-homedir@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "os-tmpdir": {
+                  "version": "1.0.2",
+                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.6.1",
+              "from": "rimraf@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+            },
+            "semver": {
+              "version": "5.3.0",
+              "from": "semver@>=5.3.0 <5.4.0",
+              "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+            },
+            "tar": {
+              "version": "2.2.1",
+              "from": "tar@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
+              "dependencies": {
+                "block-stream": {
+                  "version": "0.0.9",
+                  "from": "block-stream@*",
+                  "resolved": "http://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "which": {
+              "version": "1.2.14",
+              "from": "which@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/which/-/which-1.2.14.tgz",
+              "dependencies": {
+                "isexe": {
+                  "version": "2.0.0",
+                  "from": "isexe@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "npmlog": {
+          "version": "4.1.2",
+          "from": "npmlog@>=4.0.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "dependencies": {
+            "are-we-there-yet": {
+              "version": "1.1.4",
+              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+              "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+              "dependencies": {
+                "delegates": {
+                  "version": "1.0.0",
+                  "from": "delegates@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "from": "readable-stream@>=2.0.6 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.3 <2.1.0",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "console-control-strings": {
+              "version": "1.1.0",
+              "from": "console-control-strings@>=1.1.0 <1.2.0",
+              "resolved": "http://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+            },
+            "gauge": {
+              "version": "2.7.4",
+              "from": "gauge@>=2.7.3 <2.8.0",
+              "resolved": "http://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+              "dependencies": {
+                "aproba": {
+                  "version": "1.1.2",
+                  "from": "aproba@>=1.0.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+                },
+                "has-unicode": {
+                  "version": "2.0.1",
+                  "from": "has-unicode@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                },
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                },
+                "signal-exit": {
+                  "version": "3.0.2",
+                  "from": "signal-exit@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "from": "string-width@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "wide-align": {
+                  "version": "1.1.2",
+                  "from": "wide-align@>=1.1.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+                }
+              }
+            },
+            "set-blocking": {
+              "version": "2.0.0",
+              "from": "set-blocking@>=2.0.0 <2.1.0",
+              "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+            }
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@>=2.61.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "dependencies": {
+            "aws-sign2": {
+              "version": "0.6.0",
+              "from": "aws-sign2@>=0.6.0 <0.7.0",
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+            },
+            "aws4": {
+              "version": "1.6.0",
+              "from": "aws4@>=1.2.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+            },
+            "caseless": {
+              "version": "0.12.0",
+              "from": "caseless@>=0.12.0 <0.13.0",
+              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+            },
+            "combined-stream": {
+              "version": "1.0.5",
+              "from": "combined-stream@>=1.0.5 <1.1.0",
+              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "dependencies": {
+                "delayed-stream": {
+                  "version": "1.0.0",
+                  "from": "delayed-stream@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                }
+              }
+            },
+            "extend": {
+              "version": "3.0.1",
+              "from": "extend@>=3.0.0 <3.1.0",
+              "resolved": "http://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+            },
+            "forever-agent": {
+              "version": "0.6.1",
+              "from": "forever-agent@>=0.6.1 <0.7.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+            },
+            "form-data": {
+              "version": "2.1.4",
+              "from": "form-data@>=2.1.1 <2.2.0",
+              "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+              "dependencies": {
+                "asynckit": {
+                  "version": "0.4.0",
+                  "from": "asynckit@>=0.4.0 <0.5.0",
+                  "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                }
+              }
+            },
+            "har-validator": {
+              "version": "4.2.1",
+              "from": "har-validator@>=4.2.1 <4.3.0",
+              "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "dependencies": {
+                "ajv": {
+                  "version": "4.11.8",
+                  "from": "ajv@>=4.9.1 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                  "dependencies": {
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@>=4.6.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "dependencies": {
+                        "jsonify": {
+                          "version": "0.0.0",
+                          "from": "jsonify@>=0.0.0 <0.1.0",
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "har-schema": {
+                  "version": "1.0.5",
+                  "from": "har-schema@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                }
+              }
+            },
+            "hawk": {
+              "version": "3.1.3",
+              "from": "hawk@>=3.1.3 <3.2.0",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "2.16.3",
+                  "from": "hoek@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                },
+                "boom": {
+                  "version": "2.10.1",
+                  "from": "boom@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                },
+                "cryptiles": {
+                  "version": "2.0.5",
+                  "from": "cryptiles@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                },
+                "sntp": {
+                  "version": "1.0.9",
+                  "from": "sntp@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                }
+              }
+            },
+            "http-signature": {
+              "version": "1.1.1",
+              "from": "http-signature@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "dependencies": {
+                "assert-plus": {
+                  "version": "0.2.0",
+                  "from": "assert-plus@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                },
+                "jsprim": {
+                  "version": "1.4.0",
+                  "from": "jsprim@>=1.2.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@1.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    }
+                  }
+                },
+                "sshpk": {
+                  "version": "1.13.1",
+                  "from": "sshpk@>=1.7.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+                  "dependencies": {
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@>=0.2.3 <0.3.0",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "1.0.0",
+                      "from": "assert-plus@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@>=1.12.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "from": "getpass@>=0.1.1 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "jsbn@>=0.1.0 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@>=0.14.0 <0.15.0",
+                      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "is-typedarray": {
+              "version": "1.0.0",
+              "from": "is-typedarray@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+            },
+            "isstream": {
+              "version": "0.1.2",
+              "from": "isstream@>=0.1.2 <0.2.0",
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "5.0.1",
+              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+            },
+            "mime-types": {
+              "version": "2.1.16",
+              "from": "mime-types@>=2.1.7 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                }
+              }
+            },
+            "oauth-sign": {
+              "version": "0.8.2",
+              "from": "oauth-sign@>=0.8.1 <0.9.0",
+              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+            },
+            "performance-now": {
+              "version": "0.2.0",
+              "from": "performance-now@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@>=6.4.0 <6.5.0",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@>=5.0.1 <6.0.0",
+              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            },
+            "stringstream": {
+              "version": "0.0.5",
+              "from": "stringstream@>=0.0.4 <0.1.0",
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+            },
+            "tough-cookie": {
+              "version": "2.3.2",
+              "from": "tough-cookie@>=2.3.0 <2.4.0",
+              "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.4.1",
+                  "from": "punycode@>=1.4.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                }
+              }
+            },
+            "tunnel-agent": {
+              "version": "0.6.0",
+              "from": "tunnel-agent@>=0.6.0 <0.7.0",
+              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+            },
+            "uuid": {
+              "version": "3.1.0",
+              "from": "uuid@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+            }
+          }
+        },
+        "sass-graph": {
+          "version": "2.2.4",
+          "from": "sass-graph@>=2.1.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
+          "dependencies": {
+            "scss-tokenizer": {
+              "version": "0.2.3",
+              "from": "scss-tokenizer@>=0.2.3 <0.3.0",
+              "resolved": "http://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+              "dependencies": {
+                "js-base64": {
+                  "version": "2.1.9",
+                  "from": "js-base64@>=2.1.8 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+                },
+                "source-map": {
+                  "version": "0.4.4",
+                  "from": "source-map@>=0.4.2 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "1.0.1",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "yargs": {
+              "version": "7.1.0",
+              "from": "yargs@>=7.0.0 <8.0.0",
+              "resolved": "http://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "3.0.0",
+                  "from": "camelcase@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+                },
+                "cliui": {
+                  "version": "3.2.0",
+                  "from": "cliui@>=3.2.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+                  "dependencies": {
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    },
+                    "wrap-ansi": {
+                      "version": "2.1.0",
+                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.1.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "get-caller-file": {
+                  "version": "1.0.2",
+                  "from": "get-caller-file@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+                },
+                "os-locale": {
+                  "version": "1.4.0",
+                  "from": "os-locale@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
+                  "dependencies": {
+                    "lcid": {
+                      "version": "1.0.0",
+                      "from": "lcid@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                      "dependencies": {
+                        "invert-kv": {
+                          "version": "1.0.0",
+                          "from": "invert-kv@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "read-pkg-up": {
+                  "version": "1.0.1",
+                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "dependencies": {
+                    "find-up": {
+                      "version": "1.1.2",
+                      "from": "find-up@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "dependencies": {
+                        "path-exists": {
+                          "version": "2.1.0",
+                          "from": "path-exists@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                        },
+                        "pinkie-promise": {
+                          "version": "2.0.1",
+                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "dependencies": {
+                            "pinkie": {
+                              "version": "2.0.4",
+                              "from": "pinkie@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "read-pkg": {
+                      "version": "1.1.0",
+                      "from": "read-pkg@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "dependencies": {
+                        "load-json-file": {
+                          "version": "1.1.0",
+                          "from": "load-json-file@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.11",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                            },
+                            "parse-json": {
+                              "version": "2.2.0",
+                              "from": "parse-json@>=2.2.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "dependencies": {
+                                "error-ex": {
+                                  "version": "1.3.1",
+                                  "from": "error-ex@>=1.2.0 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                                  "dependencies": {
+                                    "is-arrayish": {
+                                      "version": "0.2.1",
+                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            },
+                            "strip-bom": {
+                              "version": "2.0.0",
+                              "from": "strip-bom@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "dependencies": {
+                                "is-utf8": {
+                                  "version": "0.2.1",
+                                  "from": "is-utf8@>=0.2.0 <0.3.0",
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "normalize-package-data": {
+                          "version": "2.4.0",
+                          "from": "normalize-package-data@>=2.3.2 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+                          "dependencies": {
+                            "hosted-git-info": {
+                              "version": "2.5.0",
+                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+                            },
+                            "is-builtin-module": {
+                              "version": "1.0.0",
+                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                              "dependencies": {
+                                "builtin-modules": {
+                                  "version": "1.1.1",
+                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
+                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                                }
+                              }
+                            },
+                            "semver": {
+                              "version": "5.4.1",
+                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+                              "resolved": "http://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                            },
+                            "validate-npm-package-license": {
+                              "version": "3.0.1",
+                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                              "dependencies": {
+                                "spdx-correct": {
+                                  "version": "1.0.2",
+                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
+                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                                  "dependencies": {
+                                    "spdx-license-ids": {
+                                      "version": "1.2.2",
+                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                                    }
+                                  }
+                                },
+                                "spdx-expression-parse": {
+                                  "version": "1.0.4",
+                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+                                  "resolved": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        },
+                        "path-type": {
+                          "version": "1.1.0",
+                          "from": "path-type@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "dependencies": {
+                            "graceful-fs": {
+                              "version": "4.1.11",
+                              "from": "graceful-fs@>=4.1.2 <5.0.0",
+                              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                            },
+                            "pify": {
+                              "version": "2.3.0",
+                              "from": "pify@>=2.0.0 <3.0.0",
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                            },
+                            "pinkie-promise": {
+                              "version": "2.0.1",
+                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "dependencies": {
+                                "pinkie": {
+                                  "version": "2.0.4",
+                                  "from": "pinkie@>=2.0.0 <3.0.0",
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-directory": {
+                  "version": "2.1.1",
+                  "from": "require-directory@>=2.1.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+                },
+                "require-main-filename": {
+                  "version": "1.0.1",
+                  "from": "require-main-filename@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+                },
+                "set-blocking": {
+                  "version": "2.0.0",
+                  "from": "set-blocking@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                },
+                "string-width": {
+                  "version": "1.0.2",
+                  "from": "string-width@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+                  "dependencies": {
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "from": "code-point-at@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+                      "dependencies": {
+                        "number-is-nan": {
+                          "version": "1.0.1",
+                          "from": "number-is-nan@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "dependencies": {
+                        "ansi-regex": {
+                          "version": "2.1.1",
+                          "from": "ansi-regex@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "which-module": {
+                  "version": "1.0.0",
+                  "from": "which-module@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+                },
+                "y18n": {
+                  "version": "3.2.1",
+                  "from": "y18n@>=3.2.1 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+                },
+                "yargs-parser": {
+                  "version": "5.0.0",
+                  "from": "yargs-parser@>=5.0.0 <6.0.0",
+                  "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "postcss-loader": {
+      "version": "1.3.3",
+      "from": "postcss-loader@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-loader/-/postcss-loader-1.3.3.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "from": "loader-utils@>=1.0.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.1 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        },
+        "postcss": {
+          "version": "5.2.17",
+          "from": "postcss@>=5.2.15 <6.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "1.1.3",
+              "from": "chalk@>=1.1.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "2.2.1",
+                  "from": "ansi-styles@>=2.2.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.5",
+                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                },
+                "has-ansi": {
+                  "version": "2.0.0",
+                  "from": "has-ansi@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "3.0.1",
+                  "from": "strip-ansi@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "2.0.0",
+                  "from": "supports-color@>=2.0.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                }
+              }
+            },
+            "js-base64": {
+              "version": "2.1.9",
+              "from": "js-base64@>=2.1.9 <3.0.0",
+              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.6 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "supports-color": {
+              "version": "3.2.3",
+              "from": "supports-color@>=3.2.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+              "dependencies": {
+                "has-flag": {
+                  "version": "1.0.0",
+                  "from": "has-flag@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "postcss-load-config": {
+          "version": "1.2.0",
+          "from": "postcss-load-config@>=1.2.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
+          "dependencies": {
+            "cosmiconfig": {
+              "version": "2.2.2",
+              "from": "cosmiconfig@>=2.1.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+              "dependencies": {
+                "is-directory": {
+                  "version": "0.3.1",
+                  "from": "is-directory@>=0.3.1 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz"
+                },
+                "js-yaml": {
+                  "version": "3.9.0",
+                  "from": "js-yaml@>=3.4.3 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.9",
+                      "from": "argparse@>=1.0.7 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "4.0.0",
+                      "from": "esprima@>=4.0.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+                    }
+                  }
+                },
+                "minimist": {
+                  "version": "1.2.0",
+                  "from": "minimist@>=1.2.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                },
+                "os-homedir": {
+                  "version": "1.0.2",
+                  "from": "os-homedir@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                },
+                "parse-json": {
+                  "version": "2.2.0",
+                  "from": "parse-json@>=2.2.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                  "dependencies": {
+                    "error-ex": {
+                      "version": "1.3.1",
+                      "from": "error-ex@>=1.2.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+                      "dependencies": {
+                        "is-arrayish": {
+                          "version": "0.2.1",
+                          "from": "is-arrayish@>=0.2.1 <0.3.0",
+                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "require-from-string": {
+                  "version": "1.2.1",
+                  "from": "require-from-string@>=1.1.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+                }
+              }
+            },
+            "postcss-load-options": {
+              "version": "1.2.0",
+              "from": "postcss-load-options@>=1.2.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz"
+            },
+            "postcss-load-plugins": {
+              "version": "2.3.0",
+              "from": "postcss-load-plugins@>=2.3.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "prop-types": {
+      "version": "15.5.10",
+      "from": "prop-types@>=15.5.10 <16.0.0",
+      "resolved": "http://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.12",
+          "from": "fbjs@>=0.8.9 <0.9.0",
+          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.7.1",
+                  "from": "node-fetch@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "from": "encoding@>=0.1.11 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.18",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
+                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                        }
+                      }
+                    },
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "from": "is-stream@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                    }
+                  }
+                },
+                "whatwg-fetch": {
+                  "version": "2.0.3",
+                  "from": "whatwg-fetch@>=0.10.0",
+                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.1.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            },
+            "promise": {
+              "version": "7.3.1",
+              "from": "promise@>=7.1.1 <8.0.0",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.6",
+                  "from": "asap@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "from": "setimmediate@>=1.0.5 <2.0.0",
+              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+            },
+            "ua-parser-js": {
+              "version": "0.7.14",
+              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+            }
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.3.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "rails-erb-loader": {
+      "version": "3.0.0",
+      "from": "rails-erb-loader@3.0.0",
+      "resolved": "http://registry.npmjs.org/rails-erb-loader/-/rails-erb-loader-3.0.0.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.16 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "lodash.defaults": {
+          "version": "4.2.0",
+          "from": "lodash.defaults@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+        },
+        "node-uuid": {
+          "version": "1.4.8",
+          "from": "node-uuid@>=1.4.7 <2.0.0",
+          "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
+        }
+      }
+    },
+    "rc-pagination": {
+      "version": "1.10.1",
+      "from": "rc-pagination@>=1.9.7 <2.0.0",
+      "resolved": "http://registry.npmjs.org/rc-pagination/-/rc-pagination-1.10.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.23.0 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "react": {
+      "version": "15.6.1",
+      "from": "react@>=15.4.0 <16.0.0",
+      "resolved": "http://registry.npmjs.org/react/-/react-15.6.1.tgz",
+      "dependencies": {
+        "create-react-class": {
+          "version": "15.6.0",
+          "from": "create-react-class@>=15.6.0 <16.0.0",
+          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz"
+        },
+        "fbjs": {
+          "version": "0.8.12",
+          "from": "fbjs@>=0.8.9 <0.9.0",
+          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.7.1",
+                  "from": "node-fetch@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "from": "encoding@>=0.1.11 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.18",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
+                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                        }
+                      }
+                    },
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "from": "is-stream@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                    }
+                  }
+                },
+                "whatwg-fetch": {
+                  "version": "2.0.3",
+                  "from": "whatwg-fetch@>=0.10.0",
+                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.3.1",
+              "from": "promise@>=7.1.1 <8.0.0",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.6",
+                  "from": "asap@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "from": "setimmediate@>=1.0.5 <2.0.0",
+              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+            },
+            "ua-parser-js": {
+              "version": "0.7.14",
+              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+            }
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "react-addons-shallow-compare": {
+      "version": "15.6.0",
+      "from": "react-addons-shallow-compare@>=15.5.2 <16.0.0",
+      "resolved": "http://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.0.tgz",
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.12",
+          "from": "fbjs@>=0.8.4 <0.9.0",
+          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.7.1",
+                  "from": "node-fetch@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "from": "encoding@>=0.1.11 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.18",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
+                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                        }
+                      }
+                    },
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "from": "is-stream@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                    }
+                  }
+                },
+                "whatwg-fetch": {
+                  "version": "2.0.3",
+                  "from": "whatwg-fetch@>=0.10.0",
+                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                }
+              }
+            },
+            "loose-envify": {
+              "version": "1.3.1",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.3.1",
+              "from": "promise@>=7.1.1 <8.0.0",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.6",
+                  "from": "asap@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "from": "setimmediate@>=1.0.5 <2.0.0",
+              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+            },
+            "ua-parser-js": {
+              "version": "0.7.14",
+              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.1 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "react-addons-test-utils": {
+      "version": "15.6.0",
+      "from": "react-addons-test-utils@>=15.4.0 <16.0.0",
+      "resolved": "http://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz"
+    },
+    "react-bootstrap": {
+      "version": "0.31.1",
+      "from": "react-bootstrap@>=0.31.0 <0.32.0",
+      "resolved": "http://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.1.tgz",
+      "dependencies": {
+        "babel-runtime": {
+          "version": "6.23.0",
+          "from": "babel-runtime@>=6.11.6 <7.0.0",
+          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "2.4.1",
+              "from": "core-js@>=2.4.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+            },
+            "regenerator-runtime": {
+              "version": "0.10.5",
+              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+            }
+          }
+        },
+        "classnames": {
+          "version": "2.2.5",
+          "from": "classnames@>=2.2.5 <3.0.0",
+          "resolved": "http://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+        },
+        "dom-helpers": {
+          "version": "3.2.1",
+          "from": "dom-helpers@>=3.2.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@>=2.2.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.3.1",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "keycode": {
+          "version": "2.1.9",
+          "from": "keycode@>=2.1.2 <3.0.0",
+          "resolved": "http://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz"
+        },
+        "prop-types-extra": {
+          "version": "1.0.1",
+          "from": "prop-types-extra@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.0.1.tgz"
+        },
+        "react-overlays": {
+          "version": "0.7.0",
+          "from": "react-overlays@>=0.7.0 <0.8.0",
+          "resolved": "http://registry.npmjs.org/react-overlays/-/react-overlays-0.7.0.tgz"
+        },
+        "react-prop-types": {
+          "version": "0.4.0",
+          "from": "react-prop-types@>=0.4.0 <0.5.0",
+          "resolved": "http://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz"
+        },
+        "uncontrollable": {
+          "version": "4.1.0",
+          "from": "uncontrollable@>=4.1.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz"
+        },
+        "warning": {
+          "version": "3.0.0",
+          "from": "warning@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
+          "dependencies": {
+            "loose-envify": {
+              "version": "1.3.1",
+              "from": "loose-envify@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+              "dependencies": {
+                "js-tokens": {
+                  "version": "3.0.2",
+                  "from": "js-tokens@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "react-dom": {
+      "version": "15.6.1",
+      "from": "react-dom@>=15.4.0 <16.0.0",
+      "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
+      "dependencies": {
+        "fbjs": {
+          "version": "0.8.12",
+          "from": "fbjs@>=0.8.9 <0.9.0",
+          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+          "dependencies": {
+            "core-js": {
+              "version": "1.2.7",
+              "from": "core-js@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+            },
+            "isomorphic-fetch": {
+              "version": "2.2.1",
+              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+              "dependencies": {
+                "node-fetch": {
+                  "version": "1.7.1",
+                  "from": "node-fetch@>=1.0.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                  "dependencies": {
+                    "encoding": {
+                      "version": "0.1.12",
+                      "from": "encoding@>=0.1.11 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                      "dependencies": {
+                        "iconv-lite": {
+                          "version": "0.4.18",
+                          "from": "iconv-lite@>=0.4.13 <0.5.0",
+                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                        }
+                      }
+                    },
+                    "is-stream": {
+                      "version": "1.1.0",
+                      "from": "is-stream@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                    }
+                  }
+                },
+                "whatwg-fetch": {
+                  "version": "2.0.3",
+                  "from": "whatwg-fetch@>=0.10.0",
+                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                }
+              }
+            },
+            "promise": {
+              "version": "7.3.1",
+              "from": "promise@>=7.1.1 <8.0.0",
+              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+              "dependencies": {
+                "asap": {
+                  "version": "2.0.6",
+                  "from": "asap@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                }
+              }
+            },
+            "setimmediate": {
+              "version": "1.0.5",
+              "from": "setimmediate@>=1.0.5 <2.0.0",
+              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+            },
+            "ua-parser-js": {
+              "version": "0.7.14",
+              "from": "ua-parser-js@>=0.7.9 <0.8.0",
+              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+            }
+          }
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "react-joyride": {
+      "version": "1.10.1",
+      "from": "react-joyride@>=1.10.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/react-joyride/-/react-joyride-1.10.1.tgz",
+      "dependencies": {
+        "nested-property": {
+          "version": "0.0.7",
+          "from": "nested-property@>=0.0.7 <0.0.8",
+          "resolved": "http://registry.npmjs.org/nested-property/-/nested-property-0.0.7.tgz"
+        },
+        "react-autobind": {
+          "version": "1.0.6",
+          "from": "react-autobind@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz"
+        },
+        "scroll": {
+          "version": "2.0.0",
+          "from": "scroll@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/scroll/-/scroll-2.0.0.tgz",
+          "dependencies": {
+            "rafl": {
+              "version": "1.2.2",
+              "from": "rafl@>=1.2.1 <1.3.0",
+              "resolved": "http://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
+              "dependencies": {
+                "global": {
+                  "version": "4.3.2",
+                  "from": "global@>=4.3.0 <4.4.0",
+                  "resolved": "http://registry.npmjs.org/global/-/global-4.3.2.tgz",
+                  "dependencies": {
+                    "min-document": {
+                      "version": "2.19.0",
+                      "from": "min-document@>=2.19.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+                      "dependencies": {
+                        "dom-walk": {
+                          "version": "0.1.1",
+                          "from": "dom-walk@>=0.1.0 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
+                        }
+                      }
+                    },
+                    "process": {
+                      "version": "0.5.2",
+                      "from": "process@>=0.5.1 <0.6.0",
+                      "resolved": "http://registry.npmjs.org/process/-/process-0.5.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "react-redux": {
+      "version": "4.4.8",
+      "from": "react-redux@>=4.4.6 <5.0.0",
+      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-4.4.8.tgz",
+      "dependencies": {
+        "create-react-class": {
+          "version": "15.6.0",
+          "from": "create-react-class@>=15.5.1 <16.0.0",
+          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+          "dependencies": {
+            "fbjs": {
+              "version": "0.8.12",
+              "from": "fbjs@>=0.8.9 <0.9.0",
+              "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.7",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+                },
+                "isomorphic-fetch": {
+                  "version": "2.2.1",
+                  "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+                  "dependencies": {
+                    "node-fetch": {
+                      "version": "1.7.1",
+                      "from": "node-fetch@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "from": "encoding@>=0.1.11 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.18",
+                              "from": "iconv-lite@>=0.4.13 <0.5.0",
+                              "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                            }
+                          }
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "from": "is-stream@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "whatwg-fetch": {
+                      "version": "2.0.3",
+                      "from": "whatwg-fetch@>=0.10.0",
+                      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                    }
+                  }
+                },
+                "promise": {
+                  "version": "7.3.1",
+                  "from": "promise@>=7.1.1 <8.0.0",
+                  "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+                  "dependencies": {
+                    "asap": {
+                      "version": "2.0.6",
+                      "from": "asap@>=2.0.3 <2.1.0",
+                      "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                    }
+                  }
+                },
+                "setimmediate": {
+                  "version": "1.0.5",
+                  "from": "setimmediate@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+                },
+                "ua-parser-js": {
+                  "version": "0.7.14",
+                  "from": "ua-parser-js@>=0.7.9 <0.8.0",
+                  "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.1.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        }
+      }
+    },
+    "react-router": {
+      "version": "3.0.5",
+      "from": "react-router@>=3.0.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/react-router/-/react-router-3.0.5.tgz",
+      "dependencies": {
+        "create-react-class": {
+          "version": "15.6.0",
+          "from": "create-react-class@>=15.5.1 <16.0.0",
+          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
+          "dependencies": {
+            "fbjs": {
+              "version": "0.8.12",
+              "from": "fbjs@>=0.8.9 <0.9.0",
+              "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
+              "dependencies": {
+                "core-js": {
+                  "version": "1.2.7",
+                  "from": "core-js@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+                },
+                "isomorphic-fetch": {
+                  "version": "2.2.1",
+                  "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
+                  "dependencies": {
+                    "node-fetch": {
+                      "version": "1.7.1",
+                      "from": "node-fetch@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
+                      "dependencies": {
+                        "encoding": {
+                          "version": "0.1.12",
+                          "from": "encoding@>=0.1.11 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
+                          "dependencies": {
+                            "iconv-lite": {
+                              "version": "0.4.18",
+                              "from": "iconv-lite@>=0.4.13 <0.5.0",
+                              "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+                            }
+                          }
+                        },
+                        "is-stream": {
+                          "version": "1.1.0",
+                          "from": "is-stream@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+                        }
+                      }
+                    },
+                    "whatwg-fetch": {
+                      "version": "2.0.3",
+                      "from": "whatwg-fetch@>=0.10.0",
+                      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+                    }
+                  }
+                },
+                "promise": {
+                  "version": "7.3.1",
+                  "from": "promise@>=7.1.1 <8.0.0",
+                  "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
+                  "dependencies": {
+                    "asap": {
+                      "version": "2.0.6",
+                      "from": "asap@>=2.0.3 <2.1.0",
+                      "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+                    }
+                  }
+                },
+                "setimmediate": {
+                  "version": "1.0.5",
+                  "from": "setimmediate@>=1.0.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+                },
+                "ua-parser-js": {
+                  "version": "0.7.14",
+                  "from": "ua-parser-js@>=0.7.9 <0.8.0",
+                  "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+                }
+              }
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.1.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "history": {
+          "version": "3.3.0",
+          "from": "history@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/history/-/history-3.3.0.tgz",
+          "dependencies": {
+            "query-string": {
+              "version": "4.3.4",
+              "from": "query-string@>=4.2.2 <5.0.0",
+              "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
+              "dependencies": {
+                "object-assign": {
+                  "version": "4.1.1",
+                  "from": "object-assign@>=4.1.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "hoist-non-react-statics": {
+          "version": "1.2.0",
+          "from": "hoist-non-react-statics@>=1.2.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+        },
+        "invariant": {
+          "version": "2.2.2",
+          "from": "invariant@>=2.2.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.2.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "warning": {
+          "version": "3.0.0",
+          "from": "warning@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
+        }
+      }
+    },
+    "redux": {
+      "version": "3.7.2",
+      "from": "redux@>=3.6.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
+      "dependencies": {
+        "lodash-es": {
+          "version": "4.17.4",
+          "from": "lodash-es@>=4.2.1 <5.0.0",
+          "resolved": "http://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
+        },
+        "loose-envify": {
+          "version": "1.3.1",
+          "from": "loose-envify@>=1.1.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+          "dependencies": {
+            "js-tokens": {
+              "version": "3.0.2",
+              "from": "js-tokens@>=3.0.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+            }
+          }
+        },
+        "symbol-observable": {
+          "version": "1.0.4",
+          "from": "symbol-observable@>=1.0.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
+        }
+      }
+    },
+    "redux-devtools": {
+      "version": "3.4.0",
+      "from": "redux-devtools@>=3.3.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/redux-devtools/-/redux-devtools-3.4.0.tgz",
+      "dependencies": {
+        "redux-devtools-instrument": {
+          "version": "1.8.2",
+          "from": "redux-devtools-instrument@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz",
+          "dependencies": {
+            "symbol-observable": {
+              "version": "1.0.4",
+              "from": "symbol-observable@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
+            }
+          }
+        }
+      }
+    },
+    "redux-logger": {
+      "version": "2.10.2",
+      "from": "redux-logger@>=2.7.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz",
+      "dependencies": {
+        "deep-diff": {
+          "version": "0.3.4",
+          "from": "deep-diff@0.3.4",
+          "resolved": "http://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz"
+        }
+      }
+    },
+    "redux-promise-middleware": {
+      "version": "4.3.0",
+      "from": "redux-promise-middleware@>=4.2.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-4.3.0.tgz"
+    },
+    "reselect": {
+      "version": "2.5.4",
+      "from": "reselect@>=2.5.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz"
+    },
+    "resolve-url-loader": {
+      "version": "1.6.1",
+      "from": "resolve-url-loader@>=1.6.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/resolve-url-loader/-/resolve-url-loader-1.6.1.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.2.1 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "convert-source-map": {
+          "version": "1.5.0",
+          "from": "convert-source-map@>=1.1.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.0.1 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "lodash.defaults": {
+          "version": "3.1.2",
+          "from": "lodash.defaults@>=3.1.2 <4.0.0",
+          "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
+          "dependencies": {
+            "lodash.assign": {
+              "version": "3.2.0",
+              "from": "lodash.assign@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
+              "dependencies": {
+                "lodash._baseassign": {
+                  "version": "3.2.0",
+                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
+                  "dependencies": {
+                    "lodash._basecopy": {
+                      "version": "3.0.1",
+                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+                    }
+                  }
+                },
+                "lodash._createassigner": {
+                  "version": "3.1.1",
+                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
+                  "dependencies": {
+                    "lodash._bindcallback": {
+                      "version": "3.0.1",
+                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+                    },
+                    "lodash._isiterateecall": {
+                      "version": "3.0.9",
+                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+                    }
+                  }
+                },
+                "lodash.keys": {
+                  "version": "3.1.2",
+                  "from": "lodash.keys@>=3.0.0 <4.0.0",
+                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
+                  "dependencies": {
+                    "lodash._getnative": {
+                      "version": "3.9.1",
+                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+                    },
+                    "lodash.isarguments": {
+                      "version": "3.1.0",
+                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+                    },
+                    "lodash.isarray": {
+                      "version": "3.0.4",
+                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "lodash.restparam": {
+              "version": "3.6.1",
+              "from": "lodash.restparam@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+            }
+          }
+        },
+        "rework": {
+          "version": "1.0.1",
+          "from": "rework@>=1.0.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
+          "dependencies": {
+            "css": {
+              "version": "2.2.1",
+              "from": "css@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/css/-/css-2.2.1.tgz",
+              "dependencies": {
+                "source-map-resolve": {
+                  "version": "0.3.1",
+                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+                  "dependencies": {
+                    "source-map-url": {
+                      "version": "0.3.0",
+                      "from": "source-map-url@>=0.3.0 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+                    },
+                    "atob": {
+                      "version": "1.1.3",
+                      "from": "atob@>=1.1.0 <1.2.0",
+                      "resolved": "http://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
+                    },
+                    "resolve-url": {
+                      "version": "0.2.1",
+                      "from": "resolve-url@>=0.2.1 <0.3.0",
+                      "resolved": "http://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
+                    }
+                  }
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "convert-source-map": {
+              "version": "0.3.5",
+              "from": "convert-source-map@>=0.3.3 <0.4.0",
+              "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+            }
+          }
+        },
+        "rework-visit": {
+          "version": "1.0.0",
+          "from": "rework-visit@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz"
+        },
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.43 <0.2.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "1.0.1",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+            }
+          }
+        },
+        "urix": {
+          "version": "0.1.0",
+          "from": "urix@>=0.1.0 <0.2.0",
+          "resolved": "http://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+        }
+      }
+    },
+    "sass-loader": {
+      "version": "4.1.1",
+      "from": "sass-loader@>=4.0.2 <5.0.0",
+      "resolved": "http://registry.npmjs.org/sass-loader/-/sass-loader-4.1.1.tgz",
+      "dependencies": {
+        "async": {
+          "version": "2.5.0",
+          "from": "async@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/async/-/async-2.5.0.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.15 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@>=4.1.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "stats-webpack-plugin": {
+      "version": "0.2.2",
+      "from": "stats-webpack-plugin@>=0.2.1 <0.3.0",
+      "resolved": "http://registry.npmjs.org/stats-webpack-plugin/-/stats-webpack-plugin-0.2.2.tgz"
+    },
+    "strict-uri-encode": {
+      "version": "1.1.0",
+      "from": "strict-uri-encode@1.1.0",
+      "resolved": "http://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+    },
+    "style-loader": {
+      "version": "0.13.2",
+      "from": "style-loader@>=0.13.1 <0.14.0",
+      "resolved": "http://registry.npmjs.org/style-loader/-/style-loader-0.13.2.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "from": "loader-utils@>=1.0.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "swagger-cli": {
+      "version": "1.0.0-beta.2",
+      "from": "swagger-cli@>=1.0.0-beta.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/swagger-cli/-/swagger-cli-1.0.0-beta.2.tgz",
+      "dependencies": {
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "from": "commander@>=2.8.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+        },
+        "es6-promise": {
+          "version": "3.3.1",
+          "from": "es6-promise@>=3.0.2 <4.0.0",
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
+        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        },
+        "swagger-parser": {
+          "version": "3.4.1",
+          "from": "swagger-parser@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/swagger-parser/-/swagger-parser-3.4.1.tgz",
+          "dependencies": {
+            "call-me-maybe": {
+              "version": "1.0.1",
+              "from": "call-me-maybe@>=1.0.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz"
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "json-schema-ref-parser": {
+              "version": "1.4.1",
+              "from": "json-schema-ref-parser@>=1.4.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
+              "dependencies": {
+                "js-yaml": {
+                  "version": "3.9.0",
+                  "from": "js-yaml@>=3.4.6 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
+                  "dependencies": {
+                    "argparse": {
+                      "version": "1.0.9",
+                      "from": "argparse@>=1.0.7 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+                      "dependencies": {
+                        "sprintf-js": {
+                          "version": "1.0.3",
+                          "from": "sprintf-js@>=1.0.2 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+                        }
+                      }
+                    },
+                    "esprima": {
+                      "version": "4.0.0",
+                      "from": "esprima@>=4.0.0 <5.0.0",
+                      "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "ono": {
+              "version": "2.2.5",
+              "from": "ono@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/ono/-/ono-2.2.5.tgz"
+            },
+            "swagger-methods": {
+              "version": "1.0.0",
+              "from": "swagger-methods@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz"
+            },
+            "swagger-schema-official": {
+              "version": "2.0.0-bab6bed",
+              "from": "swagger-schema-official@2.0.0-bab6bed",
+              "resolved": "http://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz"
+            },
+            "z-schema": {
+              "version": "3.18.2",
+              "from": "z-schema@>=3.16.1 <4.0.0",
+              "resolved": "http://registry.npmjs.org/z-schema/-/z-schema-3.18.2.tgz",
+              "dependencies": {
+                "lodash.get": {
+                  "version": "4.4.2",
+                  "from": "lodash.get@>=4.1.2 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
+                },
+                "lodash.isequal": {
+                  "version": "4.5.0",
+                  "from": "lodash.isequal@>=4.4.0 <5.0.0",
+                  "resolved": "http://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
+                },
+                "validator": {
+                  "version": "6.3.0",
+                  "from": "validator@>=6.0.0 <7.0.0",
+                  "resolved": "http://registry.npmjs.org/validator/-/validator-6.3.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "swagger-server": {
+          "version": "1.0.0-alpha.18",
+          "from": "swagger-server@>=1.0.0-alpha.18 <2.0.0",
+          "resolved": "http://registry.npmjs.org/swagger-server/-/swagger-server-1.0.0-alpha.18.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@>=2.2.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "directory-search": {
+              "version": "0.0.32",
+              "from": "directory-search@0.0.32",
+              "resolved": "http://registry.npmjs.org/directory-search/-/directory-search-0.0.32.tgz"
+            },
+            "express": {
+              "version": "4.15.3",
+              "from": "express@>=4.13.3 <5.0.0",
+              "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
+              "dependencies": {
+                "accepts": {
+                  "version": "1.3.3",
+                  "from": "accepts@>=1.3.3 <1.4.0",
+                  "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+                  "dependencies": {
+                    "mime-types": {
+                      "version": "2.1.16",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.29.0",
+                          "from": "mime-db@>=1.29.0 <1.30.0",
+                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                        }
+                      }
+                    },
+                    "negotiator": {
+                      "version": "0.6.1",
+                      "from": "negotiator@0.6.1",
+                      "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                    }
+                  }
+                },
+                "array-flatten": {
+                  "version": "1.1.1",
+                  "from": "array-flatten@1.1.1",
+                  "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+                },
+                "content-disposition": {
+                  "version": "0.5.2",
+                  "from": "content-disposition@0.5.2",
+                  "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+                },
+                "content-type": {
+                  "version": "1.0.2",
+                  "from": "content-type@>=1.0.2 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+                },
+                "cookie": {
+                  "version": "0.3.1",
+                  "from": "cookie@0.3.1",
+                  "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+                },
+                "cookie-signature": {
+                  "version": "1.0.6",
+                  "from": "cookie-signature@1.0.6",
+                  "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                },
+                "debug": {
+                  "version": "2.6.7",
+                  "from": "debug@2.6.7",
+                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+                  "dependencies": {
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "depd@>=1.1.0 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                },
+                "encodeurl": {
+                  "version": "1.0.1",
+                  "from": "encodeurl@>=1.0.1 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+                },
+                "escape-html": {
+                  "version": "1.0.3",
+                  "from": "escape-html@>=1.0.3 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+                },
+                "etag": {
+                  "version": "1.8.0",
+                  "from": "etag@>=1.8.0 <1.9.0",
+                  "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+                },
+                "finalhandler": {
+                  "version": "1.0.3",
+                  "from": "finalhandler@>=1.0.3 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+                  "dependencies": {
+                    "unpipe": {
+                      "version": "1.0.0",
+                      "from": "unpipe@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                    }
+                  }
+                },
+                "fresh": {
+                  "version": "0.5.0",
+                  "from": "fresh@0.5.0",
+                  "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+                },
+                "merge-descriptors": {
+                  "version": "1.0.1",
+                  "from": "merge-descriptors@1.0.1",
+                  "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+                },
+                "methods": {
+                  "version": "1.1.2",
+                  "from": "methods@>=1.1.2 <1.2.0",
+                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+                },
+                "on-finished": {
+                  "version": "2.3.0",
+                  "from": "on-finished@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                  "dependencies": {
+                    "ee-first": {
+                      "version": "1.1.1",
+                      "from": "ee-first@1.1.1",
+                      "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                    }
+                  }
+                },
+                "parseurl": {
+                  "version": "1.3.1",
+                  "from": "parseurl@>=1.3.1 <1.4.0",
+                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+                },
+                "path-to-regexp": {
+                  "version": "0.1.7",
+                  "from": "path-to-regexp@0.1.7",
+                  "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+                },
+                "proxy-addr": {
+                  "version": "1.1.4",
+                  "from": "proxy-addr@>=1.1.4 <1.2.0",
+                  "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+                  "dependencies": {
+                    "forwarded": {
+                      "version": "0.1.0",
+                      "from": "forwarded@>=0.1.0 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                    },
+                    "ipaddr.js": {
+                      "version": "1.3.0",
+                      "from": "ipaddr.js@1.3.0",
+                      "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "6.4.0",
+                  "from": "qs@6.4.0",
+                  "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                },
+                "range-parser": {
+                  "version": "1.2.0",
+                  "from": "range-parser@>=1.2.0 <1.3.0",
+                  "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+                },
+                "send": {
+                  "version": "0.15.3",
+                  "from": "send@0.15.3",
+                  "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
+                  "dependencies": {
+                    "destroy": {
+                      "version": "1.0.4",
+                      "from": "destroy@>=1.0.4 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                    },
+                    "http-errors": {
+                      "version": "1.6.1",
+                      "from": "http-errors@>=1.6.1 <1.7.0",
+                      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "inherits@2.0.3",
+                          "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.3.4",
+                      "from": "mime@1.3.4",
+                      "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                    },
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    }
+                  }
+                },
+                "serve-static": {
+                  "version": "1.12.3",
+                  "from": "serve-static@1.12.3",
+                  "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.3",
+                  "from": "setprototypeof@1.0.3",
+                  "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.1 <1.4.0",
+                  "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+                },
+                "type-is": {
+                  "version": "1.6.15",
+                  "from": "type-is@>=1.6.15 <1.7.0",
+                  "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+                  "dependencies": {
+                    "media-typer": {
+                      "version": "0.3.0",
+                      "from": "media-typer@0.3.0",
+                      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.16",
+                      "from": "mime-types@>=2.1.11 <2.2.0",
+                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.29.0",
+                          "from": "mime-db@>=1.29.0 <1.30.0",
+                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "utils-merge": {
+                  "version": "1.0.0",
+                  "from": "utils-merge@1.0.0",
+                  "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+                },
+                "vary": {
+                  "version": "1.1.1",
+                  "from": "vary@>=1.1.1 <1.2.0",
+                  "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+                }
+              }
+            },
+            "swagger-express-middleware": {
+              "version": "1.0.0-alpha.12",
+              "from": "swagger-express-middleware@>=1.0.0-alpha.12",
+              "resolved": "http://registry.npmjs.org/swagger-express-middleware/-/swagger-express-middleware-1.0.0-alpha.12.tgz",
+              "dependencies": {
+                "body-parser": {
+                  "version": "1.17.2",
+                  "from": "body-parser@>=1.13.3 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
+                  "dependencies": {
+                    "bytes": {
+                      "version": "2.4.0",
+                      "from": "bytes@2.4.0",
+                      "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+                    },
+                    "content-type": {
+                      "version": "1.0.2",
+                      "from": "content-type@>=1.0.2 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.7",
+                      "from": "debug@2.6.7",
+                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+                      "dependencies": {
+                        "ms": {
+                          "version": "2.0.0",
+                          "from": "ms@2.0.0",
+                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "depd": {
+                      "version": "1.1.0",
+                      "from": "depd@>=1.1.0 <1.2.0",
+                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                    },
+                    "http-errors": {
+                      "version": "1.6.1",
+                      "from": "http-errors@>=1.6.1 <1.7.0",
+                      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                      "dependencies": {
+                        "inherits": {
+                          "version": "2.0.3",
+                          "from": "inherits@2.0.3",
+                          "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                        },
+                        "setprototypeof": {
+                          "version": "1.0.3",
+                          "from": "setprototypeof@1.0.3",
+                          "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+                        },
+                        "statuses": {
+                          "version": "1.3.1",
+                          "from": "statuses@>=1.3.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "iconv-lite": {
+                      "version": "0.4.15",
+                      "from": "iconv-lite@0.4.15",
+                      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+                    },
+                    "on-finished": {
+                      "version": "2.3.0",
+                      "from": "on-finished@>=2.3.0 <2.4.0",
+                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+                      "dependencies": {
+                        "ee-first": {
+                          "version": "1.1.1",
+                          "from": "ee-first@1.1.1",
+                          "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                        }
+                      }
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "from": "qs@6.4.0",
+                      "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                    },
+                    "raw-body": {
+                      "version": "2.2.0",
+                      "from": "raw-body@>=2.2.0 <2.3.0",
+                      "resolved": "http://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+                      "dependencies": {
+                        "unpipe": {
+                          "version": "1.0.0",
+                          "from": "unpipe@1.0.0",
+                          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "cookie-parser": {
+                  "version": "1.4.3",
+                  "from": "cookie-parser@>=1.3.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
+                  "dependencies": {
+                    "cookie": {
+                      "version": "0.3.1",
+                      "from": "cookie@0.3.1",
+                      "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+                    },
+                    "cookie-signature": {
+                      "version": "1.0.6",
+                      "from": "cookie-signature@1.0.6",
+                      "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+                    }
+                  }
+                },
+                "mkdirp": {
+                  "version": "0.5.1",
+                  "from": "mkdirp@>=0.5.1 <0.6.0",
+                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "dependencies": {
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    }
+                  }
+                },
+                "multer": {
+                  "version": "0.1.8",
+                  "from": "multer@>=0.1.8 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+                  "dependencies": {
+                    "busboy": {
+                      "version": "0.2.14",
+                      "from": "busboy@>=0.2.9 <0.3.0",
+                      "resolved": "http://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+                      "dependencies": {
+                        "dicer": {
+                          "version": "0.2.5",
+                          "from": "dicer@0.2.5",
+                          "resolved": "http://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+                          "dependencies": {
+                            "streamsearch": {
+                              "version": "0.1.2",
+                              "from": "streamsearch@0.1.2",
+                              "resolved": "http://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
+                            }
+                          }
+                        },
+                        "readable-stream": {
+                          "version": "1.1.14",
+                          "from": "readable-stream@>=1.1.0 <1.2.0",
+                          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+                          "dependencies": {
+                            "core-util-is": {
+                              "version": "1.0.2",
+                              "from": "core-util-is@>=1.0.0 <1.1.0",
+                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                            },
+                            "isarray": {
+                              "version": "0.0.1",
+                              "from": "isarray@0.0.1",
+                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                            },
+                            "string_decoder": {
+                              "version": "0.10.31",
+                              "from": "string_decoder@>=0.10.0 <0.11.0",
+                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                            },
+                            "inherits": {
+                              "version": "2.0.3",
+                              "from": "inherits@>=2.0.1 <2.1.0",
+                              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mkdirp": {
+                      "version": "0.3.5",
+                      "from": "mkdirp@>=0.3.5 <0.4.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+                    },
+                    "qs": {
+                      "version": "1.2.2",
+                      "from": "qs@>=1.2.2 <1.3.0",
+                      "resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+                    },
+                    "type-is": {
+                      "version": "1.5.7",
+                      "from": "type-is@>=1.5.2 <1.6.0",
+                      "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+                      "dependencies": {
+                        "media-typer": {
+                          "version": "0.3.0",
+                          "from": "media-typer@0.3.0",
+                          "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                        },
+                        "mime-types": {
+                          "version": "2.0.14",
+                          "from": "mime-types@>=2.0.9 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+                          "dependencies": {
+                            "mime-db": {
+                              "version": "1.12.0",
+                              "from": "mime-db@>=1.12.0 <1.13.0",
+                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "ono": {
+                  "version": "1.0.22",
+                  "from": "ono@>=1.0.22 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/ono/-/ono-1.0.22.tgz"
+                },
+                "tmp": {
+                  "version": "0.0.27",
+                  "from": "tmp@0.0.27",
+                  "resolved": "http://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz",
+                  "dependencies": {
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "from": "os-tmpdir@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                    }
+                  }
+                },
+                "tv4": {
+                  "version": "1.3.0",
+                  "from": "tv4@>=1.2.5 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz"
+                },
+                "type-is": {
+                  "version": "1.6.15",
+                  "from": "type-is@>=1.6.8 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+                  "dependencies": {
+                    "media-typer": {
+                      "version": "0.3.0",
+                      "from": "media-typer@0.3.0",
+                      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.16",
+                      "from": "mime-types@>=2.1.15 <2.2.0",
+                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                      "dependencies": {
+                        "mime-db": {
+                          "version": "1.29.0",
+                          "from": "mime-db@>=1.29.0 <1.30.0",
+                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "swagger-methods": {
+              "version": "1.0.0",
+              "from": "swagger-methods@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "url-loader": {
+      "version": "0.5.9",
+      "from": "url-loader@>=0.5.7 <0.6.0",
+      "resolved": "http://registry.npmjs.org/url-loader/-/url-loader-0.5.9.tgz",
+      "dependencies": {
+        "loader-utils": {
+          "version": "1.1.0",
+          "from": "loader-utils@>=1.0.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            }
+          }
+        },
+        "mime": {
+          "version": "1.3.6",
+          "from": "mime@>=1.3.4 <2.0.0",
+          "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+        }
+      }
+    },
+    "webpack": {
+      "version": "1.15.0",
+      "from": "webpack@>=1.9.11 <2.0.0",
+      "resolved": "http://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "3.3.0",
+          "from": "acorn@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+        },
+        "async": {
+          "version": "1.5.2",
+          "from": "async@>=1.3.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+        },
+        "clone": {
+          "version": "1.0.2",
+          "from": "clone@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+        },
+        "enhanced-resolve": {
+          "version": "0.9.1",
+          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+          "resolved": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.2.0",
+              "from": "memory-fs@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            }
+          }
+        },
+        "interpret": {
+          "version": "0.6.6",
+          "from": "interpret@>=0.6.4 <0.7.0",
+          "resolved": "http://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+        },
+        "loader-utils": {
+          "version": "0.2.17",
+          "from": "loader-utils@>=0.2.11 <0.3.0",
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
+          "dependencies": {
+            "big.js": {
+              "version": "3.1.3",
+              "from": "big.js@>=3.1.3 <4.0.0",
+              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+            },
+            "emojis-list": {
+              "version": "2.1.0",
+              "from": "emojis-list@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+            },
+            "json5": {
+              "version": "0.5.1",
+              "from": "json5@>=0.5.0 <0.6.0",
+              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+            },
+            "object-assign": {
+              "version": "4.1.1",
+              "from": "object-assign@>=4.1.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+            }
+          }
+        },
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "errno@>=0.1.3 <0.2.0",
+              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.0 <0.6.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "node-libs-browser": {
+          "version": "0.7.0",
+          "from": "node-libs-browser@>=0.7.0 <0.8.0",
+          "resolved": "http://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+          "dependencies": {
+            "assert": {
+              "version": "1.4.1",
+              "from": "assert@>=1.1.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+            },
+            "browserify-zlib": {
+              "version": "0.1.4",
+              "from": "browserify-zlib@>=0.1.4 <0.2.0",
+              "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
+              "dependencies": {
+                "pako": {
+                  "version": "0.2.9",
+                  "from": "pako@>=0.2.0 <0.3.0",
+                  "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+                }
+              }
+            },
+            "buffer": {
+              "version": "4.9.1",
+              "from": "buffer@>=4.9.0 <5.0.0",
+              "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+              "dependencies": {
+                "base64-js": {
+                  "version": "1.2.1",
+                  "from": "base64-js@>=1.0.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+                },
+                "ieee754": {
+                  "version": "1.1.8",
+                  "from": "ieee754@>=1.1.4 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                }
+              }
+            },
+            "console-browserify": {
+              "version": "1.1.0",
+              "from": "console-browserify@>=1.1.0 <2.0.0",
+              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
+              "dependencies": {
+                "date-now": {
+                  "version": "0.1.4",
+                  "from": "date-now@>=0.1.4 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+                }
+              }
+            },
+            "constants-browserify": {
+              "version": "1.0.0",
+              "from": "constants-browserify@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+            },
+            "crypto-browserify": {
+              "version": "3.3.0",
+              "from": "crypto-browserify@3.3.0",
+              "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
+              "dependencies": {
+                "pbkdf2-compat": {
+                  "version": "2.0.1",
+                  "from": "pbkdf2-compat@2.0.1",
+                  "resolved": "http://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+                },
+                "ripemd160": {
+                  "version": "0.2.0",
+                  "from": "ripemd160@0.2.0",
+                  "resolved": "http://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+                },
+                "sha.js": {
+                  "version": "2.2.6",
+                  "from": "sha.js@2.2.6",
+                  "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+                },
+                "browserify-aes": {
+                  "version": "0.4.0",
+                  "from": "browserify-aes@0.4.0",
+                  "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.1 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "domain-browser": {
+              "version": "1.1.7",
+              "from": "domain-browser@>=1.1.1 <2.0.0",
+              "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+            },
+            "events": {
+              "version": "1.1.1",
+              "from": "events@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
+            },
+            "https-browserify": {
+              "version": "0.0.1",
+              "from": "https-browserify@0.0.1",
+              "resolved": "http://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+            },
+            "os-browserify": {
+              "version": "0.2.1",
+              "from": "os-browserify@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+            },
+            "path-browserify": {
+              "version": "0.0.0",
+              "from": "path-browserify@0.0.0",
+              "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+            },
+            "process": {
+              "version": "0.11.10",
+              "from": "process@>=0.11.0 <0.12.0",
+              "resolved": "http://registry.npmjs.org/process/-/process-0.11.10.tgz"
+            },
+            "punycode": {
+              "version": "1.4.1",
+              "from": "punycode@>=1.2.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+            },
+            "querystring-es3": {
+              "version": "0.2.1",
+              "from": "querystring-es3@>=0.2.0 <0.3.0",
+              "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@>=2.0.5 <3.0.0",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            },
+            "stream-browserify": {
+              "version": "2.0.1",
+              "from": "stream-browserify@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                }
+              }
+            },
+            "stream-http": {
+              "version": "2.7.2",
+              "from": "stream-http@>=2.3.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
+              "dependencies": {
+                "builtin-status-codes": {
+                  "version": "3.0.0",
+                  "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "to-arraybuffer": {
+                  "version": "1.0.1",
+                  "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+                },
+                "xtend": {
+                  "version": "4.0.1",
+                  "from": "xtend@>=4.0.0 <5.0.0",
+                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                }
+              }
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@>=0.10.25 <0.11.0",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "timers-browserify": {
+              "version": "2.0.2",
+              "from": "timers-browserify@>=2.0.2 <3.0.0",
+              "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
+              "dependencies": {
+                "setimmediate": {
+                  "version": "1.0.5",
+                  "from": "setimmediate@>=1.0.4 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+                }
+              }
+            },
+            "tty-browserify": {
+              "version": "0.0.0",
+              "from": "tty-browserify@0.0.0",
+              "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+            },
+            "url": {
+              "version": "0.11.0",
+              "from": "url@>=0.11.0 <0.12.0",
+              "resolved": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
+              "dependencies": {
+                "punycode": {
+                  "version": "1.3.2",
+                  "from": "punycode@1.3.2",
+                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+                },
+                "querystring": {
+                  "version": "0.2.0",
+                  "from": "querystring@0.2.0",
+                  "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+                }
+              }
+            },
+            "util": {
+              "version": "0.10.3",
+              "from": "util@>=0.10.3 <0.11.0",
+              "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+              "dependencies": {
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@2.0.1",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            },
+            "vm-browserify": {
+              "version": "0.0.4",
+              "from": "vm-browserify@0.0.4",
+              "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
+              "dependencies": {
+                "indexof": {
+                  "version": "0.0.1",
+                  "from": "indexof@0.0.1",
+                  "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.0 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "tapable": {
+          "version": "0.1.10",
+          "from": "tapable@>=0.1.8 <0.2.0",
+          "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+        },
+        "uglify-js": {
+          "version": "2.7.5",
+          "from": "uglify-js@>=2.7.3 <2.8.0",
+          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@>=0.2.6 <0.3.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.5.6",
+              "from": "source-map@>=0.5.1 <0.6.0",
+              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+            },
+            "uglify-to-browserify": {
+              "version": "1.0.2",
+              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+            },
+            "yargs": {
+              "version": "3.10.0",
+              "from": "yargs@>=3.10.0 <3.11.0",
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+              "dependencies": {
+                "camelcase": {
+                  "version": "1.2.1",
+                  "from": "camelcase@>=1.0.2 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+                },
+                "cliui": {
+                  "version": "2.1.0",
+                  "from": "cliui@>=2.1.0 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+                  "dependencies": {
+                    "center-align": {
+                      "version": "0.1.3",
+                      "from": "center-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.2.2",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.5",
+                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        },
+                        "lazy-cache": {
+                          "version": "1.0.4",
+                          "from": "lazy-cache@>=1.0.3 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+                        }
+                      }
+                    },
+                    "right-align": {
+                      "version": "0.1.3",
+                      "from": "right-align@>=0.1.1 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+                      "dependencies": {
+                        "align-text": {
+                          "version": "0.1.4",
+                          "from": "align-text@>=0.1.1 <0.2.0",
+                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+                          "dependencies": {
+                            "kind-of": {
+                              "version": "3.2.2",
+                              "from": "kind-of@>=3.0.2 <4.0.0",
+                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                              "dependencies": {
+                                "is-buffer": {
+                                  "version": "1.1.5",
+                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                }
+                              }
+                            },
+                            "longest": {
+                              "version": "1.0.1",
+                              "from": "longest@>=1.0.1 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                },
+                "decamelize": {
+                  "version": "1.2.0",
+                  "from": "decamelize@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                },
+                "window-size": {
+                  "version": "0.1.0",
+                  "from": "window-size@0.1.0",
+                  "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "watchpack": {
+          "version": "0.2.9",
+          "from": "watchpack@>=0.2.1 <0.3.0",
+          "resolved": "http://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.2",
+              "from": "async@>=0.9.0 <0.10.0",
+              "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz"
+            },
+            "chokidar": {
+              "version": "1.7.0",
+              "from": "chokidar@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
+              "dependencies": {
+                "anymatch": {
+                  "version": "1.3.0",
+                  "from": "anymatch@>=1.3.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
+                  "dependencies": {
+                    "arrify": {
+                      "version": "1.0.1",
+                      "from": "arrify@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+                    },
+                    "micromatch": {
+                      "version": "2.3.11",
+                      "from": "micromatch@>=2.1.5 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+                      "dependencies": {
+                        "arr-diff": {
+                          "version": "2.0.0",
+                          "from": "arr-diff@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                          "dependencies": {
+                            "arr-flatten": {
+                              "version": "1.1.0",
+                              "from": "arr-flatten@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+                            }
+                          }
+                        },
+                        "array-unique": {
+                          "version": "0.2.1",
+                          "from": "array-unique@>=0.2.1 <0.3.0",
+                          "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                        },
+                        "braces": {
+                          "version": "1.8.5",
+                          "from": "braces@>=1.8.2 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                          "dependencies": {
+                            "expand-range": {
+                              "version": "1.8.2",
+                              "from": "expand-range@>=1.8.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                              "dependencies": {
+                                "fill-range": {
+                                  "version": "2.2.3",
+                                  "from": "fill-range@>=2.1.0 <3.0.0",
+                                  "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                                  "dependencies": {
+                                    "is-number": {
+                                      "version": "2.1.0",
+                                      "from": "is-number@>=2.1.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                                    },
+                                    "isobject": {
+                                      "version": "2.1.0",
+                                      "from": "isobject@>=2.0.0 <3.0.0",
+                                      "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                                      "dependencies": {
+                                        "isarray": {
+                                          "version": "1.0.0",
+                                          "from": "isarray@1.0.0",
+                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                        }
+                                      }
+                                    },
+                                    "randomatic": {
+                                      "version": "1.1.7",
+                                      "from": "randomatic@>=1.1.3 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                                      "dependencies": {
+                                        "is-number": {
+                                          "version": "3.0.0",
+                                          "from": "is-number@>=3.0.0 <4.0.0",
+                                          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                          "dependencies": {
+                                            "kind-of": {
+                                              "version": "3.2.2",
+                                              "from": "kind-of@>=3.0.2 <4.0.0",
+                                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                              "dependencies": {
+                                                "is-buffer": {
+                                                  "version": "1.1.5",
+                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
+                                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                                }
+                                              }
+                                            }
+                                          }
+                                        },
+                                        "kind-of": {
+                                          "version": "4.0.0",
+                                          "from": "kind-of@>=4.0.0 <5.0.0",
+                                          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                          "dependencies": {
+                                            "is-buffer": {
+                                              "version": "1.1.5",
+                                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                                              "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                            }
+                                          }
+                                        }
+                                      }
+                                    },
+                                    "repeat-string": {
+                                      "version": "1.6.1",
+                                      "from": "repeat-string@>=1.5.2 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "preserve": {
+                              "version": "0.2.0",
+                              "from": "preserve@>=0.2.0 <0.3.0",
+                              "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                            },
+                            "repeat-element": {
+                              "version": "1.1.2",
+                              "from": "repeat-element@>=1.1.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                            }
+                          }
+                        },
+                        "expand-brackets": {
+                          "version": "0.1.5",
+                          "from": "expand-brackets@>=0.1.4 <0.2.0",
+                          "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                          "dependencies": {
+                            "is-posix-bracket": {
+                              "version": "0.1.1",
+                              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "extglob": {
+                          "version": "0.3.2",
+                          "from": "extglob@>=0.3.1 <0.4.0",
+                          "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                        },
+                        "filename-regex": {
+                          "version": "2.0.1",
+                          "from": "filename-regex@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                        },
+                        "is-extglob": {
+                          "version": "1.0.0",
+                          "from": "is-extglob@>=1.0.0 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                        },
+                        "kind-of": {
+                          "version": "3.2.2",
+                          "from": "kind-of@>=3.0.2 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                          "dependencies": {
+                            "is-buffer": {
+                              "version": "1.1.5",
+                              "from": "is-buffer@>=1.1.5 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                            }
+                          }
+                        },
+                        "normalize-path": {
+                          "version": "2.1.1",
+                          "from": "normalize-path@>=2.0.1 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                          "dependencies": {
+                            "remove-trailing-separator": {
+                              "version": "1.0.2",
+                              "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "object.omit": {
+                          "version": "2.0.1",
+                          "from": "object.omit@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                          "dependencies": {
+                            "for-own": {
+                              "version": "0.1.5",
+                              "from": "for-own@>=0.1.4 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                              "dependencies": {
+                                "for-in": {
+                                  "version": "1.0.2",
+                                  "from": "for-in@>=1.0.1 <2.0.0",
+                                  "resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                                }
+                              }
+                            },
+                            "is-extendable": {
+                              "version": "0.1.1",
+                              "from": "is-extendable@>=0.1.1 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                            }
+                          }
+                        },
+                        "parse-glob": {
+                          "version": "3.0.4",
+                          "from": "parse-glob@>=3.0.4 <4.0.0",
+                          "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                          "dependencies": {
+                            "glob-base": {
+                              "version": "0.3.0",
+                              "from": "glob-base@>=0.3.0 <0.4.0",
+                              "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+                            },
+                            "is-dotfile": {
+                              "version": "1.0.3",
+                              "from": "is-dotfile@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                            }
+                          }
+                        },
+                        "regex-cache": {
+                          "version": "0.4.3",
+                          "from": "regex-cache@>=0.4.2 <0.5.0",
+                          "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                          "dependencies": {
+                            "is-equal-shallow": {
+                              "version": "0.1.3",
+                              "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                              "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                            },
+                            "is-primitive": {
+                              "version": "2.0.0",
+                              "from": "is-primitive@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                "async-each": {
+                  "version": "1.0.1",
+                  "from": "async-each@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+                },
+                "glob-parent": {
+                  "version": "2.0.0",
+                  "from": "glob-parent@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "is-binary-path": {
+                  "version": "1.0.1",
+                  "from": "is-binary-path@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                  "dependencies": {
+                    "binary-extensions": {
+                      "version": "1.9.0",
+                      "from": "binary-extensions@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz"
+                    }
+                  }
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                  "dependencies": {
+                    "is-extglob": {
+                      "version": "1.0.0",
+                      "from": "is-extglob@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                    }
+                  }
+                },
+                "path-is-absolute": {
+                  "version": "1.0.1",
+                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                },
+                "readdirp": {
+                  "version": "2.1.0",
+                  "from": "readdirp@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
+                  "dependencies": {
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "from": "minimatch@>=3.0.2 <4.0.0",
+                      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                      "dependencies": {
+                        "brace-expansion": {
+                          "version": "1.1.8",
+                          "from": "brace-expansion@>=1.1.7 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                          "dependencies": {
+                            "balanced-match": {
+                              "version": "1.0.0",
+                              "from": "balanced-match@>=1.0.0 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+                            },
+                            "concat-map": {
+                              "version": "0.0.1",
+                              "from": "concat-map@0.0.1",
+                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "readable-stream": {
+                      "version": "2.3.3",
+                      "from": "readable-stream@>=2.0.2 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.2",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                        },
+                        "isarray": {
+                          "version": "1.0.0",
+                          "from": "isarray@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                        },
+                        "process-nextick-args": {
+                          "version": "1.0.7",
+                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                          "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                        },
+                        "safe-buffer": {
+                          "version": "5.1.1",
+                          "from": "safe-buffer@>=5.1.1 <5.2.0",
+                          "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "1.0.3",
+                          "from": "string_decoder@>=1.0.3 <1.1.0",
+                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                        },
+                        "util-deprecate": {
+                          "version": "1.0.2",
+                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "set-immediate-shim": {
+                      "version": "1.0.1",
+                      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+                    }
+                  }
+                },
+                "fsevents": {
+                  "version": "1.1.2",
+                  "from": "fsevents@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+                  "dependencies": {
+                    "nan": {
+                      "version": "2.6.2",
+                      "from": "nan@>=2.3.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+                    },
+                    "node-pre-gyp": {
+                      "version": "0.6.36",
+                      "from": "node-pre-gyp@^0.6.36",
+                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
+                    },
+                    "abbrev": {
+                      "version": "1.1.0",
+                      "from": "abbrev@1.1.0",
+                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+                    },
+                    "ansi-regex": {
+                      "version": "2.1.1",
+                      "from": "ansi-regex@2.1.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                    },
+                    "ajv": {
+                      "version": "4.11.8",
+                      "from": "ajv@4.11.8",
+                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+                    },
+                    "are-we-there-yet": {
+                      "version": "1.1.4",
+                      "from": "are-we-there-yet@1.1.4",
+                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+                    },
+                    "aproba": {
+                      "version": "1.1.1",
+                      "from": "aproba@1.1.1",
+                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.2.3",
+                      "from": "asn1@0.2.3",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                    },
+                    "assert-plus": {
+                      "version": "0.2.0",
+                      "from": "assert-plus@0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                    },
+                    "asynckit": {
+                      "version": "0.4.0",
+                      "from": "asynckit@0.4.0",
+                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                    },
+                    "aws-sign2": {
+                      "version": "0.6.0",
+                      "from": "aws-sign2@0.6.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+                    },
+                    "balanced-match": {
+                      "version": "0.4.2",
+                      "from": "balanced-match@0.4.2",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+                    },
+                    "aws4": {
+                      "version": "1.6.0",
+                      "from": "aws4@1.6.0",
+                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+                    },
+                    "bcrypt-pbkdf": {
+                      "version": "1.0.1",
+                      "from": "bcrypt-pbkdf@1.0.1",
+                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
+                    },
+                    "block-stream": {
+                      "version": "0.0.9",
+                      "from": "block-stream@0.0.9",
+                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+                    },
+                    "boom": {
+                      "version": "2.10.1",
+                      "from": "boom@2.10.1",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                    },
+                    "brace-expansion": {
+                      "version": "1.1.7",
+                      "from": "brace-expansion@1.1.7",
+                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+                    },
+                    "buffer-shims": {
+                      "version": "1.0.0",
+                      "from": "buffer-shims@1.0.0",
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                    },
+                    "caseless": {
+                      "version": "0.12.0",
+                      "from": "caseless@0.12.0",
+                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+                    },
+                    "co": {
+                      "version": "4.6.0",
+                      "from": "co@4.6.0",
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                    },
+                    "code-point-at": {
+                      "version": "1.1.0",
+                      "from": "code-point-at@1.1.0",
+                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+                    },
+                    "combined-stream": {
+                      "version": "1.0.5",
+                      "from": "combined-stream@1.0.5",
+                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    },
+                    "console-control-strings": {
+                      "version": "1.1.0",
+                      "from": "console-control-strings@1.1.0",
+                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+                    },
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@1.0.2",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.5",
+                      "from": "cryptiles@2.0.5",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                    },
+                    "debug": {
+                      "version": "2.6.8",
+                      "from": "debug@2.6.8",
+                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+                    },
+                    "deep-extend": {
+                      "version": "0.4.2",
+                      "from": "deep-extend@0.4.2",
+                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
+                    },
+                    "delayed-stream": {
+                      "version": "1.0.0",
+                      "from": "delayed-stream@1.0.0",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                    },
+                    "delegates": {
+                      "version": "1.0.0",
+                      "from": "delegates@1.0.0",
+                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+                    },
+                    "ecc-jsbn": {
+                      "version": "0.1.1",
+                      "from": "ecc-jsbn@0.1.1",
+                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
+                    },
+                    "extend": {
+                      "version": "3.0.1",
+                      "from": "extend@3.0.1",
+                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+                    },
+                    "extsprintf": {
+                      "version": "1.0.2",
+                      "from": "extsprintf@1.0.2",
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.6.1",
+                      "from": "forever-agent@0.6.1",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                    },
+                    "form-data": {
+                      "version": "2.1.4",
+                      "from": "form-data@2.1.4",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+                    },
+                    "fstream": {
+                      "version": "1.0.11",
+                      "from": "fstream@1.0.11",
+                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+                    },
+                    "fs.realpath": {
+                      "version": "1.0.0",
+                      "from": "fs.realpath@1.0.0",
+                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+                    },
+                    "fstream-ignore": {
+                      "version": "1.0.5",
+                      "from": "fstream-ignore@1.0.5",
+                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
+                    },
+                    "gauge": {
+                      "version": "2.7.4",
+                      "from": "gauge@2.7.4",
+                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+                    },
+                    "glob": {
+                      "version": "7.1.2",
+                      "from": "glob@7.1.2",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+                    },
+                    "graceful-fs": {
+                      "version": "4.1.11",
+                      "from": "graceful-fs@4.1.11",
+                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+                    },
+                    "har-schema": {
+                      "version": "1.0.5",
+                      "from": "har-schema@1.0.5",
+                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                    },
+                    "har-validator": {
+                      "version": "4.2.1",
+                      "from": "har-validator@4.2.1",
+                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+                    },
+                    "has-unicode": {
+                      "version": "2.0.1",
+                      "from": "has-unicode@2.0.1",
+                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+                    },
+                    "hawk": {
+                      "version": "3.1.3",
+                      "from": "hawk@3.1.3",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+                    },
+                    "hoek": {
+                      "version": "2.16.3",
+                      "from": "hoek@2.16.3",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                    },
+                    "http-signature": {
+                      "version": "1.1.1",
+                      "from": "http-signature@1.1.1",
+                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+                    },
+                    "inflight": {
+                      "version": "1.0.6",
+                      "from": "inflight@1.0.6",
+                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@2.0.3",
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "ini": {
+                      "version": "1.3.4",
+                      "from": "ini@1.3.4",
+                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+                    },
+                    "is-fullwidth-code-point": {
+                      "version": "1.0.0",
+                      "from": "is-fullwidth-code-point@1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+                    },
+                    "is-typedarray": {
+                      "version": "1.0.0",
+                      "from": "is-typedarray@1.0.0",
+                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+                    },
+                    "isstream": {
+                      "version": "0.1.2",
+                      "from": "isstream@0.1.2",
+                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@1.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "jodid25519": {
+                      "version": "1.0.2",
+                      "from": "jodid25519@1.0.2",
+                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
+                    },
+                    "jsbn": {
+                      "version": "0.1.1",
+                      "from": "jsbn@0.1.1",
+                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
+                    },
+                    "json-schema": {
+                      "version": "0.2.3",
+                      "from": "json-schema@0.2.3",
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "5.0.1",
+                      "from": "json-stringify-safe@5.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                    },
+                    "json-stable-stringify": {
+                      "version": "1.0.1",
+                      "from": "json-stable-stringify@1.0.1",
+                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+                    },
+                    "jsonify": {
+                      "version": "0.0.0",
+                      "from": "jsonify@0.0.0",
+                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                    },
+                    "mime-types": {
+                      "version": "2.1.15",
+                      "from": "mime-types@2.1.15",
+                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+                    },
+                    "mime-db": {
+                      "version": "1.27.0",
+                      "from": "mime-db@1.27.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+                    },
+                    "minimatch": {
+                      "version": "3.0.4",
+                      "from": "minimatch@3.0.4",
+                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.8",
+                      "from": "minimist@0.0.8",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+                    },
+                    "ms": {
+                      "version": "2.0.0",
+                      "from": "ms@2.0.0",
+                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                    },
+                    "mkdirp": {
+                      "version": "0.5.1",
+                      "from": "mkdirp@0.5.1",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+                    },
+                    "nopt": {
+                      "version": "4.0.1",
+                      "from": "nopt@4.0.1",
+                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
+                    },
+                    "npmlog": {
+                      "version": "4.1.0",
+                      "from": "npmlog@4.1.0",
+                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
+                    },
+                    "number-is-nan": {
+                      "version": "1.0.1",
+                      "from": "number-is-nan@1.0.1",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.8.2",
+                      "from": "oauth-sign@0.8.2",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+                    },
+                    "object-assign": {
+                      "version": "4.1.1",
+                      "from": "object-assign@4.1.1",
+                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+                    },
+                    "once": {
+                      "version": "1.4.0",
+                      "from": "once@1.4.0",
+                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+                    },
+                    "os-homedir": {
+                      "version": "1.0.2",
+                      "from": "os-homedir@1.0.2",
+                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+                    },
+                    "os-tmpdir": {
+                      "version": "1.0.2",
+                      "from": "os-tmpdir@1.0.2",
+                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+                    },
+                    "path-is-absolute": {
+                      "version": "1.0.1",
+                      "from": "path-is-absolute@1.0.1",
+                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+                    },
+                    "osenv": {
+                      "version": "0.1.4",
+                      "from": "osenv@0.1.4",
+                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+                    },
+                    "performance-now": {
+                      "version": "0.2.0",
+                      "from": "performance-now@0.2.0",
+                      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@1.0.7",
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "punycode": {
+                      "version": "1.4.1",
+                      "from": "punycode@1.4.1",
+                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                    },
+                    "qs": {
+                      "version": "6.4.0",
+                      "from": "qs@6.4.0",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+                    },
+                    "readable-stream": {
+                      "version": "2.2.9",
+                      "from": "readable-stream@2.2.9",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+                    },
+                    "request": {
+                      "version": "2.81.0",
+                      "from": "request@2.81.0",
+                      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
+                    },
+                    "rimraf": {
+                      "version": "2.6.1",
+                      "from": "rimraf@2.6.1",
+                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.0.1",
+                      "from": "safe-buffer@5.0.1",
+                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+                    },
+                    "semver": {
+                      "version": "5.3.0",
+                      "from": "semver@5.3.0",
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                    },
+                    "set-blocking": {
+                      "version": "2.0.0",
+                      "from": "set-blocking@2.0.0",
+                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+                    },
+                    "signal-exit": {
+                      "version": "3.0.2",
+                      "from": "signal-exit@3.0.2",
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@1.0.9",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    },
+                    "string-width": {
+                      "version": "1.0.2",
+                      "from": "string-width@1.0.2",
+                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.1",
+                      "from": "string_decoder@1.0.1",
+                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+                    },
+                    "strip-json-comments": {
+                      "version": "2.0.1",
+                      "from": "strip-json-comments@2.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+                    },
+                    "stringstream": {
+                      "version": "0.0.5",
+                      "from": "stringstream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+                    },
+                    "strip-ansi": {
+                      "version": "3.0.1",
+                      "from": "strip-ansi@3.0.1",
+                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+                    },
+                    "tar": {
+                      "version": "2.2.1",
+                      "from": "tar@2.2.1",
+                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+                    },
+                    "tar-pack": {
+                      "version": "3.4.0",
+                      "from": "tar-pack@3.4.0",
+                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
+                    },
+                    "tough-cookie": {
+                      "version": "2.3.2",
+                      "from": "tough-cookie@2.3.2",
+                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.6.0",
+                      "from": "tunnel-agent@0.6.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+                    },
+                    "tweetnacl": {
+                      "version": "0.14.5",
+                      "from": "tweetnacl@0.14.5",
+                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
+                    },
+                    "uid-number": {
+                      "version": "0.0.6",
+                      "from": "uid-number@0.0.6",
+                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@1.0.2",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    },
+                    "uuid": {
+                      "version": "3.0.1",
+                      "from": "uuid@3.0.1",
+                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+                    },
+                    "verror": {
+                      "version": "1.3.6",
+                      "from": "verror@1.3.6",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                    },
+                    "wide-align": {
+                      "version": "1.1.2",
+                      "from": "wide-align@1.1.2",
+                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+                    },
+                    "wrappy": {
+                      "version": "1.0.2",
+                      "from": "wrappy@1.0.2",
+                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                    },
+                    "dashdash": {
+                      "version": "1.14.1",
+                      "from": "dashdash@1.14.1",
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "jsprim": {
+                      "version": "1.4.0",
+                      "from": "jsprim@1.4.0",
+                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "sshpk": {
+                      "version": "1.13.0",
+                      "from": "sshpk@1.13.0",
+                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "getpass": {
+                      "version": "0.1.7",
+                      "from": "getpass@0.1.7",
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+                      "dependencies": {
+                        "assert-plus": {
+                          "version": "1.0.0",
+                          "from": "assert-plus@1.0.0",
+                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                        }
+                      }
+                    },
+                    "rc": {
+                      "version": "1.2.1",
+                      "from": "rc@1.2.1",
+                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+                      "dependencies": {
+                        "minimist": {
+                          "version": "1.2.0",
+                          "from": "minimist@1.2.0",
+                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "graceful-fs": {
+              "version": "4.1.11",
+              "from": "graceful-fs@>=4.1.2 <5.0.0",
+              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+            }
+          }
+        },
+        "webpack-core": {
+          "version": "0.6.9",
+          "from": "webpack-core@>=0.6.9 <0.7.0",
+          "resolved": "http://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+          "dependencies": {
+            "source-map": {
+              "version": "0.4.4",
+              "from": "source-map@>=0.4.1 <0.5.0",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "1.0.1",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+                }
+              }
+            },
+            "source-list-map": {
+              "version": "0.1.8",
+              "from": "source-list-map@>=0.1.7 <0.2.0",
+              "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "webpack-bundle-analyzer": {
+      "version": "2.8.3",
+      "from": "webpack-bundle-analyzer@>=2.8.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.3.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "5.1.1",
+          "from": "acorn@>=5.1.1 <6.0.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "from": "chalk@>=1.1.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "2.2.1",
+              "from": "ansi-styles@>=2.2.1 <3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.5",
+              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+            },
+            "has-ansi": {
+              "version": "2.0.0",
+              "from": "has-ansi@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "from": "strip-ansi@>=3.0.0 <4.0.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "2.1.1",
+                  "from": "ansi-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "2.0.0",
+              "from": "supports-color@>=2.0.0 <3.0.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+            }
+          }
+        },
+        "commander": {
+          "version": "2.11.0",
+          "from": "commander@>=2.9.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+        },
+        "ejs": {
+          "version": "2.5.6",
+          "from": "ejs@>=2.5.6 <3.0.0",
+          "resolved": "http://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz"
+        },
+        "express": {
+          "version": "4.15.3",
+          "from": "express@>=4.15.2 <5.0.0",
+          "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "accepts@>=1.3.3 <1.4.0",
+              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.16",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "from": "mime-db@>=1.29.0 <1.30.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "negotiator@0.6.1",
+                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "array-flatten": {
+              "version": "1.1.1",
+              "from": "array-flatten@1.1.1",
+              "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+            },
+            "content-disposition": {
+              "version": "0.5.2",
+              "from": "content-disposition@0.5.2",
+              "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+            },
+            "content-type": {
+              "version": "1.0.2",
+              "from": "content-type@>=1.0.2 <1.1.0",
+              "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "from": "cookie@0.3.1",
+              "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6",
+              "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "debug": {
+              "version": "2.6.7",
+              "from": "debug@2.6.7",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "depd@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "encodeurl": {
+              "version": "1.0.1",
+              "from": "encodeurl@>=1.0.1 <1.1.0",
+              "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "etag": {
+              "version": "1.8.0",
+              "from": "etag@>=1.8.0 <1.9.0",
+              "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+            },
+            "finalhandler": {
+              "version": "1.0.3",
+              "from": "finalhandler@>=1.0.3 <1.1.0",
+              "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+              "dependencies": {
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.5.0",
+              "from": "fresh@0.5.0",
+              "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "from": "merge-descriptors@1.0.1",
+              "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+            },
+            "methods": {
+              "version": "1.1.2",
+              "from": "methods@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "on-finished@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "from": "path-to-regexp@0.1.7",
+              "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.1.4",
+              "from": "proxy-addr@>=1.1.4 <1.2.0",
+              "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                },
+                "ipaddr.js": {
+                  "version": "1.3.0",
+                  "from": "ipaddr.js@1.3.0",
+                  "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@6.4.0",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "range-parser@>=1.2.0 <1.3.0",
+              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            },
+            "send": {
+              "version": "0.15.3",
+              "from": "send@0.15.3",
+              "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.6.1",
+                  "from": "http-errors@>=1.6.1 <1.7.0",
+                  "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@2.0.3",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.12.3",
+              "from": "serve-static@1.12.3",
+              "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "from": "setprototypeof@1.0.3",
+              "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+            },
+            "statuses": {
+              "version": "1.3.1",
+              "from": "statuses@>=1.3.1 <1.4.0",
+              "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            },
+            "type-is": {
+              "version": "1.6.15",
+              "from": "type-is@>=1.6.15 <1.7.0",
+              "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.16",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "from": "mime-db@>=1.29.0 <1.30.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vary": {
+              "version": "1.1.1",
+              "from": "vary@>=1.1.1 <1.2.0",
+              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+            }
+          }
+        },
+        "filesize": {
+          "version": "3.5.10",
+          "from": "filesize@>=3.5.9 <4.0.0",
+          "resolved": "http://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz"
+        },
+        "gzip-size": {
+          "version": "3.0.0",
+          "from": "gzip-size@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+          "dependencies": {
+            "duplexer": {
+              "version": "0.1.1",
+              "from": "duplexer@>=0.1.1 <0.2.0",
+              "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
+            }
+          }
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@>=0.5.1 <0.6.0",
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "0.0.8",
+              "from": "minimist@0.0.8",
+              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+            }
+          }
+        },
+        "opener": {
+          "version": "1.4.3",
+          "from": "opener@>=1.4.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
+        },
+        "ws": {
+          "version": "2.3.1",
+          "from": "ws@>=2.3.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.0.1",
+              "from": "safe-buffer@>=5.0.1 <5.1.0",
+              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+            },
+            "ultron": {
+              "version": "1.1.0",
+              "from": "ultron@>=1.1.0 <1.2.0",
+              "resolved": "http://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "webpack-dev-middleware": {
+      "version": "1.7.0",
+      "from": "webpack-dev-middleware@1.7.0",
+      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.7.0.tgz",
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.3.0",
+          "from": "memory-fs@>=0.3.0 <0.4.0",
+          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
+          "dependencies": {
+            "errno": {
+              "version": "0.1.4",
+              "from": "errno@>=0.1.3 <0.2.0",
+              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+              "dependencies": {
+                "prr": {
+                  "version": "0.0.0",
+                  "from": "prr@>=0.0.0 <0.1.0",
+                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                }
+              }
+            },
+            "readable-stream": {
+              "version": "2.3.3",
+              "from": "readable-stream@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.2",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@>=2.0.3 <2.1.0",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "isarray": {
+                  "version": "1.0.0",
+                  "from": "isarray@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                },
+                "process-nextick-args": {
+                  "version": "1.0.7",
+                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                },
+                "safe-buffer": {
+                  "version": "5.1.1",
+                  "from": "safe-buffer@>=5.1.1 <5.2.0",
+                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "1.0.3",
+                  "from": "string_decoder@>=1.0.3 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                },
+                "util-deprecate": {
+                  "version": "1.0.2",
+                  "from": "util-deprecate@>=1.0.1 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "mime": {
+          "version": "1.3.6",
+          "from": "mime@>=1.3.4 <2.0.0",
+          "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "from": "range-parser@>=1.0.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+        }
+      }
+    },
+    "webpack-dev-server": {
+      "version": "1.16.5",
+      "from": "webpack-dev-server@>=1.9.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
+      "dependencies": {
+        "compression": {
+          "version": "1.7.0",
+          "from": "compression@>=1.5.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "accepts@>=1.3.3 <1.4.0",
+              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.16",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "from": "mime-db@>=1.29.0 <1.30.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "negotiator@0.6.1",
+                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "bytes": {
+              "version": "2.5.0",
+              "from": "bytes@2.5.0",
+              "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
+            },
+            "compressible": {
+              "version": "2.0.10",
+              "from": "compressible@>=2.0.10 <2.1.0",
+              "resolved": "http://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.27.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                }
+              }
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@2.6.8",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "on-headers": {
+              "version": "1.0.1",
+              "from": "on-headers@>=1.0.1 <1.1.0",
+              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+            },
+            "safe-buffer": {
+              "version": "5.1.1",
+              "from": "safe-buffer@5.1.1",
+              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+            },
+            "vary": {
+              "version": "1.1.1",
+              "from": "vary@>=1.1.1 <1.2.0",
+              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+            }
+          }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.3.0",
+          "from": "connect-history-api-fallback@>=1.3.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
+        },
+        "express": {
+          "version": "4.15.3",
+          "from": "express@>=4.13.3 <5.0.0",
+          "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "accepts@>=1.3.3 <1.4.0",
+              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "mime-types": {
+                  "version": "2.1.16",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "from": "mime-db@>=1.29.0 <1.30.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                    }
+                  }
+                },
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "negotiator@0.6.1",
+                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "array-flatten": {
+              "version": "1.1.1",
+              "from": "array-flatten@1.1.1",
+              "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+            },
+            "content-disposition": {
+              "version": "0.5.2",
+              "from": "content-disposition@0.5.2",
+              "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+            },
+            "content-type": {
+              "version": "1.0.2",
+              "from": "content-type@>=1.0.2 <1.1.0",
+              "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+            },
+            "cookie": {
+              "version": "0.3.1",
+              "from": "cookie@0.3.1",
+              "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+            },
+            "cookie-signature": {
+              "version": "1.0.6",
+              "from": "cookie-signature@1.0.6",
+              "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+            },
+            "debug": {
+              "version": "2.6.7",
+              "from": "debug@2.6.7",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "depd": {
+              "version": "1.1.0",
+              "from": "depd@>=1.1.0 <1.2.0",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+            },
+            "encodeurl": {
+              "version": "1.0.1",
+              "from": "encodeurl@>=1.0.1 <1.1.0",
+              "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "etag": {
+              "version": "1.8.0",
+              "from": "etag@>=1.8.0 <1.9.0",
+              "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+            },
+            "finalhandler": {
+              "version": "1.0.3",
+              "from": "finalhandler@>=1.0.3 <1.1.0",
+              "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
+              "dependencies": {
+                "unpipe": {
+                  "version": "1.0.0",
+                  "from": "unpipe@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+                }
+              }
+            },
+            "fresh": {
+              "version": "0.5.0",
+              "from": "fresh@0.5.0",
+              "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+            },
+            "merge-descriptors": {
+              "version": "1.0.1",
+              "from": "merge-descriptors@1.0.1",
+              "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+            },
+            "methods": {
+              "version": "1.1.2",
+              "from": "methods@>=1.1.2 <1.2.0",
+              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+            },
+            "on-finished": {
+              "version": "2.3.0",
+              "from": "on-finished@>=2.3.0 <2.4.0",
+              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+              "dependencies": {
+                "ee-first": {
+                  "version": "1.1.1",
+                  "from": "ee-first@1.1.1",
+                  "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            },
+            "path-to-regexp": {
+              "version": "0.1.7",
+              "from": "path-to-regexp@0.1.7",
+              "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+            },
+            "proxy-addr": {
+              "version": "1.1.4",
+              "from": "proxy-addr@>=1.1.4 <1.2.0",
+              "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
+              "dependencies": {
+                "forwarded": {
+                  "version": "0.1.0",
+                  "from": "forwarded@>=0.1.0 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+                },
+                "ipaddr.js": {
+                  "version": "1.3.0",
+                  "from": "ipaddr.js@1.3.0",
+                  "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
+                }
+              }
+            },
+            "qs": {
+              "version": "6.4.0",
+              "from": "qs@6.4.0",
+              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "range-parser@>=1.2.0 <1.3.0",
+              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            },
+            "send": {
+              "version": "0.15.3",
+              "from": "send@0.15.3",
+              "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
+              "dependencies": {
+                "destroy": {
+                  "version": "1.0.4",
+                  "from": "destroy@>=1.0.4 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+                },
+                "http-errors": {
+                  "version": "1.6.1",
+                  "from": "http-errors@>=1.6.1 <1.7.0",
+                  "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+                  "dependencies": {
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@2.0.3",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    }
+                  }
+                },
+                "mime": {
+                  "version": "1.3.4",
+                  "from": "mime@1.3.4",
+                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+                },
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "serve-static": {
+              "version": "1.12.3",
+              "from": "serve-static@1.12.3",
+              "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "from": "setprototypeof@1.0.3",
+              "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+            },
+            "statuses": {
+              "version": "1.3.1",
+              "from": "statuses@>=1.3.1 <1.4.0",
+              "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+            },
+            "type-is": {
+              "version": "1.6.15",
+              "from": "type-is@>=1.6.15 <1.7.0",
+              "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+              "dependencies": {
+                "media-typer": {
+                  "version": "0.3.0",
+                  "from": "media-typer@0.3.0",
+                  "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+                },
+                "mime-types": {
+                  "version": "2.1.16",
+                  "from": "mime-types@>=2.1.11 <2.2.0",
+                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.29.0",
+                      "from": "mime-db@>=1.29.0 <1.30.0",
+                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "utils-merge": {
+              "version": "1.0.0",
+              "from": "utils-merge@1.0.0",
+              "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+            },
+            "vary": {
+              "version": "1.1.1",
+              "from": "vary@>=1.1.1 <1.2.0",
+              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+            }
+          }
+        },
+        "optimist": {
+          "version": "0.6.1",
+          "from": "optimist@>=0.6.1 <0.7.0",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.3",
+              "from": "wordwrap@>=0.0.2 <0.1.0",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+            },
+            "minimist": {
+              "version": "0.0.10",
+              "from": "minimist@>=0.0.1 <0.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+            }
+          }
+        },
+        "open": {
+          "version": "0.0.5",
+          "from": "open@0.0.5",
+          "resolved": "http://registry.npmjs.org/open/-/open-0.0.5.tgz"
+        },
+        "serve-index": {
+          "version": "1.9.0",
+          "from": "serve-index@>=1.7.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
+          "dependencies": {
+            "accepts": {
+              "version": "1.3.3",
+              "from": "accepts@>=1.3.3 <1.4.0",
+              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
+              "dependencies": {
+                "negotiator": {
+                  "version": "0.6.1",
+                  "from": "negotiator@0.6.1",
+                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+                }
+              }
+            },
+            "batch": {
+              "version": "0.6.1",
+              "from": "batch@0.6.1",
+              "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
+            },
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@2.6.8",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "escape-html": {
+              "version": "1.0.3",
+              "from": "escape-html@>=1.0.3 <1.1.0",
+              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+            },
+            "http-errors": {
+              "version": "1.6.1",
+              "from": "http-errors@>=1.6.1 <1.7.0",
+              "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
+              "dependencies": {
+                "depd": {
+                  "version": "1.1.0",
+                  "from": "depd@1.1.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.3",
+                  "from": "inherits@2.0.3",
+                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                },
+                "setprototypeof": {
+                  "version": "1.0.3",
+                  "from": "setprototypeof@1.0.3",
+                  "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+                },
+                "statuses": {
+                  "version": "1.3.1",
+                  "from": "statuses@>=1.3.1 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+                }
+              }
+            },
+            "mime-types": {
+              "version": "2.1.16",
+              "from": "mime-types@>=2.1.15 <2.2.0",
+              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.29.0",
+                  "from": "mime-db@>=1.29.0 <1.30.0",
+                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+                }
+              }
+            },
+            "parseurl": {
+              "version": "1.3.1",
+              "from": "parseurl@>=1.3.1 <1.4.0",
+              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+            }
+          }
+        },
+        "sockjs": {
+          "version": "0.3.18",
+          "from": "sockjs@>=0.3.15 <0.4.0",
+          "resolved": "http://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+          "dependencies": {
+            "faye-websocket": {
+              "version": "0.10.0",
+              "from": "faye-websocket@>=0.10.0 <0.11.0",
+              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "from": "websocket-driver@>=0.5.1",
+                  "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@>=0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "uuid": {
+              "version": "2.0.3",
+              "from": "uuid@>=2.0.2 <3.0.0",
+              "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+            }
+          }
+        },
+        "sockjs-client": {
+          "version": "1.1.4",
+          "from": "sockjs-client@>=1.0.3 <2.0.0",
+          "resolved": "http://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "2.6.8",
+              "from": "debug@>=2.6.6 <3.0.0",
+              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+              "dependencies": {
+                "ms": {
+                  "version": "2.0.0",
+                  "from": "ms@2.0.0",
+                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+                }
+              }
+            },
+            "eventsource": {
+              "version": "0.1.6",
+              "from": "eventsource@0.1.6",
+              "resolved": "http://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
+              "dependencies": {
+                "original": {
+                  "version": "1.0.0",
+                  "from": "original@>=0.0.5",
+                  "resolved": "http://registry.npmjs.org/original/-/original-1.0.0.tgz",
+                  "dependencies": {
+                    "url-parse": {
+                      "version": "1.0.5",
+                      "from": "url-parse@>=1.0.0 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
+                      "dependencies": {
+                        "querystringify": {
+                          "version": "0.0.4",
+                          "from": "querystringify@>=0.0.0 <0.1.0",
+                          "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
+                        },
+                        "requires-port": {
+                          "version": "1.0.0",
+                          "from": "requires-port@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "faye-websocket": {
+              "version": "0.11.1",
+              "from": "faye-websocket@>=0.11.0 <0.12.0",
+              "resolved": "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
+              "dependencies": {
+                "websocket-driver": {
+                  "version": "0.6.5",
+                  "from": "websocket-driver@>=0.5.1",
+                  "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
+                  "dependencies": {
+                    "websocket-extensions": {
+                      "version": "0.1.1",
+                      "from": "websocket-extensions@>=0.1.1",
+                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.3",
+              "from": "inherits@>=2.0.1 <3.0.0",
+              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+            },
+            "json3": {
+              "version": "3.3.2",
+              "from": "json3@>=3.3.2 <4.0.0",
+              "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+            },
+            "url-parse": {
+              "version": "1.1.9",
+              "from": "url-parse@>=1.1.8 <2.0.0",
+              "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+              "dependencies": {
+                "querystringify": {
+                  "version": "1.0.0",
+                  "from": "querystringify@>=1.0.0 <1.1.0",
+                  "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
+                },
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "requires-port@>=1.0.0 <1.1.0",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "stream-cache": {
+          "version": "0.0.2",
+          "from": "stream-cache@>=0.0.1 <0.1.0",
+          "resolved": "http://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "dependencies": {
+            "ansi-regex": {
+              "version": "2.1.1",
+              "from": "ansi-regex@>=2.0.0 <3.0.0",
+              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+            }
+          }
+        },
+        "supports-color": {
+          "version": "3.2.3",
+          "from": "supports-color@>=3.1.1 <4.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
+          "dependencies": {
+            "has-flag": {
+              "version": "1.0.0",
+              "from": "has-flag@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+            }
+          }
+        },
+        "webpack-dev-middleware": {
+          "version": "1.11.0",
+          "from": "webpack-dev-middleware@>=1.10.2 <2.0.0",
+          "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz",
+          "dependencies": {
+            "memory-fs": {
+              "version": "0.4.1",
+              "from": "memory-fs@>=0.4.1 <0.5.0",
+              "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+              "dependencies": {
+                "errno": {
+                  "version": "0.1.4",
+                  "from": "errno@>=0.1.3 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
+                  "dependencies": {
+                    "prr": {
+                      "version": "0.0.0",
+                      "from": "prr@>=0.0.0 <0.1.0",
+                      "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+                    }
+                  }
+                },
+                "readable-stream": {
+                  "version": "2.3.3",
+                  "from": "readable-stream@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
+                  "dependencies": {
+                    "core-util-is": {
+                      "version": "1.0.2",
+                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                    },
+                    "inherits": {
+                      "version": "2.0.3",
+                      "from": "inherits@>=2.0.3 <2.1.0",
+                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                    },
+                    "isarray": {
+                      "version": "1.0.0",
+                      "from": "isarray@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                    },
+                    "process-nextick-args": {
+                      "version": "1.0.7",
+                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                    },
+                    "safe-buffer": {
+                      "version": "5.1.1",
+                      "from": "safe-buffer@>=5.1.1 <5.2.0",
+                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                    },
+                    "string_decoder": {
+                      "version": "1.0.3",
+                      "from": "string_decoder@>=1.0.3 <1.1.0",
+                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+                    },
+                    "util-deprecate": {
+                      "version": "1.0.2",
+                      "from": "util-deprecate@>=1.0.1 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.3.6",
+              "from": "mime@>=1.3.4 <2.0.0",
+              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+            },
+            "path-is-absolute": {
+              "version": "1.0.1",
+              "from": "path-is-absolute@>=1.0.0 <2.0.0",
+              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+            },
+            "range-parser": {
+              "version": "1.2.0",
+              "from": "range-parser@>=1.0.3 <2.0.0",
+              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+            }
+          }
+        },
+        "http-proxy-middleware": {
+          "version": "0.17.4",
+          "from": "http-proxy-middleware@>=0.17.1 <0.18.0",
+          "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+          "dependencies": {
+            "http-proxy": {
+              "version": "1.16.2",
+              "from": "http-proxy@>=1.16.2 <2.0.0",
+              "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
+              "dependencies": {
+                "eventemitter3": {
+                  "version": "1.2.0",
+                  "from": "eventemitter3@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+                },
+                "requires-port": {
+                  "version": "1.0.0",
+                  "from": "requires-port@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
+                }
+              }
+            },
+            "is-glob": {
+              "version": "3.1.0",
+              "from": "is-glob@>=3.1.0 <4.0.0",
+              "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+              "dependencies": {
+                "is-extglob": {
+                  "version": "2.1.1",
+                  "from": "is-extglob@>=2.1.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+                }
+              }
+            },
+            "micromatch": {
+              "version": "2.3.11",
+              "from": "micromatch@>=2.3.11 <3.0.0",
+              "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
+              "dependencies": {
+                "arr-diff": {
+                  "version": "2.0.0",
+                  "from": "arr-diff@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
+                  "dependencies": {
+                    "arr-flatten": {
+                      "version": "1.1.0",
+                      "from": "arr-flatten@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+                    }
+                  }
+                },
+                "array-unique": {
+                  "version": "0.2.1",
+                  "from": "array-unique@>=0.2.1 <0.3.0",
+                  "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+                },
+                "braces": {
+                  "version": "1.8.5",
+                  "from": "braces@>=1.8.2 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
+                  "dependencies": {
+                    "expand-range": {
+                      "version": "1.8.2",
+                      "from": "expand-range@>=1.8.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
+                      "dependencies": {
+                        "fill-range": {
+                          "version": "2.2.3",
+                          "from": "fill-range@>=2.1.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
+                          "dependencies": {
+                            "is-number": {
+                              "version": "2.1.0",
+                              "from": "is-number@>=2.1.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+                            },
+                            "isobject": {
+                              "version": "2.1.0",
+                              "from": "isobject@>=2.0.0 <3.0.0",
+                              "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+                              "dependencies": {
+                                "isarray": {
+                                  "version": "1.0.0",
+                                  "from": "isarray@1.0.0",
+                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                                }
+                              }
+                            },
+                            "randomatic": {
+                              "version": "1.1.7",
+                              "from": "randomatic@>=1.1.3 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+                              "dependencies": {
+                                "is-number": {
+                                  "version": "3.0.0",
+                                  "from": "is-number@>=3.0.0 <4.0.0",
+                                  "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                                  "dependencies": {
+                                    "kind-of": {
+                                      "version": "3.2.2",
+                                      "from": "kind-of@>=3.0.2 <4.0.0",
+                                      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                                      "dependencies": {
+                                        "is-buffer": {
+                                          "version": "1.1.5",
+                                          "from": "is-buffer@>=1.1.5 <2.0.0",
+                                          "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                        }
+                                      }
+                                    }
+                                  }
+                                },
+                                "kind-of": {
+                                  "version": "4.0.0",
+                                  "from": "kind-of@>=4.0.0 <5.0.0",
+                                  "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
+                                  "dependencies": {
+                                    "is-buffer": {
+                                      "version": "1.1.5",
+                                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                                      "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                                    }
+                                  }
+                                }
+                              }
+                            },
+                            "repeat-string": {
+                              "version": "1.6.1",
+                              "from": "repeat-string@>=1.5.2 <2.0.0",
+                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "preserve": {
+                      "version": "0.2.0",
+                      "from": "preserve@>=0.2.0 <0.3.0",
+                      "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+                    },
+                    "repeat-element": {
+                      "version": "1.1.2",
+                      "from": "repeat-element@>=1.1.2 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+                    }
+                  }
+                },
+                "expand-brackets": {
+                  "version": "0.1.5",
+                  "from": "expand-brackets@>=0.1.4 <0.2.0",
+                  "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
+                  "dependencies": {
+                    "is-posix-bracket": {
+                      "version": "0.1.1",
+                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+                    }
+                  }
+                },
+                "extglob": {
+                  "version": "0.3.2",
+                  "from": "extglob@>=0.3.1 <0.4.0",
+                  "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
+                },
+                "filename-regex": {
+                  "version": "2.0.1",
+                  "from": "filename-regex@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+                },
+                "is-extglob": {
+                  "version": "1.0.0",
+                  "from": "is-extglob@>=1.0.0 <2.0.0",
+                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+                },
+                "is-glob": {
+                  "version": "2.0.1",
+                  "from": "is-glob@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+                },
+                "kind-of": {
+                  "version": "3.2.2",
+                  "from": "kind-of@>=3.0.2 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                  "dependencies": {
+                    "is-buffer": {
+                      "version": "1.1.5",
+                      "from": "is-buffer@>=1.1.5 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+                    }
+                  }
+                },
+                "normalize-path": {
+                  "version": "2.1.1",
+                  "from": "normalize-path@>=2.0.1 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                  "dependencies": {
+                    "remove-trailing-separator": {
+                      "version": "1.0.2",
+                      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+                    }
+                  }
+                },
+                "object.omit": {
+                  "version": "2.0.1",
+                  "from": "object.omit@>=2.0.0 <3.0.0",
+                  "resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
+                  "dependencies": {
+                    "for-own": {
+                      "version": "0.1.5",
+                      "from": "for-own@>=0.1.4 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
+                      "dependencies": {
+                        "for-in": {
+                          "version": "1.0.2",
+                          "from": "for-in@>=1.0.1 <2.0.0",
+                          "resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+                        }
+                      }
+                    },
+                    "is-extendable": {
+                      "version": "0.1.1",
+                      "from": "is-extendable@>=0.1.1 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+                    }
+                  }
+                },
+                "parse-glob": {
+                  "version": "3.0.4",
+                  "from": "parse-glob@>=3.0.4 <4.0.0",
+                  "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
+                  "dependencies": {
+                    "glob-base": {
+                      "version": "0.3.0",
+                      "from": "glob-base@>=0.3.0 <0.4.0",
+                      "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
+                      "dependencies": {
+                        "glob-parent": {
+                          "version": "2.0.0",
+                          "from": "glob-parent@>=2.0.0 <3.0.0",
+                          "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+                        }
+                      }
+                    },
+                    "is-dotfile": {
+                      "version": "1.0.3",
+                      "from": "is-dotfile@>=1.0.0 <2.0.0",
+                      "resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+                    }
+                  }
+                },
+                "regex-cache": {
+                  "version": "0.4.3",
+                  "from": "regex-cache@>=0.4.2 <0.5.0",
+                  "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
+                  "dependencies": {
+                    "is-equal-shallow": {
+                      "version": "0.1.3",
+                      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+                      "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+                    },
+                    "is-primitive": {
+                      "version": "2.0.0",
+                      "from": "is-primitive@>=2.0.0 <3.0.0",
+                      "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2,5633 +2,1196 @@
   "name": "SDP",
   "version": "0.0.1",
   "dependencies": {
+    "abab": {
+      "version": "1.0.3",
+      "from": "abab@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
+      "dev": true
+    },
+    "abbrev": {
+      "version": "1.1.0",
+      "from": "abbrev@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
+    },
+    "accepts": {
+      "version": "1.3.3",
+      "from": "accepts@>=1.3.3 <1.4.0",
+      "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz"
+    },
+    "acorn": {
+      "version": "3.3.0",
+      "from": "acorn@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
+    },
+    "acorn-globals": {
+      "version": "3.1.0",
+      "from": "acorn-globals@>=3.1.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "4.0.13",
+          "from": "acorn@>=4.0.4 <5.0.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "dev": true
+        }
+      }
+    },
+    "acorn-jsx": {
+      "version": "3.0.1",
+      "from": "acorn-jsx@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+      "dev": true
+    },
+    "ajv": {
+      "version": "4.11.8",
+      "from": "ajv@>=4.9.1 <5.0.0",
+      "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
+    },
+    "ajv-keywords": {
+      "version": "1.5.1",
+      "from": "ajv-keywords@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+      "dev": true
+    },
+    "align-text": {
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+    },
+    "alphanum-sort": {
+      "version": "1.0.2",
+      "from": "alphanum-sort@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
+    },
+    "amdefine": {
+      "version": "1.0.1",
+      "from": "amdefine@>=0.0.4",
+      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+    },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "from": "ansi-escapes@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "from": "ansi-regex@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+    },
+    "ansi-styles": {
+      "version": "2.2.1",
+      "from": "ansi-styles@>=2.2.1 <3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+    },
+    "anymatch": {
+      "version": "1.3.0",
+      "from": "anymatch@>=1.3.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz"
+    },
+    "aproba": {
+      "version": "1.1.2",
+      "from": "aproba@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
+    },
+    "are-we-there-yet": {
+      "version": "1.1.4",
+      "from": "are-we-there-yet@>=1.1.2 <1.2.0",
+      "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
+    },
+    "argparse": {
+      "version": "1.0.9",
+      "from": "argparse@>=1.0.7 <2.0.0",
+      "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz"
+    },
+    "arr-diff": {
+      "version": "2.0.0",
+      "from": "arr-diff@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz"
+    },
+    "arr-flatten": {
+      "version": "1.1.0",
+      "from": "arr-flatten@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
+    },
+    "array-equal": {
+      "version": "1.0.0",
+      "from": "array-equal@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
+      "dev": true
+    },
+    "array-find-index": {
+      "version": "1.0.2",
+      "from": "array-find-index@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "from": "array-flatten@1.1.1",
+      "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+    },
+    "array-union": {
+      "version": "1.0.2",
+      "from": "array-union@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "dev": true
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "from": "array-uniq@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "dev": true
+    },
+    "array-unique": {
+      "version": "0.2.1",
+      "from": "array-unique@>=0.2.1 <0.3.0",
+      "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
+    },
+    "array.prototype.find": {
+      "version": "2.0.4",
+      "from": "array.prototype.find@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
+      "dev": true
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "from": "arrify@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
+    },
+    "asap": {
+      "version": "2.0.6",
+      "from": "asap@>=2.0.3 <2.1.0",
+      "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
+    },
+    "asn1": {
+      "version": "0.2.3",
+      "from": "asn1@>=0.2.3 <0.3.0",
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+    },
+    "assert": {
+      "version": "1.4.1",
+      "from": "assert@>=1.1.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
+    },
+    "assert-plus": {
+      "version": "0.2.0",
+      "from": "assert-plus@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+    },
+    "assertion-error": {
+      "version": "1.0.2",
+      "from": "assertion-error@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+      "dev": true
+    },
+    "async": {
+      "version": "1.5.2",
+      "from": "async@>=1.5.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+    },
+    "async-each": {
+      "version": "1.0.1",
+      "from": "async-each@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
+    },
+    "async-foreach": {
+      "version": "0.1.3",
+      "from": "async-foreach@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
+    },
+    "asynckit": {
+      "version": "0.4.0",
+      "from": "asynckit@>=0.4.0 <0.5.0",
+      "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+    },
+    "atob": {
+      "version": "1.1.3",
+      "from": "atob@>=1.1.0 <1.2.0",
+      "resolved": "http://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
+    },
     "autoprefixer": {
       "version": "6.7.7",
       "from": "autoprefixer@>=6.5.1 <7.0.0",
-      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz",
-      "dependencies": {
-        "browserslist": {
-          "version": "1.7.7",
-          "from": "browserslist@>=1.5.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-          "dependencies": {
-            "electron-to-chromium": {
-              "version": "1.3.16",
-              "from": "electron-to-chromium@>=1.2.7 <2.0.0",
-              "resolved": "http://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
-            }
-          }
-        },
-        "caniuse-db": {
-          "version": "1.0.30000706",
-          "from": "caniuse-db@>=1.0.30000634 <2.0.0",
-          "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
-        },
-        "normalize-range": {
-          "version": "0.1.2",
-          "from": "normalize-range@>=0.1.2 <0.2.0",
-          "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
-        },
-        "num2fraction": {
-          "version": "1.2.2",
-          "from": "num2fraction@>=1.2.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
-        },
-        "postcss": {
-          "version": "5.2.17",
-          "from": "postcss@>=5.2.16 <6.0.0",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.6 <0.6.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "supports-color": {
-              "version": "3.2.3",
-              "from": "supports-color@>=3.2.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "postcss-value-parser": {
-          "version": "3.3.0",
-          "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/autoprefixer/-/autoprefixer-6.7.7.tgz"
+    },
+    "aws-sign2": {
+      "version": "0.6.0",
+      "from": "aws-sign2@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+    },
+    "aws4": {
+      "version": "1.6.0",
+      "from": "aws4@>=1.2.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
     },
     "axios": {
       "version": "0.13.1",
       "from": "axios@>=0.13.1 <0.14.0",
-      "resolved": "http://registry.npmjs.org/axios/-/axios-0.13.1.tgz",
-      "dependencies": {
-        "follow-redirects": {
-          "version": "0.0.7",
-          "from": "follow-redirects@0.0.7",
-          "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "stream-consume": {
-              "version": "0.1.0",
-              "from": "stream-consume@>=0.1.0 <0.2.0",
-              "resolved": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.13.1.tgz"
+    },
+    "babel-code-frame": {
+      "version": "6.22.0",
+      "from": "babel-code-frame@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz"
     },
     "babel-core": {
       "version": "6.25.0",
       "from": "babel-core@>=6.17.0 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz",
-      "dependencies": {
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "from": "babel-code-frame@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "babel-generator": {
-          "version": "6.25.0",
-          "from": "babel-generator@>=6.25.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz",
-          "dependencies": {
-            "detect-indent": {
-              "version": "4.0.0",
-              "from": "detect-indent@>=4.0.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
-              "dependencies": {
-                "repeating": {
-                  "version": "2.0.1",
-                  "from": "repeating@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                  "dependencies": {
-                    "is-finite": {
-                      "version": "1.0.2",
-                      "from": "is-finite@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "jsesc": {
-              "version": "1.3.0",
-              "from": "jsesc@>=1.3.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
-            },
-            "trim-right": {
-              "version": "1.0.1",
-              "from": "trim-right@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
-            }
-          }
-        },
-        "babel-helpers": {
-          "version": "6.24.1",
-          "from": "babel-helpers@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
-        },
-        "babel-messages": {
-          "version": "6.23.0",
-          "from": "babel-messages@>=6.23.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-        },
-        "babel-template": {
-          "version": "6.25.0",
-          "from": "babel-template@>=6.25.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-          }
-        },
-        "babel-register": {
-          "version": "6.24.1",
-          "from": "babel-register@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "home-or-tmp": {
-              "version": "2.0.0",
-              "from": "home-or-tmp@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "mkdirp": {
-              "version": "0.5.1",
-              "from": "mkdirp@>=0.5.1 <0.6.0",
-              "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-              "dependencies": {
-                "minimist": {
-                  "version": "0.0.8",
-                  "from": "minimist@0.0.8",
-                  "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                }
-              }
-            },
-            "source-map-support": {
-              "version": "0.4.15",
-              "from": "source-map-support@>=0.4.2 <0.5.0",
-              "resolved": "http://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
-            }
-          }
-        },
-        "babel-traverse": {
-          "version": "6.25.0",
-          "from": "babel-traverse@>=6.25.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-          "dependencies": {
-            "globals": {
-              "version": "9.18.0",
-              "from": "globals@>=9.0.0 <10.0.0",
-              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-            },
-            "invariant": {
-              "version": "2.2.2",
-              "from": "invariant@>=2.2.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-              "dependencies": {
-                "loose-envify": {
-                  "version": "1.3.1",
-                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                  "dependencies": {
-                    "js-tokens": {
-                      "version": "3.0.2",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "babel-types": {
-          "version": "6.25.0",
-          "from": "babel-types@>=6.25.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-          "dependencies": {
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "to-fast-properties": {
-              "version": "1.0.3",
-              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-            }
-          }
-        },
-        "babylon": {
-          "version": "6.17.4",
-          "from": "babylon@>=6.17.2 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-        },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "from": "convert-source-map@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
-        },
-        "debug": {
-          "version": "2.6.8",
-          "from": "debug@>=2.2.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "from": "ms@2.0.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-            }
-          }
-        },
-        "json5": {
-          "version": "0.5.1",
-          "from": "json5@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "from": "minimatch@>=3.0.2 <4.0.0",
-          "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-          "dependencies": {
-            "brace-expansion": {
-              "version": "1.1.8",
-              "from": "brace-expansion@>=1.1.7 <2.0.0",
-              "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-              "dependencies": {
-                "balanced-match": {
-                  "version": "1.0.0",
-                  "from": "balanced-match@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                },
-                "concat-map": {
-                  "version": "0.0.1",
-                  "from": "concat-map@0.0.1",
-                  "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "from": "path-is-absolute@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-        },
-        "private": {
-          "version": "0.1.7",
-          "from": "private@>=0.1.6 <0.2.0",
-          "resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz"
-        },
-        "slash": {
-          "version": "1.0.0",
-          "from": "slash@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
-        },
-        "source-map": {
-          "version": "0.5.6",
-          "from": "source-map@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/babel-core/-/babel-core-6.25.0.tgz"
+    },
+    "babel-generator": {
+      "version": "6.25.0",
+      "from": "babel-generator@>=6.25.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-generator/-/babel-generator-6.25.0.tgz"
+    },
+    "babel-helper-bindify-decorators": {
+      "version": "6.24.1",
+      "from": "babel-helper-bindify-decorators@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz"
+    },
+    "babel-helper-builder-binary-assignment-operator-visitor": {
+      "version": "6.24.1",
+      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz"
+    },
+    "babel-helper-builder-react-jsx": {
+      "version": "6.24.1",
+      "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz"
+    },
+    "babel-helper-call-delegate": {
+      "version": "6.24.1",
+      "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz"
+    },
+    "babel-helper-define-map": {
+      "version": "6.24.1",
+      "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
+    },
+    "babel-helper-explode-assignable-expression": {
+      "version": "6.24.1",
+      "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz"
+    },
+    "babel-helper-explode-class": {
+      "version": "6.24.1",
+      "from": "babel-helper-explode-class@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz"
+    },
+    "babel-helper-function-name": {
+      "version": "6.24.1",
+      "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz"
+    },
+    "babel-helper-get-function-arity": {
+      "version": "6.24.1",
+      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
+    },
+    "babel-helper-hoist-variables": {
+      "version": "6.24.1",
+      "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
+    },
+    "babel-helper-optimise-call-expression": {
+      "version": "6.24.1",
+      "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
+    },
+    "babel-helper-regex": {
+      "version": "6.24.1",
+      "from": "babel-helper-regex@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
+    },
+    "babel-helper-remap-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz"
+    },
+    "babel-helper-replace-supers": {
+      "version": "6.24.1",
+      "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
+    },
+    "babel-helpers": {
+      "version": "6.24.1",
+      "from": "babel-helpers@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz"
     },
     "babel-loader": {
       "version": "6.4.1",
       "from": "babel-loader@>=6.2.5 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz",
-      "dependencies": {
-        "find-cache-dir": {
-          "version": "0.1.1",
-          "from": "find-cache-dir@>=0.1.1 <0.2.0",
-          "resolved": "http://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
-          "dependencies": {
-            "commondir": {
-              "version": "1.0.1",
-              "from": "commondir@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
-            },
-            "pkg-dir": {
-              "version": "1.0.0",
-              "from": "pkg-dir@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "dependencies": {
-                    "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.15 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/babel-loader/-/babel-loader-6.4.1.tgz"
+    },
+    "babel-messages": {
+      "version": "6.23.0",
+      "from": "babel-messages@>=6.23.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
+    },
+    "babel-plugin-check-es2015-constants": {
+      "version": "6.22.0",
+      "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz"
+    },
+    "babel-plugin-syntax-async-functions": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-async-generators": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-class-constructor-call": {
+      "version": "6.18.0",
+      "from": "babel-plugin-syntax-class-constructor-call@>=6.18.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz"
+    },
+    "babel-plugin-syntax-class-properties": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-decorators": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-decorators@>=6.13.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-dynamic-import": {
+      "version": "6.18.0",
+      "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
+    },
+    "babel-plugin-syntax-exponentiation-operator": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-export-extensions": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-flow": {
+      "version": "6.18.0",
+      "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz"
+    },
+    "babel-plugin-syntax-jsx": {
+      "version": "6.18.0",
+      "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz"
+    },
+    "babel-plugin-syntax-object-rest-spread": {
+      "version": "6.13.0",
+      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
+    },
+    "babel-plugin-syntax-trailing-function-commas": {
+      "version": "6.22.0",
+      "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
+    },
+    "babel-plugin-transform-async-generator-functions": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz"
+    },
+    "babel-plugin-transform-async-to-generator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz"
+    },
+    "babel-plugin-transform-class-constructor-call": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-class-constructor-call@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz"
+    },
+    "babel-plugin-transform-class-properties": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz"
+    },
+    "babel-plugin-transform-decorators": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-arrow-functions": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoped-functions": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz"
+    },
+    "babel-plugin-transform-es2015-block-scoping": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-classes": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-computed-properties": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-destructuring": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz"
+    },
+    "babel-plugin-transform-es2015-duplicate-keys": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-for-of": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz"
+    },
+    "babel-plugin-transform-es2015-function-name": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-literals": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-systemjs": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-modules-umd": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-object-super": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-parameters": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-shorthand-properties": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-spread": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz"
+    },
+    "babel-plugin-transform-es2015-sticky-regex": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz"
+    },
+    "babel-plugin-transform-es2015-template-literals": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz"
+    },
+    "babel-plugin-transform-es2015-typeof-symbol": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz"
+    },
+    "babel-plugin-transform-es2015-unicode-regex": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz"
+    },
+    "babel-plugin-transform-exponentiation-operator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz"
+    },
+    "babel-plugin-transform-export-extensions": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-export-extensions@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz"
+    },
+    "babel-plugin-transform-flow-strip-types": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz"
+    },
+    "babel-plugin-transform-object-rest-spread": {
+      "version": "6.23.0",
+      "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz"
+    },
+    "babel-plugin-transform-react-display-name": {
+      "version": "6.25.0",
+      "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz"
+    },
+    "babel-plugin-transform-react-jsx": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz"
+    },
+    "babel-plugin-transform-react-jsx-self": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz"
+    },
+    "babel-plugin-transform-react-jsx-source": {
+      "version": "6.22.0",
+      "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz"
+    },
+    "babel-plugin-transform-regenerator": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz"
+    },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
     },
     "babel-polyfill": {
       "version": "6.23.0",
       "from": "babel-polyfill@>=6.16.0 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz",
-      "dependencies": {
-        "core-js": {
-          "version": "2.4.1",
-          "from": "core-js@>=2.4.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-        },
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz"
-        },
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.23.0.tgz"
     },
     "babel-preset-es2015": {
       "version": "6.24.1",
       "from": "babel-preset-es2015@>=6.16.0 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz",
-      "dependencies": {
-        "babel-plugin-check-es2015-constants": {
-          "version": "6.22.0",
-          "from": "babel-plugin-check-es2015-constants@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-arrow-functions": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-arrow-functions@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoped-functions": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-block-scoped-functions@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-block-scoping": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-block-scoping@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.24.1.tgz",
-          "dependencies": {
-            "babel-traverse": {
-              "version": "6.25.0",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "3.0.2",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-classes": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-classes@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-optimise-call-expression": {
-              "version": "6.24.1",
-              "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
-            },
-            "babel-helper-function-name": {
-              "version": "6.24.1",
-              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-get-function-arity": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                }
-              }
-            },
-            "babel-helper-replace-supers": {
-              "version": "6.24.1",
-              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz"
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                }
-              }
-            },
-            "babel-traverse": {
-              "version": "6.25.0",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "3.0.2",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                    }
-                  }
-                },
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-helper-define-map": {
-              "version": "6.24.1",
-              "from": "babel-helper-define-map@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.24.1.tgz"
-            },
-            "babel-messages": {
-              "version": "6.23.0",
-              "from": "babel-messages@>=6.23.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-computed-properties": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-computed-properties@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-          "dependencies": {
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-destructuring": {
-          "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-destructuring@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-duplicate-keys": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-duplicate-keys@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-for-of": {
-          "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-for-of@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-function-name": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-function-name@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-function-name": {
-              "version": "6.24.1",
-              "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-              "dependencies": {
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-helper-get-function-arity": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-literals": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-literals@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-amd": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-amd@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-          "dependencies": {
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-commonjs": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-commonjs@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.24.1.tgz",
-          "dependencies": {
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-strict-mode": {
-              "version": "6.24.1",
-              "from": "babel-plugin-transform-strict-mode@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz"
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-systemjs": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-systemjs@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-          "dependencies": {
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-helper-hoist-variables": {
-              "version": "6.24.1",
-              "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-modules-umd": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-modules-umd@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-          "dependencies": {
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-object-super": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-object-super@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-replace-supers": {
-              "version": "6.24.1",
-              "from": "babel-helper-replace-supers@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-optimise-call-expression": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-optimise-call-expression@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-parameters": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-parameters@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-          "dependencies": {
-            "babel-traverse": {
-              "version": "6.25.0",
-              "from": "babel-traverse@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-              "dependencies": {
-                "babel-code-frame": {
-                  "version": "6.22.0",
-                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                  "dependencies": {
-                    "chalk": {
-                      "version": "1.1.3",
-                      "from": "chalk@>=1.1.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                      "dependencies": {
-                        "ansi-styles": {
-                          "version": "2.2.1",
-                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                        },
-                        "escape-string-regexp": {
-                          "version": "1.0.5",
-                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                        },
-                        "has-ansi": {
-                          "version": "2.0.0",
-                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "strip-ansi": {
-                          "version": "3.0.1",
-                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                          "dependencies": {
-                            "ansi-regex": {
-                              "version": "2.1.1",
-                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                            }
-                          }
-                        },
-                        "supports-color": {
-                          "version": "2.0.0",
-                          "from": "supports-color@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "js-tokens": {
-                      "version": "3.0.2",
-                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                    }
-                  }
-                },
-                "babel-messages": {
-                  "version": "6.23.0",
-                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                },
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "debug": {
-                  "version": "2.6.8",
-                  "from": "debug@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "globals": {
-                  "version": "9.18.0",
-                  "from": "globals@>=9.0.0 <10.0.0",
-                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                },
-                "invariant": {
-                  "version": "2.2.2",
-                  "from": "invariant@>=2.2.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                  "dependencies": {
-                    "loose-envify": {
-                      "version": "1.3.1",
-                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                      "dependencies": {
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-helper-call-delegate": {
-              "version": "6.24.1",
-              "from": "babel-helper-call-delegate@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-hoist-variables": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-hoist-variables@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz"
-                }
-              }
-            },
-            "babel-helper-get-function-arity": {
-              "version": "6.24.1",
-              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-            },
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                }
-              }
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-shorthand-properties": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-shorthand-properties@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-          "dependencies": {
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-spread": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-spread@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-sticky-regex": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-sticky-regex@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-regex": {
-              "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz"
-            },
-            "babel-types": {
-              "version": "6.25.0",
-              "from": "babel-types@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-              "dependencies": {
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.2 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                },
-                "to-fast-properties": {
-                  "version": "1.0.3",
-                  "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-template-literals": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-es2015-template-literals@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-typeof-symbol": {
-          "version": "6.23.0",
-          "from": "babel-plugin-transform-es2015-typeof-symbol@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-es2015-unicode-regex": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-es2015-unicode-regex@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-          "dependencies": {
-            "babel-helper-regex": {
-              "version": "6.24.1",
-              "from": "babel-helper-regex@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.24.1.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            },
-            "regexpu-core": {
-              "version": "2.0.0",
-              "from": "regexpu-core@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
-              "dependencies": {
-                "regenerate": {
-                  "version": "1.3.2",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-regenerator": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-regenerator@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.24.1.tgz",
-          "dependencies": {
-            "regenerator-transform": {
-              "version": "0.9.11",
-              "from": "regenerator-transform@0.9.11",
-              "resolved": "http://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz",
-              "dependencies": {
-                "babel-runtime": {
-                  "version": "6.23.0",
-                  "from": "babel-runtime@>=6.18.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.10.5",
-                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.19.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                },
-                "private": {
-                  "version": "0.1.7",
-                  "from": "private@>=0.1.6 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/babel-preset-es2015/-/babel-preset-es2015-6.24.1.tgz"
+    },
+    "babel-preset-flow": {
+      "version": "6.23.0",
+      "from": "babel-preset-flow@>=6.23.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz"
     },
     "babel-preset-react": {
       "version": "6.24.1",
       "from": "babel-preset-react@>=6.16.0 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
-      "dependencies": {
-        "babel-preset-flow": {
-          "version": "6.23.0",
-          "from": "babel-preset-flow@>=6.23.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
-          "dependencies": {
-            "babel-plugin-transform-flow-strip-types": {
-              "version": "6.22.0",
-              "from": "babel-plugin-transform-flow-strip-types@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
-              "dependencies": {
-                "babel-runtime": {
-                  "version": "6.23.0",
-                  "from": "babel-runtime@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.10.5",
-                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                    }
-                  }
-                },
-                "babel-plugin-syntax-flow": {
-                  "version": "6.18.0",
-                  "from": "babel-plugin-syntax-flow@>=6.18.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-syntax-jsx": {
-          "version": "6.18.0",
-          "from": "babel-plugin-syntax-jsx@>=6.3.13 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz"
-        },
-        "babel-plugin-transform-react-display-name": {
-          "version": "6.25.0",
-          "from": "babel-plugin-transform-react-display-name@>=6.23.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-react-jsx": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-react-jsx@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            },
-            "babel-helper-builder-react-jsx": {
-              "version": "6.24.1",
-              "from": "babel-helper-builder-react-jsx@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.24.1.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                },
-                "esutils": {
-                  "version": "2.0.2",
-                  "from": "esutils@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-react-jsx-source": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-react-jsx-source@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-plugin-transform-react-jsx-self": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-react-jsx-self@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
-          "dependencies": {
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz"
     },
     "babel-preset-stage-1": {
       "version": "6.24.1",
       "from": "babel-preset-stage-1@>=6.16.0 <7.0.0",
-      "resolved": "http://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz",
+      "resolved": "http://registry.npmjs.org/babel-preset-stage-1/-/babel-preset-stage-1-6.24.1.tgz"
+    },
+    "babel-preset-stage-2": {
+      "version": "6.24.1",
+      "from": "babel-preset-stage-2@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz"
+    },
+    "babel-preset-stage-3": {
+      "version": "6.24.1",
+      "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz"
+    },
+    "babel-register": {
+      "version": "6.24.1",
+      "from": "babel-register@>=6.24.1 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-register/-/babel-register-6.24.1.tgz"
+    },
+    "babel-runtime": {
+      "version": "6.25.0",
+      "from": "babel-runtime@>=6.22.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz"
+    },
+    "babel-template": {
+      "version": "6.25.0",
+      "from": "babel-template@>=6.25.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz"
+    },
+    "babel-traverse": {
+      "version": "6.25.0",
+      "from": "babel-traverse@>=6.25.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz"
+    },
+    "babel-types": {
+      "version": "6.25.0",
+      "from": "babel-types@>=6.25.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz"
+    },
+    "babylon": {
+      "version": "6.17.4",
+      "from": "babylon@>=6.17.2 <7.0.0",
+      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "from": "balanced-match@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+    },
+    "base64-js": {
+      "version": "1.2.1",
+      "from": "base64-js@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
+    },
+    "batch": {
+      "version": "0.6.1",
+      "from": "batch@0.6.1",
+      "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.1",
+      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+      "optional": true
+    },
+    "big.js": {
+      "version": "3.1.3",
+      "from": "big.js@>=3.1.3 <4.0.0",
+      "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
+    },
+    "binary-extensions": {
+      "version": "1.9.0",
+      "from": "binary-extensions@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz"
+    },
+    "block-stream": {
+      "version": "0.0.9",
+      "from": "block-stream@*",
+      "resolved": "http://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+    },
+    "body-parser": {
+      "version": "1.17.2",
+      "from": "body-parser@>=1.13.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
       "dependencies": {
-        "babel-plugin-transform-class-constructor-call": {
-          "version": "6.24.1",
-          "from": "babel-plugin-transform-class-constructor-call@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-constructor-call/-/babel-plugin-transform-class-constructor-call-6.24.1.tgz",
-          "dependencies": {
-            "babel-template": {
-              "version": "6.25.0",
-              "from": "babel-template@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-              "dependencies": {
-                "babylon": {
-                  "version": "6.17.4",
-                  "from": "babylon@>=6.17.2 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                },
-                "babel-traverse": {
-                  "version": "6.25.0",
-                  "from": "babel-traverse@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                  "dependencies": {
-                    "babel-code-frame": {
-                      "version": "6.22.0",
-                      "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                      "dependencies": {
-                        "chalk": {
-                          "version": "1.1.3",
-                          "from": "chalk@>=1.1.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                          "dependencies": {
-                            "ansi-styles": {
-                              "version": "2.2.1",
-                              "from": "ansi-styles@>=2.2.1 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                            },
-                            "escape-string-regexp": {
-                              "version": "1.0.5",
-                              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                            },
-                            "has-ansi": {
-                              "version": "2.0.0",
-                              "from": "has-ansi@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "strip-ansi": {
-                              "version": "3.0.1",
-                              "from": "strip-ansi@>=3.0.0 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                              "dependencies": {
-                                "ansi-regex": {
-                                  "version": "2.1.1",
-                                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                }
-                              }
-                            },
-                            "supports-color": {
-                              "version": "2.0.0",
-                              "from": "supports-color@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "js-tokens": {
-                          "version": "3.0.2",
-                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                        }
-                      }
-                    },
-                    "babel-messages": {
-                      "version": "6.23.0",
-                      "from": "babel-messages@>=6.23.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "globals": {
-                      "version": "9.18.0",
-                      "from": "globals@>=9.0.0 <10.0.0",
-                      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                    },
-                    "invariant": {
-                      "version": "2.2.2",
-                      "from": "invariant@>=2.2.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                      "dependencies": {
-                        "loose-envify": {
-                          "version": "1.3.1",
-                          "from": "loose-envify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                          "dependencies": {
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.25.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-syntax-class-constructor-call": {
-              "version": "6.18.0",
-              "from": "babel-plugin-syntax-class-constructor-call@>=6.18.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-constructor-call/-/babel-plugin-syntax-class-constructor-call-6.18.0.tgz"
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
+        "debug": {
+          "version": "2.6.7",
+          "from": "debug@2.6.7",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
         },
-        "babel-plugin-transform-export-extensions": {
-          "version": "6.22.0",
-          "from": "babel-plugin-transform-export-extensions@>=6.22.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-plugin-transform-export-extensions/-/babel-plugin-transform-export-extensions-6.22.0.tgz",
-          "dependencies": {
-            "babel-plugin-syntax-export-extensions": {
-              "version": "6.13.0",
-              "from": "babel-plugin-syntax-export-extensions@>=6.8.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-export-extensions/-/babel-plugin-syntax-export-extensions-6.13.0.tgz"
-            },
-            "babel-runtime": {
-              "version": "6.23.0",
-              "from": "babel-runtime@>=6.22.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "2.4.1",
-                  "from": "core-js@>=2.4.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                },
-                "regenerator-runtime": {
-                  "version": "0.10.5",
-                  "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "babel-preset-stage-2": {
-          "version": "6.24.1",
-          "from": "babel-preset-stage-2@>=6.24.1 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-preset-stage-2/-/babel-preset-stage-2-6.24.1.tgz",
-          "dependencies": {
-            "babel-plugin-transform-class-properties": {
-              "version": "6.24.1",
-              "from": "babel-plugin-transform-class-properties@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-transform-class-properties/-/babel-plugin-transform-class-properties-6.24.1.tgz",
-              "dependencies": {
-                "babel-helper-function-name": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                  "dependencies": {
-                    "babel-types": {
-                      "version": "6.25.0",
-                      "from": "babel-types@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.3",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "babel-traverse": {
-                      "version": "6.25.0",
-                      "from": "babel-traverse@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.22.0",
-                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.23.0",
-                          "from": "babel-messages@>=6.23.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.17.4",
-                          "from": "babylon@>=6.17.2 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "from": "ms@2.0.0",
-                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.18.0",
-                          "from": "globals@>=9.0.0 <10.0.0",
-                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.1",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-helper-get-function-arity": {
-                      "version": "6.24.1",
-                      "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                    }
-                  }
-                },
-                "babel-plugin-syntax-class-properties": {
-                  "version": "6.13.0",
-                  "from": "babel-plugin-syntax-class-properties@>=6.8.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz"
-                },
-                "babel-runtime": {
-                  "version": "6.23.0",
-                  "from": "babel-runtime@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.10.5",
-                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                    }
-                  }
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    },
-                    "babel-traverse": {
-                      "version": "6.25.0",
-                      "from": "babel-traverse@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.22.0",
-                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.23.0",
-                          "from": "babel-messages@>=6.23.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "from": "ms@2.0.0",
-                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.18.0",
-                          "from": "globals@>=9.0.0 <10.0.0",
-                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.1",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-types": {
-                      "version": "6.25.0",
-                      "from": "babel-types@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                      "dependencies": {
-                        "esutils": {
-                          "version": "2.0.2",
-                          "from": "esutils@>=2.0.2 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                        },
-                        "to-fast-properties": {
-                          "version": "1.0.3",
-                          "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-transform-decorators": {
-              "version": "6.24.1",
-              "from": "babel-plugin-transform-decorators@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-transform-decorators/-/babel-plugin-transform-decorators-6.24.1.tgz",
-              "dependencies": {
-                "babel-types": {
-                  "version": "6.25.0",
-                  "from": "babel-types@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                  "dependencies": {
-                    "esutils": {
-                      "version": "2.0.2",
-                      "from": "esutils@>=2.0.2 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                    },
-                    "to-fast-properties": {
-                      "version": "1.0.3",
-                      "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                    }
-                  }
-                },
-                "babel-plugin-syntax-decorators": {
-                  "version": "6.13.0",
-                  "from": "babel-plugin-syntax-decorators@>=6.13.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-decorators/-/babel-plugin-syntax-decorators-6.13.0.tgz"
-                },
-                "babel-helper-explode-class": {
-                  "version": "6.24.1",
-                  "from": "babel-helper-explode-class@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-helper-explode-class/-/babel-helper-explode-class-6.24.1.tgz",
-                  "dependencies": {
-                    "babel-traverse": {
-                      "version": "6.25.0",
-                      "from": "babel-traverse@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.22.0",
-                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.23.0",
-                          "from": "babel-messages@>=6.23.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                        },
-                        "babylon": {
-                          "version": "6.17.4",
-                          "from": "babylon@>=6.17.2 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "from": "ms@2.0.0",
-                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.18.0",
-                          "from": "globals@>=9.0.0 <10.0.0",
-                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "invariant@>=2.2.1 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.1",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-helper-bindify-decorators": {
-                      "version": "6.24.1",
-                      "from": "babel-helper-bindify-decorators@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-helper-bindify-decorators/-/babel-helper-bindify-decorators-6.24.1.tgz"
-                    }
-                  }
-                },
-                "babel-template": {
-                  "version": "6.25.0",
-                  "from": "babel-template@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                  "dependencies": {
-                    "babylon": {
-                      "version": "6.17.4",
-                      "from": "babylon@>=6.17.2 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                    },
-                    "babel-traverse": {
-                      "version": "6.25.0",
-                      "from": "babel-traverse@>=6.25.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                      "dependencies": {
-                        "babel-code-frame": {
-                          "version": "6.22.0",
-                          "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "js-tokens": {
-                              "version": "3.0.2",
-                              "from": "js-tokens@>=3.0.0 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                            }
-                          }
-                        },
-                        "babel-messages": {
-                          "version": "6.23.0",
-                          "from": "babel-messages@>=6.23.0 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                        },
-                        "debug": {
-                          "version": "2.6.8",
-                          "from": "debug@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                          "dependencies": {
-                            "ms": {
-                              "version": "2.0.0",
-                              "from": "ms@2.0.0",
-                              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                            }
-                          }
-                        },
-                        "globals": {
-                          "version": "9.18.0",
-                          "from": "globals@>=9.0.0 <10.0.0",
-                          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                        },
-                        "invariant": {
-                          "version": "2.2.2",
-                          "from": "invariant@>=2.2.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                          "dependencies": {
-                            "loose-envify": {
-                              "version": "1.3.1",
-                              "from": "loose-envify@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                              "dependencies": {
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-runtime": {
-                  "version": "6.23.0",
-                  "from": "babel-runtime@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                  "dependencies": {
-                    "core-js": {
-                      "version": "2.4.1",
-                      "from": "core-js@>=2.4.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                    },
-                    "regenerator-runtime": {
-                      "version": "0.10.5",
-                      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "babel-plugin-syntax-dynamic-import": {
-              "version": "6.18.0",
-              "from": "babel-plugin-syntax-dynamic-import@>=6.18.0 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-plugin-syntax-dynamic-import/-/babel-plugin-syntax-dynamic-import-6.18.0.tgz"
-            },
-            "babel-preset-stage-3": {
-              "version": "6.24.1",
-              "from": "babel-preset-stage-3@>=6.24.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/babel-preset-stage-3/-/babel-preset-stage-3-6.24.1.tgz",
-              "dependencies": {
-                "babel-plugin-syntax-trailing-function-commas": {
-                  "version": "6.22.0",
-                  "from": "babel-plugin-syntax-trailing-function-commas@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz"
-                },
-                "babel-plugin-transform-async-generator-functions": {
-                  "version": "6.24.1",
-                  "from": "babel-plugin-transform-async-generator-functions@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-generator-functions/-/babel-plugin-transform-async-generator-functions-6.24.1.tgz",
-                  "dependencies": {
-                    "babel-helper-remap-async-to-generator": {
-                      "version": "6.24.1",
-                      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-                      "dependencies": {
-                        "babel-template": {
-                          "version": "6.25.0",
-                          "from": "babel-template@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                          "dependencies": {
-                            "babylon": {
-                              "version": "6.17.4",
-                              "from": "babylon@>=6.17.2 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                            }
-                          }
-                        },
-                        "babel-types": {
-                          "version": "6.25.0",
-                          "from": "babel-types@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.3",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "babel-traverse": {
-                          "version": "6.25.0",
-                          "from": "babel-traverse@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.22.0",
-                              "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.1.1",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.1.1",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.23.0",
-                              "from": "babel-messages@>=6.23.0 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.17.4",
-                              "from": "babylon@>=6.17.2 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                            },
-                            "debug": {
-                              "version": "2.6.8",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "2.0.0",
-                                  "from": "ms@2.0.0",
-                                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.18.0",
-                              "from": "globals@>=9.0.0 <10.0.0",
-                              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.1",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "3.0.2",
-                                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-helper-function-name": {
-                          "version": "6.24.1",
-                          "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                          "dependencies": {
-                            "babel-helper-get-function-arity": {
-                              "version": "6.24.1",
-                              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-plugin-syntax-async-generators": {
-                      "version": "6.13.0",
-                      "from": "babel-plugin-syntax-async-generators@>=6.5.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz"
-                    },
-                    "babel-runtime": {
-                      "version": "6.23.0",
-                      "from": "babel-runtime@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "2.4.1",
-                          "from": "core-js@>=2.4.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                        },
-                        "regenerator-runtime": {
-                          "version": "0.10.5",
-                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-async-to-generator": {
-                  "version": "6.24.1",
-                  "from": "babel-plugin-transform-async-to-generator@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-                  "dependencies": {
-                    "babel-helper-remap-async-to-generator": {
-                      "version": "6.24.1",
-                      "from": "babel-helper-remap-async-to-generator@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-                      "dependencies": {
-                        "babel-template": {
-                          "version": "6.25.0",
-                          "from": "babel-template@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-template/-/babel-template-6.25.0.tgz",
-                          "dependencies": {
-                            "babylon": {
-                              "version": "6.17.4",
-                              "from": "babylon@>=6.17.2 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                            }
-                          }
-                        },
-                        "babel-types": {
-                          "version": "6.25.0",
-                          "from": "babel-types@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.3",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "babel-traverse": {
-                          "version": "6.25.0",
-                          "from": "babel-traverse@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                          "dependencies": {
-                            "babel-code-frame": {
-                              "version": "6.22.0",
-                              "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                              "dependencies": {
-                                "chalk": {
-                                  "version": "1.1.3",
-                                  "from": "chalk@>=1.1.0 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                  "dependencies": {
-                                    "ansi-styles": {
-                                      "version": "2.2.1",
-                                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                    },
-                                    "escape-string-regexp": {
-                                      "version": "1.0.5",
-                                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                    },
-                                    "has-ansi": {
-                                      "version": "2.0.0",
-                                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.1.1",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "strip-ansi": {
-                                      "version": "3.0.1",
-                                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                      "dependencies": {
-                                        "ansi-regex": {
-                                          "version": "2.1.1",
-                                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                        }
-                                      }
-                                    },
-                                    "supports-color": {
-                                      "version": "2.0.0",
-                                      "from": "supports-color@>=2.0.0 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "esutils": {
-                                  "version": "2.0.2",
-                                  "from": "esutils@>=2.0.2 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                },
-                                "js-tokens": {
-                                  "version": "3.0.2",
-                                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                }
-                              }
-                            },
-                            "babel-messages": {
-                              "version": "6.23.0",
-                              "from": "babel-messages@>=6.23.0 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                            },
-                            "babylon": {
-                              "version": "6.17.4",
-                              "from": "babylon@>=6.17.2 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                            },
-                            "debug": {
-                              "version": "2.6.8",
-                              "from": "debug@>=2.2.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                              "dependencies": {
-                                "ms": {
-                                  "version": "2.0.0",
-                                  "from": "ms@2.0.0",
-                                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                                }
-                              }
-                            },
-                            "globals": {
-                              "version": "9.18.0",
-                              "from": "globals@>=9.0.0 <10.0.0",
-                              "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                            },
-                            "invariant": {
-                              "version": "2.2.2",
-                              "from": "invariant@>=2.2.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                              "dependencies": {
-                                "loose-envify": {
-                                  "version": "1.3.1",
-                                  "from": "loose-envify@>=1.0.0 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                                  "dependencies": {
-                                    "js-tokens": {
-                                      "version": "3.0.2",
-                                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-helper-function-name": {
-                          "version": "6.24.1",
-                          "from": "babel-helper-function-name@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-                          "dependencies": {
-                            "babel-helper-get-function-arity": {
-                              "version": "6.24.1",
-                              "from": "babel-helper-get-function-arity@>=6.24.1 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-plugin-syntax-async-functions": {
-                      "version": "6.13.0",
-                      "from": "babel-plugin-syntax-async-functions@>=6.8.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz"
-                    },
-                    "babel-runtime": {
-                      "version": "6.23.0",
-                      "from": "babel-runtime@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "2.4.1",
-                          "from": "core-js@>=2.4.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                        },
-                        "regenerator-runtime": {
-                          "version": "0.10.5",
-                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-exponentiation-operator": {
-                  "version": "6.24.1",
-                  "from": "babel-plugin-transform-exponentiation-operator@>=6.24.1 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-                  "dependencies": {
-                    "babel-plugin-syntax-exponentiation-operator": {
-                      "version": "6.13.0",
-                      "from": "babel-plugin-syntax-exponentiation-operator@>=6.8.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz"
-                    },
-                    "babel-helper-builder-binary-assignment-operator-visitor": {
-                      "version": "6.24.1",
-                      "from": "babel-helper-builder-binary-assignment-operator-visitor@>=6.24.1 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-                      "dependencies": {
-                        "babel-helper-explode-assignable-expression": {
-                          "version": "6.24.1",
-                          "from": "babel-helper-explode-assignable-expression@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-                          "dependencies": {
-                            "babel-traverse": {
-                              "version": "6.25.0",
-                              "from": "babel-traverse@>=6.24.1 <7.0.0",
-                              "resolved": "http://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
-                              "dependencies": {
-                                "babel-code-frame": {
-                                  "version": "6.22.0",
-                                  "from": "babel-code-frame@>=6.22.0 <7.0.0",
-                                  "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-                                  "dependencies": {
-                                    "chalk": {
-                                      "version": "1.1.3",
-                                      "from": "chalk@>=1.1.0 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                                      "dependencies": {
-                                        "ansi-styles": {
-                                          "version": "2.2.1",
-                                          "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                        },
-                                        "escape-string-regexp": {
-                                          "version": "1.0.5",
-                                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                        },
-                                        "has-ansi": {
-                                          "version": "2.0.0",
-                                          "from": "has-ansi@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.1.1",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                            }
-                                          }
-                                        },
-                                        "strip-ansi": {
-                                          "version": "3.0.1",
-                                          "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                          "dependencies": {
-                                            "ansi-regex": {
-                                              "version": "2.1.1",
-                                              "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                            }
-                                          }
-                                        },
-                                        "supports-color": {
-                                          "version": "2.0.0",
-                                          "from": "supports-color@>=2.0.0 <3.0.0",
-                                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "esutils": {
-                                      "version": "2.0.2",
-                                      "from": "esutils@>=2.0.2 <3.0.0",
-                                      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                                    },
-                                    "js-tokens": {
-                                      "version": "3.0.2",
-                                      "from": "js-tokens@>=3.0.0 <4.0.0",
-                                      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                    }
-                                  }
-                                },
-                                "babel-messages": {
-                                  "version": "6.23.0",
-                                  "from": "babel-messages@>=6.23.0 <7.0.0",
-                                  "resolved": "http://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz"
-                                },
-                                "babylon": {
-                                  "version": "6.17.4",
-                                  "from": "babylon@>=6.17.2 <7.0.0",
-                                  "resolved": "http://registry.npmjs.org/babylon/-/babylon-6.17.4.tgz"
-                                },
-                                "debug": {
-                                  "version": "2.6.8",
-                                  "from": "debug@>=2.2.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-                                  "dependencies": {
-                                    "ms": {
-                                      "version": "2.0.0",
-                                      "from": "ms@2.0.0",
-                                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                                    }
-                                  }
-                                },
-                                "globals": {
-                                  "version": "9.18.0",
-                                  "from": "globals@>=9.0.0 <10.0.0",
-                                  "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-                                },
-                                "invariant": {
-                                  "version": "2.2.2",
-                                  "from": "invariant@>=2.2.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-                                  "dependencies": {
-                                    "loose-envify": {
-                                      "version": "1.3.1",
-                                      "from": "loose-envify@>=1.0.0 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-                                      "dependencies": {
-                                        "js-tokens": {
-                                          "version": "3.0.2",
-                                          "from": "js-tokens@>=3.0.0 <4.0.0",
-                                          "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "babel-types": {
-                          "version": "6.25.0",
-                          "from": "babel-types@>=6.24.1 <7.0.0",
-                          "resolved": "http://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
-                          "dependencies": {
-                            "esutils": {
-                              "version": "2.0.2",
-                              "from": "esutils@>=2.0.2 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-                            },
-                            "to-fast-properties": {
-                              "version": "1.0.3",
-                              "from": "to-fast-properties@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "babel-runtime": {
-                      "version": "6.23.0",
-                      "from": "babel-runtime@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "2.4.1",
-                          "from": "core-js@>=2.4.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                        },
-                        "regenerator-runtime": {
-                          "version": "0.10.5",
-                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "babel-plugin-transform-object-rest-spread": {
-                  "version": "6.23.0",
-                  "from": "babel-plugin-transform-object-rest-spread@>=6.22.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/babel-plugin-transform-object-rest-spread/-/babel-plugin-transform-object-rest-spread-6.23.0.tgz",
-                  "dependencies": {
-                    "babel-plugin-syntax-object-rest-spread": {
-                      "version": "6.13.0",
-                      "from": "babel-plugin-syntax-object-rest-spread@>=6.8.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"
-                    },
-                    "babel-runtime": {
-                      "version": "6.23.0",
-                      "from": "babel-runtime@>=6.22.0 <7.0.0",
-                      "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-                      "dependencies": {
-                        "core-js": {
-                          "version": "2.4.1",
-                          "from": "core-js@>=2.4.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-                        },
-                        "regenerator-runtime": {
-                          "version": "0.10.5",
-                          "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-                          "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
+        "iconv-lite": {
+          "version": "0.4.15",
+          "from": "iconv-lite@0.4.15",
+          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
         }
       }
+    },
+    "boolbase": {
+      "version": "1.0.0",
+      "from": "boolbase@>=1.0.0 <1.1.0",
+      "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "dev": true
+    },
+    "boom": {
+      "version": "2.10.1",
+      "from": "boom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
     },
     "bootstrap-sass": {
       "version": "3.3.7",
       "from": "bootstrap-sass@>=3.3.7 <4.0.0",
-      "resolved": "http://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz"
+      "resolved": "http://registry.npmjs.org/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.8",
+      "from": "brace-expansion@>=1.1.7 <2.0.0",
+      "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz"
+    },
+    "braces": {
+      "version": "1.8.5",
+      "from": "braces@>=1.8.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz"
+    },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "from": "browser-stdout@1.3.0",
+      "resolved": "http://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "dev": true
+    },
+    "browserify-aes": {
+      "version": "0.4.0",
+      "from": "browserify-aes@0.4.0",
+      "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz"
+    },
+    "browserify-zlib": {
+      "version": "0.1.4",
+      "from": "browserify-zlib@>=0.1.4 <0.2.0",
+      "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz"
+    },
+    "browserslist": {
+      "version": "1.7.7",
+      "from": "browserslist@>=1.7.6 <2.0.0",
+      "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz"
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "from": "buffer@>=4.9.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz"
+    },
+    "builtin-modules": {
+      "version": "1.1.1",
+      "from": "builtin-modules@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+    },
+    "builtin-status-codes": {
+      "version": "3.0.0",
+      "from": "builtin-status-codes@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
+    },
+    "busboy": {
+      "version": "0.2.14",
+      "from": "busboy@>=0.2.9 <0.3.0",
+      "resolved": "http://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        }
+      }
+    },
+    "bytes": {
+      "version": "2.4.0",
+      "from": "bytes@2.4.0",
+      "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
+    },
+    "call-me-maybe": {
+      "version": "1.0.1",
+      "from": "call-me-maybe@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz"
+    },
+    "caller-path": {
+      "version": "0.1.0",
+      "from": "caller-path@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+      "dev": true
+    },
+    "callsites": {
+      "version": "0.2.0",
+      "from": "callsites@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+      "dev": true
+    },
+    "camelcase": {
+      "version": "2.1.1",
+      "from": "camelcase@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+    },
+    "camelcase-keys": {
+      "version": "2.1.0",
+      "from": "camelcase-keys@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz"
+    },
+    "caniuse-api": {
+      "version": "1.6.1",
+      "from": "caniuse-api@>=1.5.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz"
+    },
+    "caniuse-db": {
+      "version": "1.0.30000708",
+      "from": "caniuse-db@>=1.0.30000634 <2.0.0",
+      "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000708.tgz"
+    },
+    "caseless": {
+      "version": "0.12.0",
+      "from": "caseless@>=0.12.0 <0.13.0",
+      "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
     "chai": {
       "version": "3.5.0",
       "from": "chai@>=3.5.0 <4.0.0",
       "resolved": "http://registry.npmjs.org/chai/-/chai-3.5.0.tgz",
-      "dependencies": {
-        "assertion-error": {
-          "version": "1.0.2",
-          "from": "assertion-error@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz"
-        },
-        "deep-eql": {
-          "version": "0.1.3",
-          "from": "deep-eql@>=0.1.3 <0.2.0",
-          "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
-          "dependencies": {
-            "type-detect": {
-              "version": "0.1.1",
-              "from": "type-detect@0.1.1",
-              "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz"
-            }
-          }
-        },
-        "type-detect": {
-          "version": "1.0.0",
-          "from": "type-detect@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz"
-        }
-      }
+      "dev": true
     },
     "chai-jquery": {
       "version": "2.0.0",
       "from": "chai-jquery@>=2.0.0 <3.0.0",
-      "resolved": "http://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz"
+      "resolved": "http://registry.npmjs.org/chai-jquery/-/chai-jquery-2.0.0.tgz",
+      "dev": true
     },
     "chai-spies": {
       "version": "0.7.1",
       "from": "chai-spies@latest",
       "resolved": "http://registry.npmjs.org/chai-spies/-/chai-spies-0.7.1.tgz"
     },
+    "chalk": {
+      "version": "1.1.3",
+      "from": "chalk@>=1.1.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "dependencies": {
+        "supports-color": {
+          "version": "2.0.0",
+          "from": "supports-color@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+        }
+      }
+    },
+    "cheerio": {
+      "version": "0.22.0",
+      "from": "cheerio@>=0.22.0 <0.23.0",
+      "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
+      "dev": true
+    },
+    "chokidar": {
+      "version": "1.7.0",
+      "from": "chokidar@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz"
+    },
+    "circular-json": {
+      "version": "0.3.3",
+      "from": "circular-json@>=0.3.1 <0.4.0",
+      "resolved": "http://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "dev": true
+    },
+    "clap": {
+      "version": "1.2.0",
+      "from": "clap@>=1.0.9 <2.0.0",
+      "resolved": "http://registry.npmjs.org/clap/-/clap-1.2.0.tgz"
+    },
+    "classnames": {
+      "version": "2.2.5",
+      "from": "classnames@>=2.2.5 <3.0.0",
+      "resolved": "http://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "from": "cli-cursor@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "dev": true
+    },
+    "cli-width": {
+      "version": "2.1.0",
+      "from": "cli-width@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+      "dev": true
+    },
+    "cliui": {
+      "version": "3.2.0",
+      "from": "cliui@>=3.2.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz"
+    },
+    "clone": {
+      "version": "1.0.2",
+      "from": "clone@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
+    },
+    "co": {
+      "version": "4.6.0",
+      "from": "co@>=4.6.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
+    },
+    "coa": {
+      "version": "1.0.4",
+      "from": "coa@>=1.0.1 <1.1.0",
+      "resolved": "http://registry.npmjs.org/coa/-/coa-1.0.4.tgz"
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "from": "code-point-at@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+    },
+    "color": {
+      "version": "0.11.4",
+      "from": "color@>=0.11.0 <0.12.0",
+      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz"
+    },
+    "color-convert": {
+      "version": "1.9.0",
+      "from": "color-convert@>=1.3.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz"
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "from": "color-name@>=1.1.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
+    },
+    "color-string": {
+      "version": "0.3.0",
+      "from": "color-string@>=0.3.0 <0.4.0",
+      "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz"
+    },
+    "colormin": {
+      "version": "1.1.2",
+      "from": "colormin@>=1.0.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz"
+    },
+    "colors": {
+      "version": "1.1.2",
+      "from": "colors@>=1.1.2 <1.2.0",
+      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
+    },
+    "combined-stream": {
+      "version": "1.0.5",
+      "from": "combined-stream@>=1.0.5 <1.1.0",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+    },
+    "commander": {
+      "version": "2.11.0",
+      "from": "commander@>=2.8.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "from": "commondir@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz"
+    },
+    "compressible": {
+      "version": "2.0.10",
+      "from": "compressible@>=2.0.10 <2.1.0",
+      "resolved": "http://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz"
+    },
+    "compression": {
+      "version": "1.7.0",
+      "from": "compression@>=1.5.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
+      "dependencies": {
+        "bytes": {
+          "version": "2.5.0",
+          "from": "bytes@2.5.0",
+          "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
+        }
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "from": "concat-map@0.0.1",
+      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+    },
+    "concat-stream": {
+      "version": "1.6.0",
+      "from": "concat-stream@>=1.5.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+      "dev": true
+    },
+    "connect-history-api-fallback": {
+      "version": "1.3.0",
+      "from": "connect-history-api-fallback@>=1.3.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
+    },
+    "console-browserify": {
+      "version": "1.1.0",
+      "from": "console-browserify@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz"
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "from": "console-control-strings@>=1.1.0 <1.2.0",
+      "resolved": "http://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+    },
+    "constants-browserify": {
+      "version": "1.0.0",
+      "from": "constants-browserify@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "from": "content-disposition@0.5.2",
+      "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+    },
+    "content-type": {
+      "version": "1.0.2",
+      "from": "content-type@>=1.0.2 <1.1.0",
+      "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
+    },
+    "content-type-parser": {
+      "version": "1.0.1",
+      "from": "content-type-parser@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz",
+      "dev": true
+    },
+    "convert-source-map": {
+      "version": "1.5.0",
+      "from": "convert-source-map@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "from": "cookie@0.3.1",
+      "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+    },
+    "cookie-parser": {
+      "version": "1.4.3",
+      "from": "cookie-parser@>=1.3.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz"
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "from": "cookie-signature@1.0.6",
+      "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+    },
+    "core-js": {
+      "version": "2.4.1",
+      "from": "core-js@>=2.4.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "from": "core-util-is@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+    },
+    "cosmiconfig": {
+      "version": "2.2.2",
+      "from": "cosmiconfig@>=2.1.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.2.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
+    "create-react-class": {
+      "version": "15.6.0",
+      "from": "create-react-class@>=15.6.0 <16.0.0",
+      "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz"
+    },
+    "cross-spawn": {
+      "version": "3.0.1",
+      "from": "cross-spawn@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz"
+    },
+    "cryptiles": {
+      "version": "2.0.5",
+      "from": "cryptiles@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+    },
+    "crypto-browserify": {
+      "version": "3.3.0",
+      "from": "crypto-browserify@3.3.0",
+      "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz"
+    },
+    "css": {
+      "version": "2.2.1",
+      "from": "css@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "from": "source-map@>=0.1.38 <0.2.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
+        }
+      }
+    },
+    "css-color-names": {
+      "version": "0.0.4",
+      "from": "css-color-names@0.0.4",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz"
+    },
     "css-loader": {
       "version": "0.25.0",
       "from": "css-loader@>=0.25.0 <0.26.0",
-      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz",
+      "resolved": "http://registry.npmjs.org/css-loader/-/css-loader-0.25.0.tgz"
+    },
+    "css-select": {
+      "version": "1.2.0",
+      "from": "css-select@>=1.2.0 <1.3.0",
+      "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
+      "dev": true
+    },
+    "css-selector-tokenizer": {
+      "version": "0.6.0",
+      "from": "css-selector-tokenizer@>=0.6.0 <0.7.0",
+      "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
       "dependencies": {
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "from": "babel-code-frame@>=6.11.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "css-selector-tokenizer": {
-          "version": "0.6.0",
-          "from": "css-selector-tokenizer@>=0.6.0 <0.7.0",
-          "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.6.0.tgz",
-          "dependencies": {
-            "cssesc": {
-              "version": "0.1.0",
-              "from": "cssesc@>=0.1.0 <0.2.0",
-              "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
-            },
-            "fastparse": {
-              "version": "1.1.1",
-              "from": "fastparse@>=1.1.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
-            },
-            "regexpu-core": {
-              "version": "1.0.0",
-              "from": "regexpu-core@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-              "dependencies": {
-                "regenerate": {
-                  "version": "1.3.2",
-                  "from": "regenerate@>=1.2.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-                },
-                "regjsgen": {
-                  "version": "0.2.0",
-                  "from": "regjsgen@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                },
-                "regjsparser": {
-                  "version": "0.1.5",
-                  "from": "regjsparser@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                  "dependencies": {
-                    "jsesc": {
-                      "version": "0.5.0",
-                      "from": "jsesc@>=0.5.0 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "cssnano": {
-          "version": "3.10.0",
-          "from": "cssnano@>=2.6.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz",
-          "dependencies": {
-            "decamelize": {
-              "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-            },
-            "defined": {
-              "version": "1.0.0",
-              "from": "defined@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
-            },
-            "has": {
-              "version": "1.0.1",
-              "from": "has@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
-              "dependencies": {
-                "function-bind": {
-                  "version": "1.1.0",
-                  "from": "function-bind@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-                }
-              }
-            },
-            "postcss-calc": {
-              "version": "5.3.1",
-              "from": "postcss-calc@>=5.2.0 <6.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz",
-              "dependencies": {
-                "postcss-message-helpers": {
-                  "version": "2.0.0",
-                  "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
-                },
-                "reduce-css-calc": {
-                  "version": "1.3.0",
-                  "from": "reduce-css-calc@>=1.2.6 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@>=0.4.2 <0.5.0",
-                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "math-expression-evaluator": {
-                      "version": "1.2.17",
-                      "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz"
-                    },
-                    "reduce-function-call": {
-                      "version": "1.0.2",
-                      "from": "reduce-function-call@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-colormin": {
-              "version": "2.2.2",
-              "from": "postcss-colormin@>=2.1.8 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz",
-              "dependencies": {
-                "colormin": {
-                  "version": "1.1.2",
-                  "from": "colormin@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/colormin/-/colormin-1.1.2.tgz",
-                  "dependencies": {
-                    "color": {
-                      "version": "0.11.4",
-                      "from": "color@>=0.11.0 <0.12.0",
-                      "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
-                      "dependencies": {
-                        "clone": {
-                          "version": "1.0.2",
-                          "from": "clone@>=1.0.2 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-                        },
-                        "color-convert": {
-                          "version": "1.9.0",
-                          "from": "color-convert@>=1.3.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.1.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        },
-                        "color-string": {
-                          "version": "0.3.0",
-                          "from": "color-string@>=0.3.0 <0.4.0",
-                          "resolved": "http://registry.npmjs.org/color-string/-/color-string-0.3.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "css-color-names": {
-                      "version": "0.0.4",
-                      "from": "css-color-names@0.0.4",
-                      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-convert-values": {
-              "version": "2.6.1",
-              "from": "postcss-convert-values@>=2.3.4 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz"
-            },
-            "postcss-discard-comments": {
-              "version": "2.0.4",
-              "from": "postcss-discard-comments@>=2.0.4 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
-            },
-            "postcss-discard-duplicates": {
-              "version": "2.1.0",
-              "from": "postcss-discard-duplicates@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz"
-            },
-            "postcss-discard-empty": {
-              "version": "2.1.0",
-              "from": "postcss-discard-empty@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
-            },
-            "postcss-discard-overridden": {
-              "version": "0.1.1",
-              "from": "postcss-discard-overridden@>=0.1.1 <0.2.0",
-              "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz"
-            },
-            "postcss-discard-unused": {
-              "version": "2.2.3",
-              "from": "postcss-discard-unused@>=2.2.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-filter-plugins": {
-              "version": "2.0.2",
-              "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-              "dependencies": {
-                "uniqid": {
-                  "version": "4.1.1",
-                  "from": "uniqid@>=4.0.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-                  "dependencies": {
-                    "macaddress": {
-                      "version": "0.2.8",
-                      "from": "macaddress@>=0.2.8 <0.3.0",
-                      "resolved": "http://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-merge-idents": {
-              "version": "2.1.7",
-              "from": "postcss-merge-idents@>=2.1.5 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz"
-            },
-            "postcss-merge-longhand": {
-              "version": "2.0.2",
-              "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz"
-            },
-            "postcss-merge-rules": {
-              "version": "2.1.2",
-              "from": "postcss-merge-rules@>=2.0.3 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz",
-              "dependencies": {
-                "browserslist": {
-                  "version": "1.7.7",
-                  "from": "browserslist@>=1.5.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/browserslist/-/browserslist-1.7.7.tgz",
-                  "dependencies": {
-                    "caniuse-db": {
-                      "version": "1.0.30000706",
-                      "from": "caniuse-db@>=1.0.30000639 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
-                    },
-                    "electron-to-chromium": {
-                      "version": "1.3.16",
-                      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
-                    }
-                  }
-                },
-                "caniuse-api": {
-                  "version": "1.6.1",
-                  "from": "caniuse-api@>=1.5.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/caniuse-api/-/caniuse-api-1.6.1.tgz",
-                  "dependencies": {
-                    "caniuse-db": {
-                      "version": "1.0.30000706",
-                      "from": "caniuse-db@>=1.0.30000529 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000706.tgz"
-                    },
-                    "lodash.memoize": {
-                      "version": "4.1.2",
-                      "from": "lodash.memoize@>=4.1.2 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
-                    },
-                    "lodash.uniq": {
-                      "version": "4.5.0",
-                      "from": "lodash.uniq@>=4.5.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
-                    }
-                  }
-                },
-                "postcss-selector-parser": {
-                  "version": "2.2.3",
-                  "from": "postcss-selector-parser@>=2.2.2 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-                  "dependencies": {
-                    "flatten": {
-                      "version": "1.0.2",
-                      "from": "flatten@>=1.0.2 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
-                    },
-                    "indexes-of": {
-                      "version": "1.0.1",
-                      "from": "indexes-of@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
-                    },
-                    "uniq": {
-                      "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-                    }
-                  }
-                },
-                "vendors": {
-                  "version": "1.0.1",
-                  "from": "vendors@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
-                }
-              }
-            },
-            "postcss-minify-font-values": {
-              "version": "1.0.5",
-              "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz"
-            },
-            "postcss-minify-gradients": {
-              "version": "1.0.5",
-              "from": "postcss-minify-gradients@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz"
-            },
-            "postcss-minify-params": {
-              "version": "1.2.2",
-              "from": "postcss-minify-params@>=1.0.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-minify-selectors": {
-              "version": "2.1.1",
-              "from": "postcss-minify-selectors@>=2.0.4 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "postcss-selector-parser": {
-                  "version": "2.2.3",
-                  "from": "postcss-selector-parser@>=2.2.2 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz",
-                  "dependencies": {
-                    "flatten": {
-                      "version": "1.0.2",
-                      "from": "flatten@>=1.0.2 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
-                    },
-                    "indexes-of": {
-                      "version": "1.0.1",
-                      "from": "indexes-of@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
-                    },
-                    "uniq": {
-                      "version": "1.0.1",
-                      "from": "uniq@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-normalize-charset": {
-              "version": "1.1.1",
-              "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz"
-            },
-            "postcss-normalize-url": {
-              "version": "3.0.8",
-              "from": "postcss-normalize-url@>=3.0.7 <4.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz",
-              "dependencies": {
-                "is-absolute-url": {
-                  "version": "2.1.0",
-                  "from": "is-absolute-url@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
-                },
-                "normalize-url": {
-                  "version": "1.9.1",
-                  "from": "normalize-url@>=1.4.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
-                  "dependencies": {
-                    "prepend-http": {
-                      "version": "1.0.4",
-                      "from": "prepend-http@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
-                    },
-                    "query-string": {
-                      "version": "4.3.4",
-                      "from": "query-string@>=4.1.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz"
-                    },
-                    "sort-keys": {
-                      "version": "1.1.2",
-                      "from": "sort-keys@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
-                      "dependencies": {
-                        "is-plain-obj": {
-                          "version": "1.1.0",
-                          "from": "is-plain-obj@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-ordered-values": {
-              "version": "2.2.3",
-              "from": "postcss-ordered-values@>=2.1.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz"
-            },
-            "postcss-reduce-idents": {
-              "version": "2.4.0",
-              "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz"
-            },
-            "postcss-reduce-initial": {
-              "version": "1.0.1",
-              "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz"
-            },
-            "postcss-reduce-transforms": {
-              "version": "1.0.4",
-              "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz"
-            },
-            "postcss-svgo": {
-              "version": "2.1.6",
-              "from": "postcss-svgo@>=2.1.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz",
-              "dependencies": {
-                "is-svg": {
-                  "version": "2.1.0",
-                  "from": "is-svg@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz",
-                  "dependencies": {
-                    "html-comment-regex": {
-                      "version": "1.1.1",
-                      "from": "html-comment-regex@>=1.1.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
-                    }
-                  }
-                },
-                "svgo": {
-                  "version": "0.7.2",
-                  "from": "svgo@>=0.7.0 <0.8.0",
-                  "resolved": "http://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz",
-                  "dependencies": {
-                    "sax": {
-                      "version": "1.2.4",
-                      "from": "sax@>=1.2.1 <1.3.0",
-                      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
-                    },
-                    "coa": {
-                      "version": "1.0.4",
-                      "from": "coa@>=1.0.1 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/coa/-/coa-1.0.4.tgz",
-                      "dependencies": {
-                        "q": {
-                          "version": "1.5.0",
-                          "from": "q@>=1.1.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
-                        }
-                      }
-                    },
-                    "js-yaml": {
-                      "version": "3.7.0",
-                      "from": "js-yaml@>=3.7.0 <3.8.0",
-                      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz",
-                      "dependencies": {
-                        "argparse": {
-                          "version": "1.0.9",
-                          "from": "argparse@>=1.0.7 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                          "dependencies": {
-                            "sprintf-js": {
-                              "version": "1.0.3",
-                              "from": "sprintf-js@>=1.0.2 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "esprima": {
-                          "version": "2.7.3",
-                          "from": "esprima@>=2.6.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-                        }
-                      }
-                    },
-                    "colors": {
-                      "version": "1.1.2",
-                      "from": "colors@>=1.1.2 <1.2.0",
-                      "resolved": "http://registry.npmjs.org/colors/-/colors-1.1.2.tgz"
-                    },
-                    "whet.extend": {
-                      "version": "0.9.9",
-                      "from": "whet.extend@>=0.9.9 <0.10.0",
-                      "resolved": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                        }
-                      }
-                    },
-                    "csso": {
-                      "version": "2.3.2",
-                      "from": "csso@>=2.3.1 <2.4.0",
-                      "resolved": "http://registry.npmjs.org/csso/-/csso-2.3.2.tgz",
-                      "dependencies": {
-                        "clap": {
-                          "version": "1.2.0",
-                          "from": "clap@>=1.0.9 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/clap/-/clap-1.2.0.tgz",
-                          "dependencies": {
-                            "chalk": {
-                              "version": "1.1.3",
-                              "from": "chalk@>=1.1.3 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                              "dependencies": {
-                                "ansi-styles": {
-                                  "version": "2.2.1",
-                                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                                },
-                                "escape-string-regexp": {
-                                  "version": "1.0.5",
-                                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                                },
-                                "has-ansi": {
-                                  "version": "2.0.0",
-                                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "strip-ansi": {
-                                  "version": "3.0.1",
-                                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                                  "dependencies": {
-                                    "ansi-regex": {
-                                      "version": "2.1.1",
-                                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                                    }
-                                  }
-                                },
-                                "supports-color": {
-                                  "version": "2.0.0",
-                                  "from": "supports-color@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "source-map": {
-                          "version": "0.5.6",
-                          "from": "source-map@>=0.5.3 <0.6.0",
-                          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss-unique-selectors": {
-              "version": "2.0.2",
-              "from": "postcss-unique-selectors@>=2.0.2 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz",
-              "dependencies": {
-                "alphanum-sort": {
-                  "version": "1.0.2",
-                  "from": "alphanum-sort@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/alphanum-sort/-/alphanum-sort-1.0.2.tgz"
-                },
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            },
-            "postcss-value-parser": {
-              "version": "3.3.0",
-              "from": "postcss-value-parser@>=3.2.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
-            },
-            "postcss-zindex": {
-              "version": "2.2.0",
-              "from": "postcss-zindex@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz",
-              "dependencies": {
-                "uniqs": {
-                  "version": "2.0.0",
-                  "from": "uniqs@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.2 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "lodash.camelcase": {
-          "version": "3.0.1",
-          "from": "lodash.camelcase@>=3.0.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz",
-          "dependencies": {
-            "lodash._createcompounder": {
-              "version": "3.0.0",
-              "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz",
-              "dependencies": {
-                "lodash.deburr": {
-                  "version": "3.2.0",
-                  "from": "lodash.deburr@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._root": {
-                      "version": "3.0.1",
-                      "from": "lodash._root@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash.words": {
-                  "version": "3.2.0",
-                  "from": "lodash.words@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._root": {
-                      "version": "3.0.1",
-                      "from": "lodash._root@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.0.1 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        },
-        "postcss": {
-          "version": "5.2.17",
-          "from": "postcss@>=5.0.6 <6.0.0",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.6 <0.6.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "supports-color": {
-              "version": "3.2.3",
-              "from": "supports-color@>=3.2.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "postcss-modules-extract-imports": {
-          "version": "1.1.0",
-          "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
-          "dependencies": {
-            "postcss": {
-              "version": "6.0.8",
-              "from": "postcss@>=6.0.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "2.0.1",
-                  "from": "chalk@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "3.2.0",
-                      "from": "ansi-styles@>=3.1.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.9.0",
-                          "from": "color-convert@>=1.9.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.1.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "from": "source-map@>=0.5.6 <0.6.0",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                },
-                "supports-color": {
-                  "version": "4.2.1",
-                  "from": "supports-color@>=4.2.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "2.0.0",
-                      "from": "has-flag@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "postcss-modules-local-by-default": {
-          "version": "1.2.0",
-          "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
-          "dependencies": {
-            "css-selector-tokenizer": {
-              "version": "0.7.0",
-              "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
-              "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-              "dependencies": {
-                "cssesc": {
-                  "version": "0.1.0",
-                  "from": "cssesc@>=0.1.0 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
-                },
-                "fastparse": {
-                  "version": "1.1.1",
-                  "from": "fastparse@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
-                },
-                "regexpu-core": {
-                  "version": "1.0.0",
-                  "from": "regexpu-core@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                  "dependencies": {
-                    "regenerate": {
-                      "version": "1.3.2",
-                      "from": "regenerate@>=1.2.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-                    },
-                    "regjsgen": {
-                      "version": "0.2.0",
-                      "from": "regjsgen@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                    },
-                    "regjsparser": {
-                      "version": "0.1.5",
-                      "from": "regjsparser@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                      "dependencies": {
-                        "jsesc": {
-                          "version": "0.5.0",
-                          "from": "jsesc@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss": {
-              "version": "6.0.8",
-              "from": "postcss@>=6.0.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "2.0.1",
-                  "from": "chalk@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "3.2.0",
-                      "from": "ansi-styles@>=3.1.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.9.0",
-                          "from": "color-convert@>=1.9.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.1.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "from": "source-map@>=0.5.6 <0.6.0",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                },
-                "supports-color": {
-                  "version": "4.2.1",
-                  "from": "supports-color@>=4.2.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "2.0.0",
-                      "from": "has-flag@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "postcss-modules-scope": {
-          "version": "1.1.0",
-          "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
-          "dependencies": {
-            "css-selector-tokenizer": {
-              "version": "0.7.0",
-              "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
-              "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz",
-              "dependencies": {
-                "cssesc": {
-                  "version": "0.1.0",
-                  "from": "cssesc@>=0.1.0 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
-                },
-                "fastparse": {
-                  "version": "1.1.1",
-                  "from": "fastparse@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
-                },
-                "regexpu-core": {
-                  "version": "1.0.0",
-                  "from": "regexpu-core@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-                  "dependencies": {
-                    "regenerate": {
-                      "version": "1.3.2",
-                      "from": "regenerate@>=1.2.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
-                    },
-                    "regjsgen": {
-                      "version": "0.2.0",
-                      "from": "regjsgen@>=0.2.0 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
-                    },
-                    "regjsparser": {
-                      "version": "0.1.5",
-                      "from": "regjsparser@>=0.1.4 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-                      "dependencies": {
-                        "jsesc": {
-                          "version": "0.5.0",
-                          "from": "jsesc@>=0.5.0 <0.6.0",
-                          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "postcss": {
-              "version": "6.0.8",
-              "from": "postcss@>=6.0.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "2.0.1",
-                  "from": "chalk@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "3.2.0",
-                      "from": "ansi-styles@>=3.1.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.9.0",
-                          "from": "color-convert@>=1.9.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.1.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "from": "source-map@>=0.5.6 <0.6.0",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                },
-                "supports-color": {
-                  "version": "4.2.1",
-                  "from": "supports-color@>=4.2.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "2.0.0",
-                      "from": "has-flag@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "postcss-modules-values": {
-          "version": "1.3.0",
-          "from": "postcss-modules-values@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
-          "dependencies": {
-            "icss-replace-symbols": {
-              "version": "1.1.0",
-              "from": "icss-replace-symbols@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz"
-            },
-            "postcss": {
-              "version": "6.0.8",
-              "from": "postcss@>=6.0.1 <7.0.0",
-              "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "2.0.1",
-                  "from": "chalk@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "3.2.0",
-                      "from": "ansi-styles@>=3.1.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
-                      "dependencies": {
-                        "color-convert": {
-                          "version": "1.9.0",
-                          "from": "color-convert@>=1.9.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
-                          "dependencies": {
-                            "color-name": {
-                              "version": "1.1.3",
-                              "from": "color-name@>=1.1.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    }
-                  }
-                },
-                "source-map": {
-                  "version": "0.5.6",
-                  "from": "source-map@>=0.5.6 <0.6.0",
-                  "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-                },
-                "supports-color": {
-                  "version": "4.2.1",
-                  "from": "supports-color@>=4.2.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz",
-                  "dependencies": {
-                    "has-flag": {
-                      "version": "2.0.0",
-                      "from": "has-flag@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "source-list-map": {
-          "version": "0.1.8",
-          "from": "source-list-map@>=0.1.4 <0.2.0",
-          "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+        "regexpu-core": {
+          "version": "1.0.0",
+          "from": "regexpu-core@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+        }
+      }
+    },
+    "css-what": {
+      "version": "2.1.0",
+      "from": "css-what@>=2.1.0 <2.2.0",
+      "resolved": "http://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "0.1.0",
+      "from": "cssesc@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz"
+    },
+    "cssnano": {
+      "version": "3.10.0",
+      "from": "cssnano@>=2.6.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/cssnano/-/cssnano-3.10.0.tgz"
+    },
+    "csso": {
+      "version": "2.3.2",
+      "from": "csso@>=2.3.1 <2.4.0",
+      "resolved": "http://registry.npmjs.org/csso/-/csso-2.3.2.tgz"
+    },
+    "cssom": {
+      "version": "0.3.2",
+      "from": "cssom@>=0.3.2 <0.4.0",
+      "resolved": "http://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
+      "dev": true
+    },
+    "cssstyle": {
+      "version": "0.2.37",
+      "from": "cssstyle@>=0.2.37 <0.3.0",
+      "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz",
+      "dev": true
+    },
+    "currently-unhandled": {
+      "version": "0.4.1",
+      "from": "currently-unhandled@>=0.4.1 <0.5.0",
+      "resolved": "http://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz"
+    },
+    "d": {
+      "version": "1.0.0",
+      "from": "d@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "dev": true
+    },
+    "dashdash": {
+      "version": "1.14.1",
+      "from": "dashdash@>=1.12.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
@@ -5637,1308 +1200,352 @@
       "from": "date-fns@>=1.28.5 <2.0.0",
       "resolved": "http://registry.npmjs.org/date-fns/-/date-fns-1.28.5.tgz"
     },
+    "date-now": {
+      "version": "0.1.4",
+      "from": "date-now@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
+    },
+    "debug": {
+      "version": "2.6.8",
+      "from": "debug@>=2.2.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "from": "decamelize@>=1.1.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+    },
+    "deep-diff": {
+      "version": "0.3.4",
+      "from": "deep-diff@0.3.4",
+      "resolved": "http://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz"
+    },
+    "deep-eql": {
+      "version": "0.1.3",
+      "from": "deep-eql@>=0.1.3 <0.2.0",
+      "resolved": "http://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "type-detect": {
+          "version": "0.1.1",
+          "from": "type-detect@0.1.1",
+          "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "from": "deep-is@>=0.1.3 <0.2.0",
+      "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "dev": true
+    },
+    "define-properties": {
+      "version": "1.1.2",
+      "from": "define-properties@>=1.1.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
+      "dev": true
+    },
+    "defined": {
+      "version": "1.0.0",
+      "from": "defined@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz"
+    },
+    "del": {
+      "version": "2.2.2",
+      "from": "del@>=2.0.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/del/-/del-2.2.2.tgz",
+      "dev": true
+    },
+    "delayed-stream": {
+      "version": "1.0.0",
+      "from": "delayed-stream@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "from": "delegates@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
+    },
+    "depd": {
+      "version": "1.1.0",
+      "from": "depd@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "from": "destroy@>=1.0.4 <1.1.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+    },
+    "detect-indent": {
+      "version": "4.0.0",
+      "from": "detect-indent@>=4.0.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz"
+    },
+    "dicer": {
+      "version": "0.2.5",
+      "from": "dicer@0.2.5",
+      "resolved": "http://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "from": "readable-stream@>=1.1.0 <1.2.0",
+          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+        }
+      }
+    },
+    "diff": {
+      "version": "3.2.0",
+      "from": "diff@3.2.0",
+      "resolved": "http://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+      "dev": true
+    },
+    "directory-search": {
+      "version": "0.0.32",
+      "from": "directory-search@0.0.32",
+      "resolved": "http://registry.npmjs.org/directory-search/-/directory-search-0.0.32.tgz"
+    },
+    "doctrine": {
+      "version": "2.0.0",
+      "from": "doctrine@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+      "dev": true
+    },
+    "dom-helpers": {
+      "version": "3.2.1",
+      "from": "dom-helpers@>=3.2.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz"
+    },
+    "dom-serializer": {
+      "version": "0.1.0",
+      "from": "dom-serializer@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": {
+          "version": "1.1.3",
+          "from": "domelementtype@>=1.1.1 <1.2.0",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "dom-walk": {
+      "version": "0.1.1",
+      "from": "dom-walk@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
+    },
+    "domain-browser": {
+      "version": "1.1.7",
+      "from": "domain-browser@>=1.1.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
+    },
+    "domelementtype": {
+      "version": "1.3.0",
+      "from": "domelementtype@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz",
+      "dev": true
+    },
+    "domhandler": {
+      "version": "2.4.1",
+      "from": "domhandler@>=2.3.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz",
+      "dev": true
+    },
+    "domutils": {
+      "version": "1.5.1",
+      "from": "domutils@1.5.1",
+      "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
+      "dev": true
+    },
+    "duplexer": {
+      "version": "0.1.1",
+      "from": "duplexer@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "dev": true
+    },
+    "ecc-jsbn": {
+      "version": "0.1.1",
+      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+      "optional": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "from": "ee-first@1.1.1",
+      "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+    },
+    "ejs": {
+      "version": "2.5.6",
+      "from": "ejs@>=2.5.6 <3.0.0",
+      "resolved": "http://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz",
+      "dev": true
+    },
+    "electron-to-chromium": {
+      "version": "1.3.16",
+      "from": "electron-to-chromium@>=1.2.7 <2.0.0",
+      "resolved": "http://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.16.tgz"
+    },
+    "emojis-list": {
+      "version": "2.1.0",
+      "from": "emojis-list@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
+    },
+    "encodeurl": {
+      "version": "1.0.1",
+      "from": "encodeurl@>=1.0.1 <1.1.0",
+      "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+    },
+    "encoding": {
+      "version": "0.1.12",
+      "from": "encoding@>=0.1.11 <0.2.0",
+      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz"
+    },
+    "enhanced-resolve": {
+      "version": "0.9.1",
+      "from": "enhanced-resolve@>=0.9.0 <0.10.0",
+      "resolved": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
+      "dependencies": {
+        "memory-fs": {
+          "version": "0.2.0",
+          "from": "memory-fs@>=0.2.0 <0.3.0",
+          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
+        }
+      }
+    },
+    "entities": {
+      "version": "1.1.1",
+      "from": "entities@>=1.1.1 <1.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
+      "dev": true
+    },
     "enzyme": {
       "version": "2.9.1",
       "from": "enzyme@2.9.1",
       "resolved": "http://registry.npmjs.org/enzyme/-/enzyme-2.9.1.tgz",
+      "dev": true
+    },
+    "errno": {
+      "version": "0.1.4",
+      "from": "errno@>=0.1.3 <0.2.0",
+      "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz"
+    },
+    "error-ex": {
+      "version": "1.3.1",
+      "from": "error-ex@>=1.2.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz"
+    },
+    "es-abstract": {
+      "version": "1.7.0",
+      "from": "es-abstract@>=1.6.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
+      "dev": true
+    },
+    "es-to-primitive": {
+      "version": "1.1.1",
+      "from": "es-to-primitive@>=1.1.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
+      "dev": true
+    },
+    "es5-ext": {
+      "version": "0.10.24",
+      "from": "es5-ext@>=0.10.14 <0.11.0",
+      "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz",
+      "dev": true
+    },
+    "es6-iterator": {
+      "version": "2.0.1",
+      "from": "es6-iterator@>=2.0.1 <2.1.0",
+      "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+      "dev": true
+    },
+    "es6-map": {
+      "version": "0.1.5",
+      "from": "es6-map@>=0.1.3 <0.2.0",
+      "resolved": "http://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+      "dev": true
+    },
+    "es6-promise": {
+      "version": "3.3.1",
+      "from": "es6-promise@>=3.0.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
+    },
+    "es6-set": {
+      "version": "0.1.5",
+      "from": "es6-set@>=0.1.5 <0.2.0",
+      "resolved": "http://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+      "dev": true
+    },
+    "es6-symbol": {
+      "version": "3.1.1",
+      "from": "es6-symbol@>=3.1.1 <3.2.0",
+      "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+      "dev": true
+    },
+    "es6-weak-map": {
+      "version": "2.0.2",
+      "from": "es6-weak-map@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "from": "escape-html@>=1.0.3 <1.1.0",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+    },
+    "escodegen": {
+      "version": "1.8.1",
+      "from": "escodegen@>=1.6.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
+      "dev": true,
       "dependencies": {
-        "cheerio": {
-          "version": "0.22.0",
-          "from": "cheerio@>=0.22.0 <0.23.0",
-          "resolved": "http://registry.npmjs.org/cheerio/-/cheerio-0.22.0.tgz",
-          "dependencies": {
-            "css-select": {
-              "version": "1.2.0",
-              "from": "css-select@>=1.2.0 <1.3.0",
-              "resolved": "http://registry.npmjs.org/css-select/-/css-select-1.2.0.tgz",
-              "dependencies": {
-                "css-what": {
-                  "version": "2.1.0",
-                  "from": "css-what@>=2.1.0 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/css-what/-/css-what-2.1.0.tgz"
-                },
-                "domutils": {
-                  "version": "1.5.1",
-                  "from": "domutils@1.5.1",
-                  "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.5.1.tgz",
-                  "dependencies": {
-                    "domelementtype": {
-                      "version": "1.3.0",
-                      "from": "domelementtype@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                    }
-                  }
-                },
-                "boolbase": {
-                  "version": "1.0.0",
-                  "from": "boolbase@>=1.0.0 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz"
-                },
-                "nth-check": {
-                  "version": "1.0.1",
-                  "from": "nth-check@>=1.0.1 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz"
-                }
-              }
-            },
-            "dom-serializer": {
-              "version": "0.1.0",
-              "from": "dom-serializer@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.0.tgz",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.1.3",
-                  "from": "domelementtype@>=1.1.1 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.1.3.tgz"
-                }
-              }
-            },
-            "entities": {
-              "version": "1.1.1",
-              "from": "entities@>=1.1.1 <1.2.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz"
-            },
-            "htmlparser2": {
-              "version": "3.9.2",
-              "from": "htmlparser2@>=3.9.1 <4.0.0",
-              "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
-              "dependencies": {
-                "domelementtype": {
-                  "version": "1.3.0",
-                  "from": "domelementtype@>=1.3.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.0.tgz"
-                },
-                "domhandler": {
-                  "version": "2.4.1",
-                  "from": "domhandler@>=2.3.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/domhandler/-/domhandler-2.4.1.tgz"
-                },
-                "domutils": {
-                  "version": "1.6.2",
-                  "from": "domutils@>=1.5.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/domutils/-/domutils-1.6.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.0.2 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.assignin": {
-              "version": "4.2.0",
-              "from": "lodash.assignin@>=4.0.9 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz"
-            },
-            "lodash.bind": {
-              "version": "4.2.1",
-              "from": "lodash.bind@>=4.1.4 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz"
-            },
-            "lodash.defaults": {
-              "version": "4.2.0",
-              "from": "lodash.defaults@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
-            },
-            "lodash.filter": {
-              "version": "4.6.0",
-              "from": "lodash.filter@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz"
-            },
-            "lodash.flatten": {
-              "version": "4.4.0",
-              "from": "lodash.flatten@>=4.2.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz"
-            },
-            "lodash.foreach": {
-              "version": "4.5.0",
-              "from": "lodash.foreach@>=4.3.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz"
-            },
-            "lodash.map": {
-              "version": "4.6.0",
-              "from": "lodash.map@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz"
-            },
-            "lodash.merge": {
-              "version": "4.6.0",
-              "from": "lodash.merge@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz"
-            },
-            "lodash.pick": {
-              "version": "4.4.0",
-              "from": "lodash.pick@>=4.2.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz"
-            },
-            "lodash.reduce": {
-              "version": "4.6.0",
-              "from": "lodash.reduce@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz"
-            },
-            "lodash.reject": {
-              "version": "4.6.0",
-              "from": "lodash.reject@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz"
-            },
-            "lodash.some": {
-              "version": "4.6.0",
-              "from": "lodash.some@>=4.4.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz"
-            }
-          }
+        "estraverse": {
+          "version": "1.9.3",
+          "from": "estraverse@>=1.9.1 <2.0.0",
+          "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
+          "dev": true
         },
-        "function.prototype.name": {
-          "version": "1.0.3",
-          "from": "function.prototype.name@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                },
-                "object-keys": {
-                  "version": "1.0.11",
-                  "from": "object-keys@>=1.0.8 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-                }
-              }
-            },
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            },
-            "is-callable": {
-              "version": "1.1.3",
-              "from": "is-callable@>=1.1.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-            }
-          }
-        },
-        "is-subset": {
-          "version": "0.1.1",
-          "from": "is-subset@>=0.1.1 <0.2.0",
-          "resolved": "http://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz"
-        },
-        "object-is": {
-          "version": "1.0.1",
-          "from": "object-is@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz"
-        },
-        "object.assign": {
-          "version": "4.0.4",
-          "from": "object.assign@>=4.0.4 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            },
-            "object-keys": {
-              "version": "1.0.11",
-              "from": "object-keys@>=1.0.10 <2.0.0",
-              "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object.entries": {
-          "version": "1.0.4",
-          "from": "object.entries@>=1.0.4 <2.0.0",
-          "resolved": "http://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                },
-                "object-keys": {
-                  "version": "1.0.11",
-                  "from": "object-keys@>=1.0.8 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-                }
-              }
-            },
-            "es-abstract": {
-              "version": "1.7.0",
-              "from": "es-abstract@>=1.6.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-              "dependencies": {
-                "is-callable": {
-                  "version": "1.1.3",
-                  "from": "is-callable@>=1.1.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-                },
-                "es-to-primitive": {
-                  "version": "1.1.1",
-                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-                  "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1",
-                      "from": "is-date-object@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
-                    },
-                    "is-symbol": {
-                      "version": "1.0.1",
-                      "from": "is-symbol@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-regex": {
-                  "version": "1.0.4",
-                  "from": "is-regex@>=1.0.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-                }
-              }
-            },
-            "has": {
-              "version": "1.0.1",
-              "from": "has@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz"
-            },
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            }
-          }
-        },
-        "object.values": {
-          "version": "1.0.4",
-          "from": "object.values@>=1.0.4 <2.0.0",
-          "resolved": "http://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                },
-                "object-keys": {
-                  "version": "1.0.11",
-                  "from": "object-keys@>=1.0.8 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-                }
-              }
-            },
-            "es-abstract": {
-              "version": "1.7.0",
-              "from": "es-abstract@>=1.6.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-              "dependencies": {
-                "is-callable": {
-                  "version": "1.1.3",
-                  "from": "is-callable@>=1.1.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-                },
-                "es-to-primitive": {
-                  "version": "1.1.1",
-                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-                  "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1",
-                      "from": "is-date-object@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
-                    },
-                    "is-symbol": {
-                      "version": "1.0.1",
-                      "from": "is-symbol@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-regex": {
-                  "version": "1.0.4",
-                  "from": "is-regex@>=1.0.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-                }
-              }
-            },
-            "has": {
-              "version": "1.0.1",
-              "from": "has@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz"
-            },
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            }
-          }
-        },
-        "uuid": {
-          "version": "3.1.0",
-          "from": "uuid@>=3.0.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+        "source-map": {
+          "version": "0.2.0",
+          "from": "source-map@>=0.2.0 <0.3.0",
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
+          "dev": true,
+          "optional": true
         }
       }
+    },
+    "escope": {
+      "version": "3.6.0",
+      "from": "escope@>=3.6.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+      "dev": true
     },
     "eslint": {
       "version": "3.19.0",
       "from": "eslint@>=3.10.2 <4.0.0",
       "resolved": "http://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+      "dev": true,
       "dependencies": {
-        "babel-code-frame": {
-          "version": "6.22.0",
-          "from": "babel-code-frame@>=6.16.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "concat-stream": {
-          "version": "1.6.0",
-          "from": "concat-stream@>=1.5.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-          "dependencies": {
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.3 <3.0.0",
-              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "typedarray": {
-              "version": "0.0.6",
-              "from": "typedarray@>=0.0.6 <0.0.7",
-              "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "from": "readable-stream@>=2.2.2 <3.0.0",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "debug": {
-          "version": "2.6.8",
-          "from": "debug@>=2.1.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "2.0.0",
-              "from": "ms@2.0.0",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-            }
-          }
-        },
-        "doctrine": {
-          "version": "2.0.0",
-          "from": "doctrine@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-          "dependencies": {
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
-        },
-        "escope": {
-          "version": "3.6.0",
-          "from": "escope@>=3.6.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-          "dependencies": {
-            "es6-map": {
-              "version": "0.1.5",
-              "from": "es6-map@>=0.1.3 <0.2.0",
-              "resolved": "http://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "1.0.0",
-                  "from": "d@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.24",
-                  "from": "es5-ext@>=0.10.14 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
-                },
-                "es6-iterator": {
-                  "version": "2.0.1",
-                  "from": "es6-iterator@>=2.0.1 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
-                },
-                "es6-set": {
-                  "version": "0.1.5",
-                  "from": "es6-set@>=0.1.5 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz"
-                },
-                "es6-symbol": {
-                  "version": "3.1.1",
-                  "from": "es6-symbol@>=3.1.1 <3.2.0",
-                  "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                },
-                "event-emitter": {
-                  "version": "0.3.5",
-                  "from": "event-emitter@>=0.3.5 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz"
-                }
-              }
-            },
-            "es6-weak-map": {
-              "version": "2.0.2",
-              "from": "es6-weak-map@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-              "dependencies": {
-                "d": {
-                  "version": "1.0.0",
-                  "from": "d@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz"
-                },
-                "es5-ext": {
-                  "version": "0.10.24",
-                  "from": "es5-ext@>=0.10.14 <0.11.0",
-                  "resolved": "http://registry.npmjs.org/es5-ext/-/es5-ext-0.10.24.tgz"
-                },
-                "es6-iterator": {
-                  "version": "2.0.1",
-                  "from": "es6-iterator@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz"
-                },
-                "es6-symbol": {
-                  "version": "3.1.1",
-                  "from": "es6-symbol@>=3.1.1 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz"
-                }
-              }
-            },
-            "esrecurse": {
-              "version": "4.2.0",
-              "from": "esrecurse@>=4.1.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "espree": {
-          "version": "3.4.3",
-          "from": "espree@>=3.4.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
-          "dependencies": {
-            "acorn": {
-              "version": "5.1.1",
-              "from": "acorn@>=5.0.1 <6.0.0",
-              "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
-            },
-            "acorn-jsx": {
-              "version": "3.0.1",
-              "from": "acorn-jsx@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
-              "dependencies": {
-                "acorn": {
-                  "version": "3.3.0",
-                  "from": "acorn@>=3.0.4 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "esquery": {
-          "version": "1.0.0",
-          "from": "esquery@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz"
-        },
-        "estraverse": {
-          "version": "4.2.0",
-          "from": "estraverse@>=4.2.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
-        },
-        "esutils": {
-          "version": "2.0.2",
-          "from": "esutils@>=2.0.2 <3.0.0",
-          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-        },
-        "file-entry-cache": {
-          "version": "2.0.0",
-          "from": "file-entry-cache@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-          "dependencies": {
-            "flat-cache": {
-              "version": "1.2.2",
-              "from": "flat-cache@>=1.2.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-              "dependencies": {
-                "circular-json": {
-                  "version": "0.3.3",
-                  "from": "circular-json@>=0.3.1 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz"
-                },
-                "del": {
-                  "version": "2.2.2",
-                  "from": "del@>=2.0.2 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/del/-/del-2.2.2.tgz",
-                  "dependencies": {
-                    "globby": {
-                      "version": "5.0.0",
-                      "from": "globby@>=5.0.0 <6.0.0",
-                      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
-                      "dependencies": {
-                        "array-union": {
-                          "version": "1.0.2",
-                          "from": "array-union@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-                          "dependencies": {
-                            "array-uniq": {
-                              "version": "1.0.3",
-                              "from": "array-uniq@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "arrify": {
-                          "version": "1.0.1",
-                          "from": "arrify@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "is-path-cwd": {
-                      "version": "1.0.0",
-                      "from": "is-path-cwd@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz"
-                    },
-                    "is-path-in-cwd": {
-                      "version": "1.0.0",
-                      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-                      "dependencies": {
-                        "is-path-inside": {
-                          "version": "1.0.0",
-                          "from": "is-path-inside@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "pify": {
-                      "version": "2.3.0",
-                      "from": "pify@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
-                    },
-                    "rimraf": {
-                      "version": "2.6.1",
-                      "from": "rimraf@>=2.2.8 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-                    }
-                  }
-                },
-                "graceful-fs": {
-                  "version": "4.1.11",
-                  "from": "graceful-fs@>=4.1.2 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                },
-                "write": {
-                  "version": "0.2.1",
-                  "from": "write@>=0.2.1 <0.3.0",
-                  "resolved": "http://registry.npmjs.org/write/-/write-0.2.1.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=3.0.4 <4.0.0",
-              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            }
-          }
-        },
-        "globals": {
-          "version": "9.18.0",
-          "from": "globals@>=9.14.0 <10.0.0",
-          "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
-        },
-        "ignore": {
-          "version": "3.3.3",
-          "from": "ignore@>=3.2.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz"
-        },
-        "imurmurhash": {
-          "version": "0.1.4",
-          "from": "imurmurhash@>=0.1.4 <0.2.0",
-          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
-        },
-        "inquirer": {
-          "version": "0.12.0",
-          "from": "inquirer@>=0.12.0 <0.13.0",
-          "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-          "dependencies": {
-            "ansi-escapes": {
-              "version": "1.4.0",
-              "from": "ansi-escapes@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz"
-            },
-            "ansi-regex": {
-              "version": "2.1.1",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            },
-            "cli-cursor": {
-              "version": "1.0.2",
-              "from": "cli-cursor@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-              "dependencies": {
-                "restore-cursor": {
-                  "version": "1.0.1",
-                  "from": "restore-cursor@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-                  "dependencies": {
-                    "exit-hook": {
-                      "version": "1.1.1",
-                      "from": "exit-hook@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz"
-                    },
-                    "onetime": {
-                      "version": "1.1.0",
-                      "from": "onetime@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "cli-width": {
-              "version": "2.1.0",
-              "from": "cli-width@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz"
-            },
-            "figures": {
-              "version": "1.7.0",
-              "from": "figures@>=1.3.5 <2.0.0",
-              "resolved": "http://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-              "dependencies": {
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                }
-              }
-            },
-            "readline2": {
-              "version": "1.0.1",
-              "from": "readline2@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                    }
-                  }
-                },
-                "mute-stream": {
-                  "version": "0.0.5",
-                  "from": "mute-stream@0.0.5",
-                  "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz"
-                }
-              }
-            },
-            "run-async": {
-              "version": "0.1.0",
-              "from": "run-async@>=0.1.0 <0.2.0",
-              "resolved": "http://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-              "dependencies": {
-                "once": {
-                  "version": "1.4.0",
-                  "from": "once@>=1.3.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
-                  "dependencies": {
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "rx-lite": {
-              "version": "3.1.2",
-              "from": "rx-lite@>=3.1.2 <4.0.0",
-              "resolved": "http://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz"
-            },
-            "string-width": {
-              "version": "1.0.2",
-              "from": "string-width@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "dependencies": {
-                "code-point-at": {
-                  "version": "1.1.0",
-                  "from": "code-point-at@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                },
-                "is-fullwidth-code-point": {
-                  "version": "1.0.0",
-                  "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                  "dependencies": {
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "from": "number-is-nan@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-            },
-            "through": {
-              "version": "2.3.8",
-              "from": "through@>=2.3.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
-            }
-          }
-        },
-        "is-my-json-valid": {
-          "version": "2.16.0",
-          "from": "is-my-json-valid@>=2.10.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-          "dependencies": {
-            "generate-function": {
-              "version": "2.0.0",
-              "from": "generate-function@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-            },
-            "generate-object-property": {
-              "version": "1.2.0",
-              "from": "generate-object-property@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-              "dependencies": {
-                "is-property": {
-                  "version": "1.0.2",
-                  "from": "is-property@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                }
-              }
-            },
-            "jsonpointer": {
-              "version": "4.0.1",
-              "from": "jsonpointer@>=4.0.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz"
-            },
-            "xtend": {
-              "version": "4.0.1",
-              "from": "xtend@>=4.0.0 <5.0.0",
-              "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-            }
-          }
-        },
-        "is-resolvable": {
-          "version": "1.0.0",
-          "from": "is-resolvable@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-          "dependencies": {
-            "tryit": {
-              "version": "1.0.3",
-              "from": "tryit@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz"
-            }
-          }
-        },
-        "js-yaml": {
-          "version": "3.9.0",
-          "from": "js-yaml@>=3.5.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-          "dependencies": {
-            "argparse": {
-              "version": "1.0.9",
-              "from": "argparse@>=1.0.7 <2.0.0",
-              "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-              "dependencies": {
-                "sprintf-js": {
-                  "version": "1.0.3",
-                  "from": "sprintf-js@>=1.0.2 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                }
-              }
-            },
-            "esprima": {
-              "version": "4.0.0",
-              "from": "esprima@>=4.0.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-            }
-          }
-        },
-        "json-stable-stringify": {
-          "version": "1.0.1",
-          "from": "json-stable-stringify@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-          "dependencies": {
-            "jsonify": {
-              "version": "0.0.0",
-              "from": "jsonify@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-            }
-          }
-        },
-        "levn": {
-          "version": "0.3.0",
-          "from": "levn@>=0.3.0 <0.4.0",
-          "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.2 <1.2.0",
-              "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "from": "type-check@>=0.3.2 <0.4.0",
-              "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "natural-compare": {
-          "version": "1.4.0",
-          "from": "natural-compare@>=1.4.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
-        },
-        "optionator": {
-          "version": "0.8.2",
-          "from": "optionator@>=0.8.2 <0.9.0",
-          "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-          "dependencies": {
-            "prelude-ls": {
-              "version": "1.1.2",
-              "from": "prelude-ls@>=1.1.2 <1.2.0",
-              "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-            },
-            "deep-is": {
-              "version": "0.1.3",
-              "from": "deep-is@>=0.1.3 <0.2.0",
-              "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-            },
-            "wordwrap": {
-              "version": "1.0.0",
-              "from": "wordwrap@>=1.0.0 <1.1.0",
-              "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-            },
-            "type-check": {
-              "version": "0.3.2",
-              "from": "type-check@>=0.3.2 <0.4.0",
-              "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-            },
-            "fast-levenshtein": {
-              "version": "2.0.6",
-              "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-              "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-            }
-          }
-        },
-        "path-is-inside": {
-          "version": "1.0.2",
-          "from": "path-is-inside@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz"
-        },
-        "pluralize": {
-          "version": "1.2.1",
-          "from": "pluralize@>=1.2.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz"
-        },
-        "progress": {
-          "version": "1.1.8",
-          "from": "progress@>=1.1.8 <2.0.0",
-          "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
-        },
-        "require-uncached": {
-          "version": "1.0.3",
-          "from": "require-uncached@>=1.0.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-          "dependencies": {
-            "caller-path": {
-              "version": "0.1.0",
-              "from": "caller-path@>=0.1.0 <0.2.0",
-              "resolved": "http://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-              "dependencies": {
-                "callsites": {
-                  "version": "0.2.0",
-                  "from": "callsites@>=0.2.0 <0.3.0",
-                  "resolved": "http://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz"
-                }
-              }
-            },
-            "resolve-from": {
-              "version": "1.0.1",
-              "from": "resolve-from@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz"
-            }
-          }
-        },
-        "shelljs": {
-          "version": "0.7.8",
-          "from": "shelljs@>=0.7.5 <0.8.0",
-          "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
-          "dependencies": {
-            "interpret": {
-              "version": "1.0.3",
-              "from": "interpret@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz"
-            },
-            "rechoir": {
-              "version": "0.6.2",
-              "from": "rechoir@>=0.6.2 <0.7.0",
-              "resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-              "dependencies": {
-                "resolve": {
-                  "version": "1.3.3",
-                  "from": "resolve@>=1.1.6 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-                  "dependencies": {
-                    "path-parse": {
-                      "version": "1.0.5",
-                      "from": "path-parse@>=1.0.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
         "strip-bom": {
           "version": "3.0.0",
           "from": "strip-bom@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz"
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.1 <2.1.0",
-          "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-        },
-        "table": {
-          "version": "3.8.3",
-          "from": "table@>=3.7.8 <4.0.0",
-          "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
-          "dependencies": {
-            "ajv": {
-              "version": "4.11.8",
-              "from": "ajv@>=4.7.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-              "dependencies": {
-                "co": {
-                  "version": "4.6.0",
-                  "from": "co@>=4.6.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                }
-              }
-            },
-            "ajv-keywords": {
-              "version": "1.5.1",
-              "from": "ajv-keywords@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz"
-            },
-            "slice-ansi": {
-              "version": "0.0.4",
-              "from": "slice-ansi@0.0.4",
-              "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz"
-            },
-            "string-width": {
-              "version": "2.1.1",
-              "from": "string-width@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-              "dependencies": {
-                "is-fullwidth-code-point": {
-                  "version": "2.0.0",
-                  "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz"
-                },
-                "strip-ansi": {
-                  "version": "4.0.0",
-                  "from": "strip-ansi@>=4.0.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "3.0.0",
-                      "from": "ansi-regex@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "text-table": {
-          "version": "0.2.0",
-          "from": "text-table@>=0.2.0 <0.3.0",
-          "resolved": "http://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
-        },
-        "user-home": {
-          "version": "2.0.0",
-          "from": "user-home@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-          "dependencies": {
-            "os-homedir": {
-              "version": "1.0.2",
-              "from": "os-homedir@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-            }
-          }
+          "resolved": "http://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "dev": true
         }
       }
     },
@@ -6946,229 +1553,1444 @@
       "version": "6.10.3",
       "from": "eslint-plugin-react@>=6.7.1 <7.0.0",
       "resolved": "http://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
+      "dev": true,
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "from": "doctrine@>=1.2.2 <2.0.0",
           "resolved": "http://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
-          "dependencies": {
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "isarray": {
-              "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-            }
-          }
-        },
-        "has": {
-          "version": "1.0.1",
-          "from": "has@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            }
-          }
-        },
-        "jsx-ast-utils": {
-          "version": "1.4.1",
-          "from": "jsx-ast-utils@>=1.3.4 <2.0.0",
-          "resolved": "http://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz"
-        },
-        "array.prototype.find": {
-          "version": "2.0.4",
-          "from": "array.prototype.find@>=2.0.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
-          "dependencies": {
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                },
-                "object-keys": {
-                  "version": "1.0.11",
-                  "from": "object-keys@>=1.0.8 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-                }
-              }
-            },
-            "es-abstract": {
-              "version": "1.7.0",
-              "from": "es-abstract@>=1.7.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-              "dependencies": {
-                "function-bind": {
-                  "version": "1.1.0",
-                  "from": "function-bind@>=1.1.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-                },
-                "is-callable": {
-                  "version": "1.1.3",
-                  "from": "is-callable@>=1.1.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz"
-                },
-                "es-to-primitive": {
-                  "version": "1.1.1",
-                  "from": "es-to-primitive@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
-                  "dependencies": {
-                    "is-date-object": {
-                      "version": "1.0.1",
-                      "from": "is-date-object@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz"
-                    },
-                    "is-symbol": {
-                      "version": "1.0.1",
-                      "from": "is-symbol@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-regex": {
-                  "version": "1.0.4",
-                  "from": "is-regex@>=1.0.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz"
-                }
-              }
-            }
-          }
-        },
-        "object.assign": {
-          "version": "4.0.4",
-          "from": "object.assign@>=4.0.4 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
-          "dependencies": {
-            "function-bind": {
-              "version": "1.1.0",
-              "from": "function-bind@>=1.1.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
-            },
-            "object-keys": {
-              "version": "1.0.11",
-              "from": "object-keys@>=1.0.10 <2.0.0",
-              "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz"
-            },
-            "define-properties": {
-              "version": "1.1.2",
-              "from": "define-properties@>=1.1.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
-              "dependencies": {
-                "foreach": {
-                  "version": "2.0.5",
-                  "from": "foreach@>=2.0.5 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
-                }
-              }
-            }
-          }
+          "dev": true
         }
       }
+    },
+    "espree": {
+      "version": "3.4.3",
+      "from": "espree@>=3.4.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "acorn": {
+          "version": "5.1.1",
+          "from": "acorn@>=5.0.1 <6.0.0",
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "esprima": {
+      "version": "2.7.3",
+      "from": "esprima@>=2.6.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
+    },
+    "esquery": {
+      "version": "1.0.0",
+      "from": "esquery@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+      "dev": true
+    },
+    "esrecurse": {
+      "version": "4.2.0",
+      "from": "esrecurse@>=4.1.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
+      "dev": true
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "from": "estraverse@>=4.2.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "from": "esutils@>=2.0.2 <3.0.0",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+    },
+    "etag": {
+      "version": "1.8.0",
+      "from": "etag@>=1.8.0 <1.9.0",
+      "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
+    },
+    "event-emitter": {
+      "version": "0.3.5",
+      "from": "event-emitter@>=0.3.5 <0.4.0",
+      "resolved": "http://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+      "dev": true
+    },
+    "eventemitter3": {
+      "version": "1.2.0",
+      "from": "eventemitter3@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
+    },
+    "events": {
+      "version": "1.1.1",
+      "from": "events@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
+    },
+    "eventsource": {
+      "version": "0.1.6",
+      "from": "eventsource@0.1.6",
+      "resolved": "http://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz"
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "from": "exit-hook@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "dev": true
+    },
+    "expand-brackets": {
+      "version": "0.1.5",
+      "from": "expand-brackets@>=0.1.4 <0.2.0",
+      "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz"
+    },
+    "expand-range": {
+      "version": "1.8.2",
+      "from": "expand-range@>=1.8.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz"
+    },
+    "express": {
+      "version": "4.15.3",
+      "from": "express@>=4.13.3 <5.0.0",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "from": "debug@2.6.7",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
+        }
+      }
+    },
+    "extend": {
+      "version": "3.0.1",
+      "from": "extend@>=3.0.0 <3.1.0",
+      "resolved": "http://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+    },
+    "extglob": {
+      "version": "0.3.2",
+      "from": "extglob@>=0.3.1 <0.4.0",
+      "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
     },
     "extract-text-webpack-plugin": {
       "version": "1.0.1",
       "from": "extract-text-webpack-plugin@>=1.0.1 <2.0.0",
-      "resolved": "http://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/extract-text-webpack-plugin/-/extract-text-webpack-plugin-1.0.1.tgz"
+    },
+    "extsprintf": {
+      "version": "1.0.2",
+      "from": "extsprintf@1.0.2",
+      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
+      "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "dev": true
+    },
+    "fastparse": {
+      "version": "1.1.1",
+      "from": "fastparse@>=1.1.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/fastparse/-/fastparse-1.1.1.tgz"
+    },
+    "faye-websocket": {
+      "version": "0.10.0",
+      "from": "faye-websocket@>=0.10.0 <0.11.0",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz"
+    },
+    "fbjs": {
+      "version": "0.8.14",
+      "from": "fbjs@>=0.8.9 <0.9.0",
+      "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.14.tgz",
       "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.5.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.3 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "webpack-sources": {
-          "version": "0.1.5",
-          "from": "webpack-sources@>=0.1.0 <0.2.0",
-          "resolved": "http://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.3 <0.6.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "source-list-map": {
-              "version": "0.1.8",
-              "from": "source-list-map@>=0.1.7 <0.2.0",
-              "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
-            }
-          }
+        "core-js": {
+          "version": "1.2.7",
+          "from": "core-js@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
         }
       }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "from": "figures@>=1.3.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "dev": true
+    },
+    "file-entry-cache": {
+      "version": "2.0.0",
+      "from": "file-entry-cache@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+      "dev": true
     },
     "file-loader": {
       "version": "0.9.0",
       "from": "file-loader@>=0.9.0 <0.10.0",
-      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz",
+      "resolved": "http://registry.npmjs.org/file-loader/-/file-loader-0.9.0.tgz"
+    },
+    "filename-regex": {
+      "version": "2.0.1",
+      "from": "filename-regex@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
+    },
+    "filesize": {
+      "version": "3.5.10",
+      "from": "filesize@>=3.5.9 <4.0.0",
+      "resolved": "http://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz",
+      "dev": true
+    },
+    "fill-range": {
+      "version": "2.2.3",
+      "from": "fill-range@>=2.1.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
+    },
+    "finalhandler": {
+      "version": "1.0.3",
+      "from": "finalhandler@>=1.0.3 <1.1.0",
+      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.5 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
+        "debug": {
+          "version": "2.6.7",
+          "from": "debug@2.6.7",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
         }
       }
+    },
+    "find-cache-dir": {
+      "version": "0.1.1",
+      "from": "find-cache-dir@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz"
+    },
+    "find-up": {
+      "version": "1.1.2",
+      "from": "find-up@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz"
+    },
+    "flat-cache": {
+      "version": "1.2.2",
+      "from": "flat-cache@>=1.2.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+      "dev": true
+    },
+    "flatten": {
+      "version": "1.0.2",
+      "from": "flatten@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/flatten/-/flatten-1.0.2.tgz"
+    },
+    "follow-redirects": {
+      "version": "0.0.7",
+      "from": "follow-redirects@0.0.7",
+      "resolved": "http://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.7.tgz"
     },
     "font-awesome": {
       "version": "4.7.0",
       "from": "font-awesome@>=4.7.0 <5.0.0",
       "resolved": "http://registry.npmjs.org/font-awesome/-/font-awesome-4.7.0.tgz"
+    },
+    "for-in": {
+      "version": "1.0.2",
+      "from": "for-in@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
+    },
+    "for-own": {
+      "version": "0.1.5",
+      "from": "for-own@>=0.1.4 <0.2.0",
+      "resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz"
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "from": "foreach@>=2.0.5 <3.0.0",
+      "resolved": "http://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "dev": true
+    },
+    "forever-agent": {
+      "version": "0.6.1",
+      "from": "forever-agent@>=0.6.1 <0.7.0",
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+    },
+    "form-data": {
+      "version": "2.1.4",
+      "from": "form-data@>=2.1.1 <2.2.0",
+      "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
+    },
+    "forwarded": {
+      "version": "0.1.0",
+      "from": "forwarded@>=0.1.0 <0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+    },
+    "fresh": {
+      "version": "0.5.0",
+      "from": "fresh@0.5.0",
+      "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "from": "fs.realpath@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+    },
+    "fsevents": {
+      "version": "1.1.2",
+      "from": "fsevents@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "from": "abbrev@1.1.0",
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "from": "ajv@4.11.8",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "from": "ansi-regex@2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "from": "aproba@1.1.1",
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz",
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "from": "are-we-there-yet@1.1.4",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "from": "asn1@0.2.3",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "from": "assert-plus@0.2.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "from": "asynckit@0.4.0",
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "from": "aws-sign2@0.6.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "from": "aws4@1.6.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@0.4.2",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "from": "bcrypt-pbkdf@1.0.1",
+          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "from": "block-stream@0.0.9",
+          "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
+        },
+        "boom": {
+          "version": "2.10.1",
+          "from": "boom@2.10.1",
+          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "from": "brace-expansion@1.1.7",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "from": "buffer-shims@1.0.0",
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "from": "caseless@0.12.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "from": "co@4.6.0",
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "from": "code-point-at@1.1.0",
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "from": "combined-stream@1.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "from": "concat-map@0.0.1",
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "from": "console-control-strings@1.1.0",
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "from": "core-util-is@1.0.2",
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "from": "cryptiles@2.0.5",
+          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "from": "dashdash@1.14.1",
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "from": "debug@2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "from": "deep-extend@0.4.2",
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "from": "delayed-stream@1.0.0",
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "from": "delegates@1.0.0",
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "from": "ecc-jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.1",
+          "from": "extend@3.0.1",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "from": "extsprintf@1.0.2",
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "from": "forever-agent@0.6.1",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "from": "form-data@2.1.4",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "from": "fs.realpath@1.0.0",
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "from": "fstream@1.0.11",
+          "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "from": "fstream-ignore@1.0.5",
+          "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz",
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "from": "gauge@2.7.4",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "from": "getpass@0.1.7",
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "from": "glob@7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "from": "graceful-fs@4.1.11",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "from": "har-schema@1.0.5",
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "from": "har-validator@4.2.1",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "from": "has-unicode@2.0.1",
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "from": "hawk@3.1.3",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "from": "http-signature@1.1.1",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "from": "inflight@1.0.6",
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "from": "inherits@2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+        },
+        "ini": {
+          "version": "1.3.4",
+          "from": "ini@1.3.4",
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "from": "is-fullwidth-code-point@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "from": "is-typedarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "from": "isarray@1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "from": "isstream@0.1.2",
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "from": "jodid25519@1.0.2",
+          "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "from": "jsbn@0.1.1",
+          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "from": "json-schema@0.2.3",
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "from": "json-stable-stringify@1.0.1",
+          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "from": "json-stringify-safe@5.0.1",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "from": "jsonify@0.0.0",
+          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "from": "jsprim@1.4.0",
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "from": "mime-db@1.27.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "from": "mime-types@2.1.15",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "from": "minimatch@3.0.4",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "from": "mkdirp@0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+        },
+        "ms": {
+          "version": "2.0.0",
+          "from": "ms@2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.36",
+          "from": "node-pre-gyp@^0.6.36",
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz",
+          "optional": true
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "from": "nopt@4.0.1",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "from": "npmlog@4.1.0",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz",
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "from": "number-is-nan@1.0.1",
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "from": "oauth-sign@0.8.2",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "from": "object-assign@4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "from": "once@1.4.0",
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "from": "os-homedir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "from": "os-tmpdir@1.0.2",
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "from": "osenv@0.1.4",
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
+          "optional": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "from": "path-is-absolute@1.0.1",
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "from": "performance-now@0.2.0",
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "from": "process-nextick-args@1.0.7",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "from": "punycode@1.4.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "from": "qs@6.4.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "from": "rc@1.2.1",
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "from": "minimist@1.2.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "from": "readable-stream@2.2.9",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
+        },
+        "request": {
+          "version": "2.81.0",
+          "from": "request@2.81.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "from": "rimraf@2.6.1",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "from": "safe-buffer@5.0.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+        },
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@5.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "from": "set-blocking@2.0.0",
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "from": "signal-exit@3.0.2",
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "from": "sntp@1.0.9",
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "from": "sshpk@1.13.0",
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "from": "assert-plus@1.0.0",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "from": "string_decoder@1.0.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "from": "string-width@1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "from": "stringstream@0.0.5",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "from": "strip-ansi@3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "from": "strip-json-comments@2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "from": "tar@2.2.1",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "from": "tar-pack@3.4.0",
+          "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz",
+          "optional": true
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "from": "tough-cookie@2.3.2",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "from": "tunnel-agent@0.6.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "from": "tweetnacl@0.14.5",
+          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "from": "uid-number@0.0.6",
+          "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz",
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "from": "util-deprecate@1.0.2",
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "from": "uuid@3.0.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "from": "verror@1.3.6",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "from": "wide-align@1.1.2",
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "from": "wrappy@1.0.2",
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+        }
+      }
+    },
+    "fstream": {
+      "version": "1.0.11",
+      "from": "fstream@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
+    },
+    "function-bind": {
+      "version": "1.1.0",
+      "from": "function-bind@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz"
+    },
+    "function.prototype.name": {
+      "version": "1.0.3",
+      "from": "function.prototype.name@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/function.prototype.name/-/function.prototype.name-1.0.3.tgz",
+      "dev": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "from": "gauge@>=2.7.3 <2.8.0",
+      "resolved": "http://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
+    },
+    "gaze": {
+      "version": "1.1.2",
+      "from": "gaze@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz"
+    },
+    "generate-function": {
+      "version": "2.0.0",
+      "from": "generate-function@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+      "dev": true
+    },
+    "generate-object-property": {
+      "version": "1.2.0",
+      "from": "generate-object-property@>=1.1.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+      "dev": true
+    },
+    "get-caller-file": {
+      "version": "1.0.2",
+      "from": "get-caller-file@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
+    },
+    "get-stdin": {
+      "version": "4.0.1",
+      "from": "get-stdin@>=4.0.1 <5.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+    },
+    "getpass": {
+      "version": "0.1.7",
+      "from": "getpass@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "glob": {
+      "version": "7.1.2",
+      "from": "glob@>=7.0.3 <8.0.0",
+      "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+    },
+    "glob-base": {
+      "version": "0.3.0",
+      "from": "glob-base@>=0.3.0 <0.4.0",
+      "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
+    },
+    "glob-parent": {
+      "version": "2.0.0",
+      "from": "glob-parent@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
+    },
+    "global": {
+      "version": "4.3.2",
+      "from": "global@>=4.3.0 <4.4.0",
+      "resolved": "http://registry.npmjs.org/global/-/global-4.3.2.tgz"
+    },
+    "globals": {
+      "version": "9.18.0",
+      "from": "globals@>=9.0.0 <10.0.0",
+      "resolved": "http://registry.npmjs.org/globals/-/globals-9.18.0.tgz"
+    },
+    "globby": {
+      "version": "5.0.0",
+      "from": "globby@>=5.0.0 <6.0.0",
+      "resolved": "http://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+      "dev": true
+    },
+    "globule": {
+      "version": "1.2.0",
+      "from": "globule@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/globule/-/globule-1.2.0.tgz"
+    },
+    "graceful-fs": {
+      "version": "4.1.11",
+      "from": "graceful-fs@>=4.1.2 <5.0.0",
+      "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+    },
+    "graceful-readlink": {
+      "version": "1.0.1",
+      "from": "graceful-readlink@>=1.0.0",
+      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+      "dev": true
+    },
+    "growl": {
+      "version": "1.9.2",
+      "from": "growl@1.9.2",
+      "resolved": "http://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "dev": true
+    },
+    "gzip-size": {
+      "version": "3.0.0",
+      "from": "gzip-size@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
+      "dev": true
+    },
+    "har-schema": {
+      "version": "1.0.5",
+      "from": "har-schema@>=1.0.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+    },
+    "har-validator": {
+      "version": "4.2.1",
+      "from": "har-validator@>=4.2.1 <4.3.0",
+      "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
+    },
+    "has": {
+      "version": "1.0.1",
+      "from": "has@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/has/-/has-1.0.1.tgz"
+    },
+    "has-ansi": {
+      "version": "2.0.0",
+      "from": "has-ansi@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz"
+    },
+    "has-flag": {
+      "version": "1.0.0",
+      "from": "has-flag@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "from": "has-unicode@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
+    },
+    "hawk": {
+      "version": "3.1.3",
+      "from": "hawk@>=3.1.3 <3.2.0",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
+    },
+    "history": {
+      "version": "3.3.0",
+      "from": "history@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/history/-/history-3.3.0.tgz"
+    },
+    "hoek": {
+      "version": "2.16.3",
+      "from": "hoek@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+    },
+    "hoist-non-react-statics": {
+      "version": "1.2.0",
+      "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
+    },
+    "home-or-tmp": {
+      "version": "2.0.0",
+      "from": "home-or-tmp@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz"
+    },
+    "hosted-git-info": {
+      "version": "2.5.0",
+      "from": "hosted-git-info@>=2.1.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
+    },
+    "html-comment-regex": {
+      "version": "1.1.1",
+      "from": "html-comment-regex@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/html-comment-regex/-/html-comment-regex-1.1.1.tgz"
+    },
+    "html-encoding-sniffer": {
+      "version": "1.0.1",
+      "from": "html-encoding-sniffer@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz",
+      "dev": true
+    },
+    "htmlparser2": {
+      "version": "3.9.2",
+      "from": "htmlparser2@>=3.9.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/htmlparser2/-/htmlparser2-3.9.2.tgz",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.1",
+      "from": "http-errors@>=1.6.1 <1.7.0",
+      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz"
+    },
+    "http-proxy": {
+      "version": "1.16.2",
+      "from": "http-proxy@>=1.16.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz"
+    },
+    "http-proxy-middleware": {
+      "version": "0.17.4",
+      "from": "http-proxy-middleware@>=0.17.1 <0.18.0",
+      "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
+      "dependencies": {
+        "is-extglob": {
+          "version": "2.1.1",
+          "from": "is-extglob@>=2.1.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
+        },
+        "is-glob": {
+          "version": "3.1.0",
+          "from": "is-glob@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz"
+        }
+      }
+    },
+    "http-signature": {
+      "version": "1.1.1",
+      "from": "http-signature@>=1.1.0 <1.2.0",
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
+    },
+    "https-browserify": {
+      "version": "0.0.1",
+      "from": "https-browserify@0.0.1",
+      "resolved": "http://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
+    },
+    "iconv-lite": {
+      "version": "0.4.18",
+      "from": "iconv-lite@>=0.4.13 <0.5.0",
+      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
+    },
+    "icss-replace-symbols": {
+      "version": "1.1.0",
+      "from": "icss-replace-symbols@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/icss-replace-symbols/-/icss-replace-symbols-1.1.0.tgz"
+    },
+    "ieee754": {
+      "version": "1.1.8",
+      "from": "ieee754@>=1.1.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
+    },
+    "ignore": {
+      "version": "3.3.3",
+      "from": "ignore@>=3.2.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+      "dev": true
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "from": "imurmurhash@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "dev": true
+    },
+    "in-publish": {
+      "version": "2.0.0",
+      "from": "in-publish@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
+    },
+    "indent-string": {
+      "version": "2.1.0",
+      "from": "indent-string@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz"
+    },
+    "indexes-of": {
+      "version": "1.0.1",
+      "from": "indexes-of@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz"
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "from": "indexof@0.0.1",
+      "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "from": "inflight@>=1.0.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "from": "inherits@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+    },
+    "inquirer": {
+      "version": "0.12.0",
+      "from": "inquirer@>=0.12.0 <0.13.0",
+      "resolved": "http://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+      "dev": true
+    },
+    "interpret": {
+      "version": "0.6.6",
+      "from": "interpret@>=0.6.4 <0.7.0",
+      "resolved": "http://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
+    },
+    "invariant": {
+      "version": "2.2.2",
+      "from": "invariant@>=2.2.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
+    },
+    "invert-kv": {
+      "version": "1.0.0",
+      "from": "invert-kv@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
+    },
+    "ipaddr.js": {
+      "version": "1.4.0",
+      "from": "ipaddr.js@1.4.0",
+      "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz"
+    },
+    "is-absolute-url": {
+      "version": "2.1.0",
+      "from": "is-absolute-url@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-absolute-url/-/is-absolute-url-2.1.0.tgz"
+    },
+    "is-arrayish": {
+      "version": "0.2.1",
+      "from": "is-arrayish@>=0.2.1 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+    },
+    "is-binary-path": {
+      "version": "1.0.1",
+      "from": "is-binary-path@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz"
+    },
+    "is-buffer": {
+      "version": "1.1.5",
+      "from": "is-buffer@>=1.1.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
+    },
+    "is-builtin-module": {
+      "version": "1.0.0",
+      "from": "is-builtin-module@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz"
+    },
+    "is-callable": {
+      "version": "1.1.3",
+      "from": "is-callable@>=1.1.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
+      "dev": true
+    },
+    "is-date-object": {
+      "version": "1.0.1",
+      "from": "is-date-object@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
+      "dev": true
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "from": "is-directory@>=0.3.1 <0.4.0",
+      "resolved": "http://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz"
+    },
+    "is-dotfile": {
+      "version": "1.0.3",
+      "from": "is-dotfile@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
+    },
+    "is-equal-shallow": {
+      "version": "0.1.3",
+      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
+      "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
+    },
+    "is-extendable": {
+      "version": "0.1.1",
+      "from": "is-extendable@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
+    },
+    "is-extglob": {
+      "version": "1.0.0",
+      "from": "is-extglob@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
+    },
+    "is-finite": {
+      "version": "1.0.2",
+      "from": "is-finite@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz"
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
+    },
+    "is-glob": {
+      "version": "2.0.1",
+      "from": "is-glob@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
+    },
+    "is-my-json-valid": {
+      "version": "2.16.0",
+      "from": "is-my-json-valid@>=2.10.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+      "dev": true
+    },
+    "is-number": {
+      "version": "2.1.0",
+      "from": "is-number@>=2.1.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
+    },
+    "is-path-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-cwd@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "dev": true
+    },
+    "is-path-in-cwd": {
+      "version": "1.0.0",
+      "from": "is-path-in-cwd@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+      "dev": true
+    },
+    "is-path-inside": {
+      "version": "1.0.0",
+      "from": "is-path-inside@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+      "dev": true
+    },
+    "is-plain-obj": {
+      "version": "1.1.0",
+      "from": "is-plain-obj@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz"
+    },
+    "is-posix-bracket": {
+      "version": "0.1.1",
+      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
+    },
+    "is-primitive": {
+      "version": "2.0.0",
+      "from": "is-primitive@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "from": "is-property@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "dev": true
+    },
+    "is-regex": {
+      "version": "1.0.4",
+      "from": "is-regex@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
+      "dev": true
+    },
+    "is-resolvable": {
+      "version": "1.0.0",
+      "from": "is-resolvable@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+      "dev": true
+    },
+    "is-stream": {
+      "version": "1.1.0",
+      "from": "is-stream@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "from": "is-subset@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "dev": true
+    },
+    "is-svg": {
+      "version": "2.1.0",
+      "from": "is-svg@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/is-svg/-/is-svg-2.1.0.tgz"
+    },
+    "is-symbol": {
+      "version": "1.0.1",
+      "from": "is-symbol@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
+      "dev": true
+    },
+    "is-typedarray": {
+      "version": "1.0.0",
+      "from": "is-typedarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+    },
+    "is-utf8": {
+      "version": "0.2.1",
+      "from": "is-utf8@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "from": "isarray@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "from": "isexe@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "from": "isobject@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz"
+    },
+    "isomorphic-fetch": {
+      "version": "2.2.1",
+      "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz"
+    },
+    "isstream": {
+      "version": "0.1.2",
+      "from": "isstream@>=0.1.2 <0.2.0",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
     },
     "jquery": {
       "version": "3.2.1",
@@ -7180,2068 +3002,940 @@
       "from": "jquery-ujs@>=1.2.2 <2.0.0",
       "resolved": "http://registry.npmjs.org/jquery-ujs/-/jquery-ujs-1.2.2.tgz"
     },
+    "js-base64": {
+      "version": "2.1.9",
+      "from": "js-base64@>=2.1.9 <3.0.0",
+      "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
+    },
+    "js-tokens": {
+      "version": "3.0.2",
+      "from": "js-tokens@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
+    },
+    "js-yaml": {
+      "version": "3.7.0",
+      "from": "js-yaml@>=3.7.0 <3.8.0",
+      "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.7.0.tgz"
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "from": "jsbn@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "optional": true
+    },
     "jsdom": {
       "version": "9.12.0",
       "from": "jsdom@>=9.8.3 <10.0.0",
       "resolved": "http://registry.npmjs.org/jsdom/-/jsdom-9.12.0.tgz",
+      "dev": true,
       "dependencies": {
-        "abab": {
-          "version": "1.0.3",
-          "from": "abab@>=1.0.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/abab/-/abab-1.0.3.tgz"
-        },
         "acorn": {
           "version": "4.0.13",
           "from": "acorn@>=4.0.4 <5.0.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz"
-        },
-        "acorn-globals": {
-          "version": "3.1.0",
-          "from": "acorn-globals@>=3.1.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/acorn-globals/-/acorn-globals-3.1.0.tgz"
-        },
-        "array-equal": {
-          "version": "1.0.0",
-          "from": "array-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz"
-        },
-        "content-type-parser": {
-          "version": "1.0.1",
-          "from": "content-type-parser@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.1.tgz"
-        },
-        "cssom": {
-          "version": "0.3.2",
-          "from": "cssom@>=0.3.2 <0.4.0",
-          "resolved": "http://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz"
-        },
-        "cssstyle": {
-          "version": "0.2.37",
-          "from": "cssstyle@>=0.2.37 <0.3.0",
-          "resolved": "http://registry.npmjs.org/cssstyle/-/cssstyle-0.2.37.tgz"
-        },
-        "escodegen": {
-          "version": "1.8.1",
-          "from": "escodegen@>=1.6.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-          "dependencies": {
-            "estraverse": {
-              "version": "1.9.3",
-              "from": "estraverse@>=1.9.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
-            },
-            "esutils": {
-              "version": "2.0.2",
-              "from": "esutils@>=2.0.2 <3.0.0",
-              "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
-            },
-            "esprima": {
-              "version": "2.7.3",
-              "from": "esprima@>=2.7.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz"
-            },
-            "optionator": {
-              "version": "0.8.2",
-              "from": "optionator@>=0.8.1 <0.9.0",
-              "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-              "dependencies": {
-                "prelude-ls": {
-                  "version": "1.1.2",
-                  "from": "prelude-ls@>=1.1.2 <1.2.0",
-                  "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
-                },
-                "deep-is": {
-                  "version": "0.1.3",
-                  "from": "deep-is@>=0.1.3 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
-                },
-                "wordwrap": {
-                  "version": "1.0.0",
-                  "from": "wordwrap@>=1.0.0 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
-                },
-                "type-check": {
-                  "version": "0.3.2",
-                  "from": "type-check@>=0.3.2 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
-                },
-                "levn": {
-                  "version": "0.3.0",
-                  "from": "levn@>=0.3.0 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
-                },
-                "fast-levenshtein": {
-                  "version": "2.0.6",
-                  "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
-                }
-              }
-            },
-            "source-map": {
-              "version": "0.2.0",
-              "from": "source-map@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "html-encoding-sniffer": {
-          "version": "1.0.1",
-          "from": "html-encoding-sniffer@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.1.tgz"
-        },
-        "nwmatcher": {
-          "version": "1.4.1",
-          "from": "nwmatcher@>=1.3.9 <2.0.0",
-          "resolved": "http://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz"
-        },
-        "parse5": {
-          "version": "1.5.1",
-          "from": "parse5@>=1.5.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz"
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@>=2.61.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@>=0.12.0 <0.13.0",
-              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "http://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "from": "form-data@>=2.1.1 <2.2.0",
-              "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "from": "har-validator@>=4.2.1 <4.3.0",
-              "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.8",
-                  "from": "ajv@>=4.9.1 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@>=4.6.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "from": "jsonify@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "from": "har-schema@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
-                      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.16",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.29.0",
-                  "from": "mime-db@>=1.29.0 <1.30.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "from": "performance-now@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@>=6.4.0 <6.5.0",
-              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "from": "safe-buffer@>=5.0.1 <6.0.0",
-              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@>=0.6.0 <0.7.0",
-              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "from": "uuid@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-            }
-          }
-        },
-        "sax": {
-          "version": "1.2.4",
-          "from": "sax@>=1.2.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
-        },
-        "symbol-tree": {
-          "version": "3.2.2",
-          "from": "symbol-tree@>=3.2.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz"
-        },
-        "tough-cookie": {
-          "version": "2.3.2",
-          "from": "tough-cookie@>=2.3.2 <3.0.0",
-          "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-          "dependencies": {
-            "punycode": {
-              "version": "1.4.1",
-              "from": "punycode@>=1.4.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            }
-          }
-        },
-        "webidl-conversions": {
-          "version": "4.0.1",
-          "from": "webidl-conversions@>=4.0.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz"
-        },
-        "whatwg-encoding": {
-          "version": "1.0.1",
-          "from": "whatwg-encoding@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
-          "dependencies": {
-            "iconv-lite": {
-              "version": "0.4.13",
-              "from": "iconv-lite@0.4.13",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
-            }
-          }
-        },
-        "whatwg-url": {
-          "version": "4.8.0",
-          "from": "whatwg-url@>=4.3.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
-          "dependencies": {
-            "tr46": {
-              "version": "0.0.3",
-              "from": "tr46@>=0.0.3 <0.1.0",
-              "resolved": "http://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
-            },
-            "webidl-conversions": {
-              "version": "3.0.1",
-              "from": "webidl-conversions@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz"
-            }
-          }
-        },
-        "xml-name-validator": {
-          "version": "2.0.1",
-          "from": "xml-name-validator@>=2.0.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz"
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
+          "dev": true
         }
       }
+    },
+    "jsesc": {
+      "version": "1.3.0",
+      "from": "jsesc@>=1.3.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz"
+    },
+    "json-schema": {
+      "version": "0.2.3",
+      "from": "json-schema@0.2.3",
+      "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+    },
+    "json-schema-ref-parser": {
+      "version": "1.4.1",
+      "from": "json-schema-ref-parser@>=1.4.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz"
+    },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
+    },
+    "json-stringify-safe": {
+      "version": "5.0.1",
+      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+    },
+    "json3": {
+      "version": "3.3.2",
+      "from": "json3@>=3.3.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
+    },
+    "json5": {
+      "version": "0.5.1",
+      "from": "json5@>=0.5.0 <0.6.0",
+      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "from": "jsonify@>=0.0.0 <0.1.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+    },
+    "jsonpointer": {
+      "version": "4.0.1",
+      "from": "jsonpointer@>=4.0.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+      "dev": true
+    },
+    "jsprim": {
+      "version": "1.4.0",
+      "from": "jsprim@>=1.2.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@1.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+        }
+      }
+    },
+    "jsx-ast-utils": {
+      "version": "1.4.1",
+      "from": "jsx-ast-utils@>=1.3.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-1.4.1.tgz",
+      "dev": true
+    },
+    "keycode": {
+      "version": "2.1.9",
+      "from": "keycode@>=2.1.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz"
+    },
+    "kind-of": {
+      "version": "3.2.2",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
+    },
+    "lcid": {
+      "version": "1.0.0",
+      "from": "lcid@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz"
+    },
+    "levn": {
+      "version": "0.3.0",
+      "from": "levn@>=0.3.0 <0.4.0",
+      "resolved": "http://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "dev": true
+    },
+    "load-json-file": {
+      "version": "1.1.0",
+      "from": "load-json-file@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz"
+    },
+    "loader-utils": {
+      "version": "0.2.17",
+      "from": "loader-utils@>=0.2.16 <0.3.0",
+      "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz"
     },
     "lodash": {
       "version": "4.17.4",
       "from": "lodash@>=4.17.4 <5.0.0",
       "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
     },
+    "lodash-es": {
+      "version": "4.17.4",
+      "from": "lodash-es@>=4.2.1 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
+    },
+    "lodash._baseassign": {
+      "version": "3.2.0",
+      "from": "lodash._baseassign@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz"
+    },
+    "lodash._basecopy": {
+      "version": "3.0.1",
+      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
+    },
+    "lodash._basecreate": {
+      "version": "3.0.3",
+      "from": "lodash._basecreate@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz",
+      "dev": true
+    },
+    "lodash._bindcallback": {
+      "version": "3.0.1",
+      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
+    },
+    "lodash._createassigner": {
+      "version": "3.1.1",
+      "from": "lodash._createassigner@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz"
+    },
+    "lodash._createcompounder": {
+      "version": "3.0.0",
+      "from": "lodash._createcompounder@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash._createcompounder/-/lodash._createcompounder-3.0.0.tgz"
+    },
+    "lodash._getnative": {
+      "version": "3.9.1",
+      "from": "lodash._getnative@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
+    },
+    "lodash._isiterateecall": {
+      "version": "3.0.9",
+      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
+    },
+    "lodash._root": {
+      "version": "3.0.1",
+      "from": "lodash._root@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash._root/-/lodash._root-3.0.1.tgz"
+    },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "from": "lodash.assign@>=4.2.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+    },
+    "lodash.assignin": {
+      "version": "4.2.0",
+      "from": "lodash.assignin@>=4.0.9 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "dev": true
+    },
+    "lodash.bind": {
+      "version": "4.2.1",
+      "from": "lodash.bind@>=4.1.4 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.bind/-/lodash.bind-4.2.1.tgz",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "3.0.1",
+      "from": "lodash.camelcase@>=3.0.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-3.0.1.tgz"
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
+    },
+    "lodash.create": {
+      "version": "3.1.1",
+      "from": "lodash.create@3.1.1",
+      "resolved": "http://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
+      "dev": true
+    },
+    "lodash.deburr": {
+      "version": "3.2.0",
+      "from": "lodash.deburr@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.deburr/-/lodash.deburr-3.2.0.tgz"
+    },
+    "lodash.defaults": {
+      "version": "4.2.0",
+      "from": "lodash.defaults@>=4.2.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
+    },
+    "lodash.filter": {
+      "version": "4.6.0",
+      "from": "lodash.filter@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.filter/-/lodash.filter-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "from": "lodash.flatten@>=4.2.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "dev": true
+    },
+    "lodash.foreach": {
+      "version": "4.5.0",
+      "from": "lodash.foreach@>=4.3.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.foreach/-/lodash.foreach-4.5.0.tgz",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "from": "lodash.get@>=4.1.2 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
+    },
+    "lodash.isarguments": {
+      "version": "3.1.0",
+      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
+    },
+    "lodash.isarray": {
+      "version": "3.0.4",
+      "from": "lodash.isarray@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "from": "lodash.isequal@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
+    },
+    "lodash.keys": {
+      "version": "3.1.2",
+      "from": "lodash.keys@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz"
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "from": "lodash.map@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.memoize": {
+      "version": "4.1.2",
+      "from": "lodash.memoize@>=4.1.2 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz"
+    },
+    "lodash.merge": {
+      "version": "4.6.0",
+      "from": "lodash.merge@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "from": "lodash.pick@>=4.2.1 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "dev": true
+    },
+    "lodash.reduce": {
+      "version": "4.6.0",
+      "from": "lodash.reduce@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.reduce/-/lodash.reduce-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.reject": {
+      "version": "4.6.0",
+      "from": "lodash.reject@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.reject/-/lodash.reject-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.restparam": {
+      "version": "3.6.1",
+      "from": "lodash.restparam@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
+    },
+    "lodash.some": {
+      "version": "4.6.0",
+      "from": "lodash.some@>=4.4.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
+      "dev": true
+    },
+    "lodash.uniq": {
+      "version": "4.5.0",
+      "from": "lodash.uniq@>=4.5.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz"
+    },
+    "lodash.words": {
+      "version": "3.2.0",
+      "from": "lodash.words@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/lodash.words/-/lodash.words-3.2.0.tgz"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+    },
+    "loose-envify": {
+      "version": "1.3.1",
+      "from": "loose-envify@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz"
+    },
+    "loud-rejection": {
+      "version": "1.6.0",
+      "from": "loud-rejection@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz"
+    },
+    "lru-cache": {
+      "version": "4.1.1",
+      "from": "lru-cache@>=4.0.1 <5.0.0",
+      "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz"
+    },
+    "macaddress": {
+      "version": "0.2.8",
+      "from": "macaddress@>=0.2.8 <0.3.0",
+      "resolved": "http://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz"
+    },
+    "map-obj": {
+      "version": "1.0.1",
+      "from": "map-obj@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+    },
+    "math-expression-evaluator": {
+      "version": "1.2.17",
+      "from": "math-expression-evaluator@>=1.2.14 <2.0.0",
+      "resolved": "http://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz"
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "from": "media-typer@0.3.0",
+      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+    },
+    "memory-fs": {
+      "version": "0.3.0",
+      "from": "memory-fs@>=0.3.0 <0.4.0",
+      "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz"
+    },
+    "meow": {
+      "version": "3.7.0",
+      "from": "meow@>=3.7.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@>=1.1.3 <2.0.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+        }
+      }
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "from": "merge-descriptors@1.0.1",
+      "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+    },
+    "methods": {
+      "version": "1.1.2",
+      "from": "methods@>=1.1.2 <1.2.0",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+    },
+    "micromatch": {
+      "version": "2.3.11",
+      "from": "micromatch@>=2.1.5 <3.0.0",
+      "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz"
+    },
+    "mime": {
+      "version": "1.3.4",
+      "from": "mime@1.3.4",
+      "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
+    },
+    "mime-db": {
+      "version": "1.29.0",
+      "from": "mime-db@>=1.29.0 <1.30.0",
+      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
+    },
+    "mime-types": {
+      "version": "2.1.16",
+      "from": "mime-types@>=2.1.7 <2.2.0",
+      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz"
+    },
+    "min-document": {
+      "version": "2.19.0",
+      "from": "min-document@>=2.19.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz"
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "from": "minimatch@>=3.0.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "from": "minimist@0.0.8",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "from": "mkdirp@>=0.5.1 <0.6.0",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+    },
     "mocha": {
       "version": "3.4.2",
       "from": "mocha@>=3.2.0 <4.0.0",
       "resolved": "http://registry.npmjs.org/mocha/-/mocha-3.4.2.tgz",
+      "dev": true,
       "dependencies": {
-        "browser-stdout": {
-          "version": "1.3.0",
-          "from": "browser-stdout@1.3.0",
-          "resolved": "http://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz"
-        },
         "commander": {
           "version": "2.9.0",
           "from": "commander@2.9.0",
           "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-          "dependencies": {
-            "graceful-readlink": {
-              "version": "1.0.1",
-              "from": "graceful-readlink@>=1.0.0",
-              "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-            }
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.6.0",
           "from": "debug@2.6.0",
           "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.0.tgz",
-          "dependencies": {
-            "ms": {
-              "version": "0.7.2",
-              "from": "ms@0.7.2",
-              "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.2.tgz"
-            }
-          }
-        },
-        "diff": {
-          "version": "3.2.0",
-          "from": "diff@3.2.0",
-          "resolved": "http://registry.npmjs.org/diff/-/diff-3.2.0.tgz"
-        },
-        "escape-string-regexp": {
-          "version": "1.0.5",
-          "from": "escape-string-regexp@1.0.5",
-          "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+          "dev": true
         },
         "glob": {
           "version": "7.1.1",
           "from": "glob@7.1.1",
           "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=3.0.2 <4.0.0",
-              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            }
-          }
+          "dev": true
         },
-        "growl": {
-          "version": "1.9.2",
-          "from": "growl@1.9.2",
-          "resolved": "http://registry.npmjs.org/growl/-/growl-1.9.2.tgz"
-        },
-        "json3": {
-          "version": "3.3.2",
-          "from": "json3@3.3.2",
-          "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-        },
-        "lodash.create": {
-          "version": "3.1.1",
-          "from": "lodash.create@3.1.1",
-          "resolved": "http://registry.npmjs.org/lodash.create/-/lodash.create-3.1.1.tgz",
-          "dependencies": {
-            "lodash._baseassign": {
-              "version": "3.2.0",
-              "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-              "dependencies": {
-                "lodash._basecopy": {
-                  "version": "3.0.1",
-                  "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash._basecreate": {
-              "version": "3.0.3",
-              "from": "lodash._basecreate@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/lodash._basecreate/-/lodash._basecreate-3.0.3.tgz"
-            },
-            "lodash._isiterateecall": {
-              "version": "3.0.9",
-              "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@0.5.1",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
+        "ms": {
+          "version": "0.7.2",
+          "from": "ms@0.7.2",
+          "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.2.tgz",
+          "dev": true
         },
         "supports-color": {
           "version": "3.1.2",
           "from": "supports-color@3.1.2",
           "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
+          "dev": true
+        }
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "from": "ms@2.0.0",
+      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+    },
+    "multer": {
+      "version": "0.1.8",
+      "from": "multer@>=0.1.8 <0.2.0",
+      "resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+      "dependencies": {
+        "mime-db": {
+          "version": "1.12.0",
+          "from": "mime-db@>=1.12.0 <1.13.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.0.14",
+          "from": "mime-types@>=2.0.9 <2.1.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+        },
+        "mkdirp": {
+          "version": "0.3.5",
+          "from": "mkdirp@>=0.3.5 <0.4.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+        },
+        "qs": {
+          "version": "1.2.2",
+          "from": "qs@>=1.2.2 <1.3.0",
+          "resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+        },
+        "type-is": {
+          "version": "1.5.7",
+          "from": "type-is@>=1.5.2 <1.6.0",
+          "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz"
+        }
+      }
+    },
+    "mute-stream": {
+      "version": "0.0.5",
+      "from": "mute-stream@0.0.5",
+      "resolved": "http://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+      "dev": true
+    },
+    "nan": {
+      "version": "2.6.2",
+      "from": "nan@>=2.3.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "from": "natural-compare@>=1.4.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "from": "negotiator@0.6.1",
+      "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+    },
+    "nested-property": {
+      "version": "0.0.7",
+      "from": "nested-property@>=0.0.7 <0.0.8",
+      "resolved": "http://registry.npmjs.org/nested-property/-/nested-property-0.0.7.tgz"
+    },
+    "node-fetch": {
+      "version": "1.7.1",
+      "from": "node-fetch@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz"
+    },
+    "node-gyp": {
+      "version": "3.6.2",
+      "from": "node-gyp@>=3.3.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
+      "dependencies": {
+        "semver": {
+          "version": "5.3.0",
+          "from": "semver@>=5.3.0 <5.4.0",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+        }
+      }
+    },
+    "node-libs-browser": {
+      "version": "0.7.0",
+      "from": "node-libs-browser@>=0.7.0 <0.8.0",
+      "resolved": "http://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
+      "dependencies": {
+        "process": {
+          "version": "0.11.10",
+          "from": "process@>=0.11.0 <0.12.0",
+          "resolved": "http://registry.npmjs.org/process/-/process-0.11.10.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.25 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         }
       }
     },
     "node-sass": {
       "version": "3.13.1",
       "from": "node-sass@>=3.10.1 <4.0.0",
-      "resolved": "http://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz",
+      "resolved": "http://registry.npmjs.org/node-sass/-/node-sass-3.13.1.tgz"
+    },
+    "nopt": {
+      "version": "3.0.6",
+      "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+    },
+    "normalize-package-data": {
+      "version": "2.4.0",
+      "from": "normalize-package-data@>=2.3.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz"
+    },
+    "normalize-path": {
+      "version": "2.1.1",
+      "from": "normalize-path@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+    },
+    "normalize-range": {
+      "version": "0.1.2",
+      "from": "normalize-range@>=0.1.2 <0.2.0",
+      "resolved": "http://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz"
+    },
+    "normalize-url": {
+      "version": "1.9.1",
+      "from": "normalize-url@>=1.4.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz"
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "from": "npmlog@>=4.0.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz"
+    },
+    "nth-check": {
+      "version": "1.0.1",
+      "from": "nth-check@>=1.0.1 <1.1.0",
+      "resolved": "http://registry.npmjs.org/nth-check/-/nth-check-1.0.1.tgz",
+      "dev": true
+    },
+    "num2fraction": {
+      "version": "1.2.2",
+      "from": "num2fraction@>=1.2.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz"
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "from": "number-is-nan@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+    },
+    "nwmatcher": {
+      "version": "1.4.1",
+      "from": "nwmatcher@>=1.3.9 <2.0.0",
+      "resolved": "http://registry.npmjs.org/nwmatcher/-/nwmatcher-1.4.1.tgz",
+      "dev": true
+    },
+    "oauth-sign": {
+      "version": "0.8.2",
+      "from": "oauth-sign@>=0.8.1 <0.9.0",
+      "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "from": "object-assign@>=4.0.1 <5.0.0",
+      "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+    },
+    "object-is": {
+      "version": "1.0.1",
+      "from": "object-is@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
+      "dev": true
+    },
+    "object-keys": {
+      "version": "1.0.11",
+      "from": "object-keys@>=1.0.8 <2.0.0",
+      "resolved": "http://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
+      "dev": true
+    },
+    "object.assign": {
+      "version": "4.0.4",
+      "from": "object.assign@>=4.0.4 <5.0.0",
+      "resolved": "http://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
+      "dev": true
+    },
+    "object.entries": {
+      "version": "1.0.4",
+      "from": "object.entries@>=1.0.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/object.entries/-/object.entries-1.0.4.tgz",
+      "dev": true
+    },
+    "object.omit": {
+      "version": "2.0.1",
+      "from": "object.omit@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz"
+    },
+    "object.values": {
+      "version": "1.0.4",
+      "from": "object.values@>=1.0.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "from": "on-finished@>=2.3.0 <2.4.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "from": "on-headers@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
+    },
+    "once": {
+      "version": "1.4.0",
+      "from": "once@>=1.3.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz"
+    },
+    "onetime": {
+      "version": "1.1.0",
+      "from": "onetime@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "dev": true
+    },
+    "ono": {
+      "version": "2.2.5",
+      "from": "ono@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/ono/-/ono-2.2.5.tgz"
+    },
+    "open": {
+      "version": "0.0.5",
+      "from": "open@0.0.5",
+      "resolved": "http://registry.npmjs.org/open/-/open-0.0.5.tgz"
+    },
+    "opener": {
+      "version": "1.4.3",
+      "from": "opener@>=1.4.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/opener/-/opener-1.4.3.tgz",
+      "dev": true
+    },
+    "optimist": {
+      "version": "0.6.1",
+      "from": "optimist@>=0.6.0 <0.7.0",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "from": "optionator@>=0.8.2 <0.9.0",
+      "resolved": "http://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "dev": true,
       "dependencies": {
-        "async-foreach": {
-          "version": "0.1.3",
-          "from": "async-foreach@>=0.1.3 <0.2.0",
-          "resolved": "https://registry.npmjs.org/async-foreach/-/async-foreach-0.1.3.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "cross-spawn": {
-          "version": "3.0.1",
-          "from": "cross-spawn@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/cross-spawn/-/cross-spawn-3.0.1.tgz",
-          "dependencies": {
-            "lru-cache": {
-              "version": "4.1.1",
-              "from": "lru-cache@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
-              "dependencies": {
-                "pseudomap": {
-                  "version": "1.0.2",
-                  "from": "pseudomap@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
-                },
-                "yallist": {
-                  "version": "2.1.2",
-                  "from": "yallist@>=2.1.2 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "from": "which@>=1.2.9 <2.0.0",
-              "resolved": "http://registry.npmjs.org/which/-/which-1.2.14.tgz",
-              "dependencies": {
-                "isexe": {
-                  "version": "2.0.0",
-                  "from": "isexe@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "gaze": {
-          "version": "1.1.2",
-          "from": "gaze@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-          "dependencies": {
-            "globule": {
-              "version": "1.2.0",
-              "from": "globule@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-              "dependencies": {
-                "minimatch": {
-                  "version": "3.0.4",
-                  "from": "minimatch@>=3.0.2 <3.1.0",
-                  "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                  "dependencies": {
-                    "brace-expansion": {
-                      "version": "1.1.8",
-                      "from": "brace-expansion@>=1.1.7 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                      "dependencies": {
-                        "balanced-match": {
-                          "version": "1.0.0",
-                          "from": "balanced-match@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                        },
-                        "concat-map": {
-                          "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
-                          "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        },
-        "get-stdin": {
-          "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
-          "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-        },
-        "glob": {
-          "version": "7.1.2",
-          "from": "glob@>=7.0.3 <8.0.0",
-          "resolved": "http://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "dependencies": {
-            "fs.realpath": {
-              "version": "1.0.0",
-              "from": "fs.realpath@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "from": "inflight@>=1.0.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=3.0.4 <4.0.0",
-              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "from": "once@>=1.3.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/once/-/once-1.4.0.tgz",
-              "dependencies": {
-                "wrappy": {
-                  "version": "1.0.2",
-                  "from": "wrappy@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                }
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            }
-          }
-        },
-        "in-publish": {
-          "version": "2.0.0",
-          "from": "in-publish@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/in-publish/-/in-publish-2.0.0.tgz"
-        },
-        "lodash.assign": {
-          "version": "4.2.0",
-          "from": "lodash.assign@>=4.2.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
-        },
-        "lodash.clonedeep": {
-          "version": "4.5.0",
-          "from": "lodash.clonedeep@>=4.3.2 <5.0.0",
-          "resolved": "http://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz"
-        },
-        "meow": {
-          "version": "3.7.0",
-          "from": "meow@>=3.7.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
-          "dependencies": {
-            "camelcase-keys": {
-              "version": "2.1.0",
-              "from": "camelcase-keys@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "2.1.1",
-                  "from": "camelcase@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
-                }
-              }
-            },
-            "decamelize": {
-              "version": "1.2.0",
-              "from": "decamelize@>=1.1.2 <2.0.0",
-              "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-            },
-            "loud-rejection": {
-              "version": "1.6.0",
-              "from": "loud-rejection@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
-              "dependencies": {
-                "currently-unhandled": {
-                  "version": "0.4.1",
-                  "from": "currently-unhandled@>=0.4.1 <0.5.0",
-                  "resolved": "http://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
-                  "dependencies": {
-                    "array-find-index": {
-                      "version": "1.0.2",
-                      "from": "array-find-index@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
-                    }
-                  }
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "from": "signal-exit@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                }
-              }
-            },
-            "map-obj": {
-              "version": "1.0.1",
-              "from": "map-obj@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
-            },
-            "minimist": {
-              "version": "1.2.0",
-              "from": "minimist@>=1.1.3 <2.0.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-            },
-            "normalize-package-data": {
-              "version": "2.4.0",
-              "from": "normalize-package-data@>=2.3.4 <3.0.0",
-              "resolved": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-              "dependencies": {
-                "hosted-git-info": {
-                  "version": "2.5.0",
-                  "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
-                },
-                "is-builtin-module": {
-                  "version": "1.0.0",
-                  "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                  "dependencies": {
-                    "builtin-modules": {
-                      "version": "1.1.1",
-                      "from": "builtin-modules@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                    }
-                  }
-                },
-                "semver": {
-                  "version": "5.4.1",
-                  "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                  "resolved": "http://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
-                },
-                "validate-npm-package-license": {
-                  "version": "3.0.1",
-                  "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                  "dependencies": {
-                    "spdx-correct": {
-                      "version": "1.0.2",
-                      "from": "spdx-correct@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                      "dependencies": {
-                        "spdx-license-ids": {
-                          "version": "1.2.2",
-                          "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                        }
-                      }
-                    },
-                    "spdx-expression-parse": {
-                      "version": "1.0.4",
-                      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            },
-            "read-pkg-up": {
-              "version": "1.0.1",
-              "from": "read-pkg-up@>=1.0.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-              "dependencies": {
-                "find-up": {
-                  "version": "1.1.2",
-                  "from": "find-up@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                  "dependencies": {
-                    "path-exists": {
-                      "version": "2.1.0",
-                      "from": "path-exists@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                    },
-                    "pinkie-promise": {
-                      "version": "2.0.1",
-                      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                      "dependencies": {
-                        "pinkie": {
-                          "version": "2.0.4",
-                          "from": "pinkie@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg": {
-                  "version": "1.1.0",
-                  "from": "read-pkg@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                  "dependencies": {
-                    "load-json-file": {
-                      "version": "1.1.0",
-                      "from": "load-json-file@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                        },
-                        "parse-json": {
-                          "version": "2.2.0",
-                          "from": "parse-json@>=2.2.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                          "dependencies": {
-                            "error-ex": {
-                              "version": "1.3.1",
-                              "from": "error-ex@>=1.2.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                              "dependencies": {
-                                "is-arrayish": {
-                                  "version": "0.2.1",
-                                  "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        },
-                        "strip-bom": {
-                          "version": "2.0.0",
-                          "from": "strip-bom@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                          "dependencies": {
-                            "is-utf8": {
-                              "version": "0.2.1",
-                              "from": "is-utf8@>=0.2.0 <0.3.0",
-                              "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "path-type": {
-                      "version": "1.1.0",
-                      "from": "path-type@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                      "dependencies": {
-                        "graceful-fs": {
-                          "version": "4.1.11",
-                          "from": "graceful-fs@>=4.1.2 <5.0.0",
-                          "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                        },
-                        "pify": {
-                          "version": "2.3.0",
-                          "from": "pify@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "redent": {
-              "version": "1.0.0",
-              "from": "redent@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
-              "dependencies": {
-                "indent-string": {
-                  "version": "2.1.0",
-                  "from": "indent-string@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
-                  "dependencies": {
-                    "repeating": {
-                      "version": "2.0.1",
-                      "from": "repeating@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
-                      "dependencies": {
-                        "is-finite": {
-                          "version": "1.0.2",
-                          "from": "is-finite@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
-                          "dependencies": {
-                            "number-is-nan": {
-                              "version": "1.0.1",
-                              "from": "number-is-nan@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-indent": {
-                  "version": "1.0.1",
-                  "from": "strip-indent@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
-                }
-              }
-            },
-            "trim-newlines": {
-              "version": "1.0.0",
-              "from": "trim-newlines@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "nan": {
-          "version": "2.6.2",
-          "from": "nan@>=2.3.2 <3.0.0",
-          "resolved": "http://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
-        },
-        "node-gyp": {
-          "version": "3.6.2",
-          "from": "node-gyp@>=3.3.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/node-gyp/-/node-gyp-3.6.2.tgz",
-          "dependencies": {
-            "fstream": {
-              "version": "1.0.11",
-              "from": "fstream@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            },
-            "minimatch": {
-              "version": "3.0.4",
-              "from": "minimatch@>=3.0.2 <4.0.0",
-              "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.8",
-                  "from": "brace-expansion@>=1.1.7 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                  "dependencies": {
-                    "balanced-match": {
-                      "version": "1.0.0",
-                      "from": "balanced-match@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "nopt": {
-              "version": "3.0.6",
-              "from": "nopt@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-              "dependencies": {
-                "abbrev": {
-                  "version": "1.1.0",
-                  "from": "abbrev@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                }
-              }
-            },
-            "osenv": {
-              "version": "0.1.4",
-              "from": "osenv@>=0.0.0 <1.0.0",
-              "resolved": "http://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz",
-              "dependencies": {
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "os-tmpdir": {
-                  "version": "1.0.2",
-                  "from": "os-tmpdir@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                }
-              }
-            },
-            "rimraf": {
-              "version": "2.6.1",
-              "from": "rimraf@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-            },
-            "semver": {
-              "version": "5.3.0",
-              "from": "semver@>=5.3.0 <5.4.0",
-              "resolved": "http://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-            },
-            "tar": {
-              "version": "2.2.1",
-              "from": "tar@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz",
-              "dependencies": {
-                "block-stream": {
-                  "version": "0.0.9",
-                  "from": "block-stream@*",
-                  "resolved": "http://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "which": {
-              "version": "1.2.14",
-              "from": "which@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/which/-/which-1.2.14.tgz",
-              "dependencies": {
-                "isexe": {
-                  "version": "2.0.0",
-                  "from": "isexe@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "from": "npmlog@>=4.0.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-          "dependencies": {
-            "are-we-there-yet": {
-              "version": "1.1.4",
-              "from": "are-we-there-yet@>=1.1.2 <1.2.0",
-              "resolved": "http://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-              "dependencies": {
-                "delegates": {
-                  "version": "1.0.0",
-                  "from": "delegates@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.0.6 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
-                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "from": "console-control-strings@>=1.1.0 <1.2.0",
-              "resolved": "http://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-            },
-            "gauge": {
-              "version": "2.7.4",
-              "from": "gauge@>=2.7.3 <2.8.0",
-              "resolved": "http://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-              "dependencies": {
-                "aproba": {
-                  "version": "1.1.2",
-                  "from": "aproba@>=1.0.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/aproba/-/aproba-1.1.2.tgz"
-                },
-                "has-unicode": {
-                  "version": "2.0.1",
-                  "from": "has-unicode@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-                },
-                "object-assign": {
-                  "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                },
-                "signal-exit": {
-                  "version": "3.0.2",
-                  "from": "signal-exit@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "from": "string-width@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "wide-align": {
-                  "version": "1.1.2",
-                  "from": "wide-align@>=1.1.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-                }
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "from": "set-blocking@>=2.0.0 <2.1.0",
-              "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-            }
-          }
-        },
-        "request": {
-          "version": "2.81.0",
-          "from": "request@>=2.61.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.6.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-            },
-            "caseless": {
-              "version": "0.12.0",
-              "from": "caseless@>=0.12.0 <0.13.0",
-              "resolved": "http://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.1",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "http://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "2.1.4",
-              "from": "form-data@>=2.1.1 <2.2.0",
-              "resolved": "http://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "http://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "4.2.1",
-              "from": "har-validator@>=4.2.1 <4.3.0",
-              "resolved": "http://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-              "dependencies": {
-                "ajv": {
-                  "version": "4.11.8",
-                  "from": "ajv@>=4.9.1 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-                  "dependencies": {
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@>=4.6.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-                      "dependencies": {
-                        "jsonify": {
-                          "version": "0.0.0",
-                          "from": "jsonify@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "har-schema": {
-                  "version": "1.0.5",
-                  "from": "har-schema@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.4.0",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                  "dependencies": {
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@1.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "http://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "http://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.13.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
-                      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.16",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.29.0",
-                  "from": "mime-db@>=1.29.0 <1.30.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                }
-              }
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "http://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "performance-now": {
-              "version": "0.2.0",
-              "from": "performance-now@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@>=6.4.0 <6.5.0",
-              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "from": "safe-buffer@>=5.0.1 <6.0.0",
-              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
-              "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.6.0",
-              "from": "tunnel-agent@>=0.6.0 <0.7.0",
-              "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-            },
-            "uuid": {
-              "version": "3.1.0",
-              "from": "uuid@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-            }
-          }
-        },
-        "sass-graph": {
-          "version": "2.2.4",
-          "from": "sass-graph@>=2.1.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz",
-          "dependencies": {
-            "scss-tokenizer": {
-              "version": "0.2.3",
-              "from": "scss-tokenizer@>=0.2.3 <0.3.0",
-              "resolved": "http://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
-              "dependencies": {
-                "js-base64": {
-                  "version": "2.1.9",
-                  "from": "js-base64@>=2.1.8 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-                },
-                "source-map": {
-                  "version": "0.4.4",
-                  "from": "source-map@>=0.4.2 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-                  "dependencies": {
-                    "amdefine": {
-                      "version": "1.0.1",
-                      "from": "amdefine@>=0.0.4",
-                      "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "yargs": {
-              "version": "7.1.0",
-              "from": "yargs@>=7.0.0 <8.0.0",
-              "resolved": "http://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "3.0.0",
-                  "from": "camelcase@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
-                },
-                "cliui": {
-                  "version": "3.2.0",
-                  "from": "cliui@>=3.2.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                  "dependencies": {
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                        }
-                      }
-                    },
-                    "wrap-ansi": {
-                      "version": "2.1.0",
-                      "from": "wrap-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "from": "decamelize@>=1.1.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "get-caller-file": {
-                  "version": "1.0.2",
-                  "from": "get-caller-file@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz"
-                },
-                "os-locale": {
-                  "version": "1.4.0",
-                  "from": "os-locale@>=1.4.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-                  "dependencies": {
-                    "lcid": {
-                      "version": "1.0.0",
-                      "from": "lcid@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-                      "dependencies": {
-                        "invert-kv": {
-                          "version": "1.0.0",
-                          "from": "invert-kv@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "read-pkg-up": {
-                  "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
-                  "dependencies": {
-                    "find-up": {
-                      "version": "1.1.2",
-                      "from": "find-up@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
-                      "dependencies": {
-                        "path-exists": {
-                          "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
-                        },
-                        "pinkie-promise": {
-                          "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                          "dependencies": {
-                            "pinkie": {
-                              "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "read-pkg": {
-                      "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
-                      "dependencies": {
-                        "load-json-file": {
-                          "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                            },
-                            "parse-json": {
-                              "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                              "dependencies": {
-                                "error-ex": {
-                                  "version": "1.3.1",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                                  "dependencies": {
-                                    "is-arrayish": {
-                                      "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            },
-                            "strip-bom": {
-                              "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
-                              "dependencies": {
-                                "is-utf8": {
-                                  "version": "0.2.1",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "normalize-package-data": {
-                          "version": "2.4.0",
-                          "from": "normalize-package-data@>=2.3.2 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-                          "dependencies": {
-                            "hosted-git-info": {
-                              "version": "2.5.0",
-                              "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz"
-                            },
-                            "is-builtin-module": {
-                              "version": "1.0.0",
-                              "from": "is-builtin-module@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-                              "dependencies": {
-                                "builtin-modules": {
-                                  "version": "1.1.1",
-                                  "from": "builtin-modules@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
-                                }
-                              }
-                            },
-                            "semver": {
-                              "version": "5.4.1",
-                              "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                              "resolved": "http://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
-                            },
-                            "validate-npm-package-license": {
-                              "version": "3.0.1",
-                              "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
-                              "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-                              "dependencies": {
-                                "spdx-correct": {
-                                  "version": "1.0.2",
-                                  "from": "spdx-correct@>=1.0.0 <1.1.0",
-                                  "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-                                  "dependencies": {
-                                    "spdx-license-ids": {
-                                      "version": "1.2.2",
-                                      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
-                                    }
-                                  }
-                                },
-                                "spdx-expression-parse": {
-                                  "version": "1.0.4",
-                                  "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                                  "resolved": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        },
-                        "path-type": {
-                          "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
-                          "dependencies": {
-                            "graceful-fs": {
-                              "version": "4.1.11",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                            },
-                            "pify": {
-                              "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
-                            },
-                            "pinkie-promise": {
-                              "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                              "dependencies": {
-                                "pinkie": {
-                                  "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                                }
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-directory": {
-                  "version": "2.1.1",
-                  "from": "require-directory@>=2.1.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
-                },
-                "require-main-filename": {
-                  "version": "1.0.1",
-                  "from": "require-main-filename@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
-                },
-                "set-blocking": {
-                  "version": "2.0.0",
-                  "from": "set-blocking@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                },
-                "string-width": {
-                  "version": "1.0.2",
-                  "from": "string-width@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                  "dependencies": {
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                      "dependencies": {
-                        "number-is-nan": {
-                          "version": "1.0.1",
-                          "from": "number-is-nan@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.1.1",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "which-module": {
-                  "version": "1.0.0",
-                  "from": "which-module@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
-                },
-                "y18n": {
-                  "version": "3.2.1",
-                  "from": "y18n@>=3.2.1 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
-                },
-                "yargs-parser": {
-                  "version": "5.0.0",
-                  "from": "yargs-parser@>=5.0.0 <6.0.0",
-                  "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz"
-                }
-              }
-            }
-          }
+        "wordwrap": {
+          "version": "1.0.0",
+          "from": "wordwrap@>=1.0.0 <1.1.0",
+          "resolved": "http://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "dev": true
         }
       }
+    },
+    "original": {
+      "version": "1.0.0",
+      "from": "original@>=0.0.5",
+      "resolved": "http://registry.npmjs.org/original/-/original-1.0.0.tgz",
+      "dependencies": {
+        "url-parse": {
+          "version": "1.0.5",
+          "from": "url-parse@>=1.0.0 <1.1.0",
+          "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz"
+        }
+      }
+    },
+    "os-browserify": {
+      "version": "0.2.1",
+      "from": "os-browserify@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "from": "os-homedir@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
+    },
+    "os-locale": {
+      "version": "1.4.0",
+      "from": "os-locale@>=1.4.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz"
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "from": "os-tmpdir@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+    },
+    "osenv": {
+      "version": "0.1.4",
+      "from": "osenv@>=0.0.0 <1.0.0",
+      "resolved": "http://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
+    },
+    "pako": {
+      "version": "0.2.9",
+      "from": "pako@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
+    },
+    "parse-glob": {
+      "version": "3.0.4",
+      "from": "parse-glob@>=3.0.4 <4.0.0",
+      "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz"
+    },
+    "parse-json": {
+      "version": "2.2.0",
+      "from": "parse-json@>=2.2.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz"
+    },
+    "parse5": {
+      "version": "1.5.1",
+      "from": "parse5@>=1.5.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/parse5/-/parse5-1.5.1.tgz",
+      "dev": true
+    },
+    "parseurl": {
+      "version": "1.3.1",
+      "from": "parseurl@>=1.3.1 <1.4.0",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
+    },
+    "path-browserify": {
+      "version": "0.0.0",
+      "from": "path-browserify@0.0.0",
+      "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
+    },
+    "path-exists": {
+      "version": "2.1.0",
+      "from": "path-exists@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "from": "path-is-absolute@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "from": "path-is-inside@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.5",
+      "from": "path-parse@>=1.0.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "from": "path-to-regexp@0.1.7",
+      "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+    },
+    "path-type": {
+      "version": "1.1.0",
+      "from": "path-type@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz"
+    },
+    "pbkdf2-compat": {
+      "version": "2.0.1",
+      "from": "pbkdf2-compat@2.0.1",
+      "resolved": "http://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
+    },
+    "performance-now": {
+      "version": "0.2.0",
+      "from": "performance-now@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+    },
+    "pify": {
+      "version": "2.3.0",
+      "from": "pify@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "from": "pinkie@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "from": "pinkie-promise@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+    },
+    "pkg-dir": {
+      "version": "1.0.0",
+      "from": "pkg-dir@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz"
+    },
+    "pluralize": {
+      "version": "1.2.1",
+      "from": "pluralize@>=1.2.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+      "dev": true
+    },
+    "postcss": {
+      "version": "5.2.17",
+      "from": "postcss@>=5.2.16 <6.0.0",
+      "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz"
+    },
+    "postcss-calc": {
+      "version": "5.3.1",
+      "from": "postcss-calc@>=5.2.0 <6.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-calc/-/postcss-calc-5.3.1.tgz"
+    },
+    "postcss-colormin": {
+      "version": "2.2.2",
+      "from": "postcss-colormin@>=2.1.8 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-colormin/-/postcss-colormin-2.2.2.tgz"
+    },
+    "postcss-convert-values": {
+      "version": "2.6.1",
+      "from": "postcss-convert-values@>=2.3.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-2.6.1.tgz"
+    },
+    "postcss-discard-comments": {
+      "version": "2.0.4",
+      "from": "postcss-discard-comments@>=2.0.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-2.0.4.tgz"
+    },
+    "postcss-discard-duplicates": {
+      "version": "2.1.0",
+      "from": "postcss-discard-duplicates@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-2.1.0.tgz"
+    },
+    "postcss-discard-empty": {
+      "version": "2.1.0",
+      "from": "postcss-discard-empty@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-2.1.0.tgz"
+    },
+    "postcss-discard-overridden": {
+      "version": "0.1.1",
+      "from": "postcss-discard-overridden@>=0.1.1 <0.2.0",
+      "resolved": "http://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-0.1.1.tgz"
+    },
+    "postcss-discard-unused": {
+      "version": "2.2.3",
+      "from": "postcss-discard-unused@>=2.2.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-discard-unused/-/postcss-discard-unused-2.2.3.tgz"
+    },
+    "postcss-filter-plugins": {
+      "version": "2.0.2",
+      "from": "postcss-filter-plugins@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz"
+    },
+    "postcss-load-config": {
+      "version": "1.2.0",
+      "from": "postcss-load-config@>=1.2.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz"
+    },
+    "postcss-load-options": {
+      "version": "1.2.0",
+      "from": "postcss-load-options@>=1.2.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz"
+    },
+    "postcss-load-plugins": {
+      "version": "2.3.0",
+      "from": "postcss-load-plugins@>=2.3.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
     },
     "postcss-loader": {
       "version": "1.3.3",
@@ -9251,325 +3945,365 @@
         "loader-utils": {
           "version": "1.1.0",
           "from": "loader-utils@>=1.0.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.1 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        },
-        "postcss": {
-          "version": "5.2.17",
-          "from": "postcss@>=5.2.15 <6.0.0",
-          "resolved": "http://registry.npmjs.org/postcss/-/postcss-5.2.17.tgz",
-          "dependencies": {
-            "chalk": {
-              "version": "1.1.3",
-              "from": "chalk@>=1.1.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-              "dependencies": {
-                "ansi-styles": {
-                  "version": "2.2.1",
-                  "from": "ansi-styles@>=2.2.1 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                },
-                "escape-string-regexp": {
-                  "version": "1.0.5",
-                  "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                },
-                "has-ansi": {
-                  "version": "2.0.0",
-                  "from": "has-ansi@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "strip-ansi": {
-                  "version": "3.0.1",
-                  "from": "strip-ansi@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                  "dependencies": {
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    }
-                  }
-                },
-                "supports-color": {
-                  "version": "2.0.0",
-                  "from": "supports-color@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                }
-              }
-            },
-            "js-base64": {
-              "version": "2.1.9",
-              "from": "js-base64@>=2.1.9 <3.0.0",
-              "resolved": "http://registry.npmjs.org/js-base64/-/js-base64-2.1.9.tgz"
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.6 <0.6.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "supports-color": {
-              "version": "3.2.3",
-              "from": "supports-color@>=3.2.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-              "dependencies": {
-                "has-flag": {
-                  "version": "1.0.0",
-                  "from": "has-flag@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "postcss-load-config": {
-          "version": "1.2.0",
-          "from": "postcss-load-config@>=1.2.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/postcss-load-config/-/postcss-load-config-1.2.0.tgz",
-          "dependencies": {
-            "cosmiconfig": {
-              "version": "2.2.2",
-              "from": "cosmiconfig@>=2.1.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
-              "dependencies": {
-                "is-directory": {
-                  "version": "0.3.1",
-                  "from": "is-directory@>=0.3.1 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz"
-                },
-                "js-yaml": {
-                  "version": "3.9.0",
-                  "from": "js-yaml@>=3.4.3 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.9",
-                      "from": "argparse@>=1.0.7 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                      "dependencies": {
-                        "sprintf-js": {
-                          "version": "1.0.3",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "4.0.0",
-                      "from": "esprima@>=4.0.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-                    }
-                  }
-                },
-                "minimist": {
-                  "version": "1.2.0",
-                  "from": "minimist@>=1.2.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                },
-                "os-homedir": {
-                  "version": "1.0.2",
-                  "from": "os-homedir@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                },
-                "parse-json": {
-                  "version": "2.2.0",
-                  "from": "parse-json@>=2.2.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-                  "dependencies": {
-                    "error-ex": {
-                      "version": "1.3.1",
-                      "from": "error-ex@>=1.2.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-                      "dependencies": {
-                        "is-arrayish": {
-                          "version": "0.2.1",
-                          "from": "is-arrayish@>=0.2.1 <0.3.0",
-                          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "require-from-string": {
-                  "version": "1.2.1",
-                  "from": "require-from-string@>=1.1.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
-                }
-              }
-            },
-            "postcss-load-options": {
-              "version": "1.2.0",
-              "from": "postcss-load-options@>=1.2.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-load-options/-/postcss-load-options-1.2.0.tgz"
-            },
-            "postcss-load-plugins": {
-              "version": "2.3.0",
-              "from": "postcss-load-plugins@>=2.3.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/postcss-load-plugins/-/postcss-load-plugins-2.3.0.tgz"
-            }
-          }
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
         }
       }
+    },
+    "postcss-merge-idents": {
+      "version": "2.1.7",
+      "from": "postcss-merge-idents@>=2.1.5 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-merge-idents/-/postcss-merge-idents-2.1.7.tgz"
+    },
+    "postcss-merge-longhand": {
+      "version": "2.0.2",
+      "from": "postcss-merge-longhand@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-2.0.2.tgz"
+    },
+    "postcss-merge-rules": {
+      "version": "2.1.2",
+      "from": "postcss-merge-rules@>=2.0.3 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-2.1.2.tgz"
+    },
+    "postcss-message-helpers": {
+      "version": "2.0.0",
+      "from": "postcss-message-helpers@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-message-helpers/-/postcss-message-helpers-2.0.0.tgz"
+    },
+    "postcss-minify-font-values": {
+      "version": "1.0.5",
+      "from": "postcss-minify-font-values@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-1.0.5.tgz"
+    },
+    "postcss-minify-gradients": {
+      "version": "1.0.5",
+      "from": "postcss-minify-gradients@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-1.0.5.tgz"
+    },
+    "postcss-minify-params": {
+      "version": "1.2.2",
+      "from": "postcss-minify-params@>=1.0.4 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-1.2.2.tgz"
+    },
+    "postcss-minify-selectors": {
+      "version": "2.1.1",
+      "from": "postcss-minify-selectors@>=2.0.4 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-2.1.1.tgz"
+    },
+    "postcss-modules-extract-imports": {
+      "version": "1.1.0",
+      "from": "postcss-modules-extract-imports@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-1.1.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "postcss": {
+          "version": "6.0.8",
+          "from": "postcss@>=6.0.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "from": "supports-color@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+        }
+      }
+    },
+    "postcss-modules-local-by-default": {
+      "version": "1.2.0",
+      "from": "postcss-modules-local-by-default@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-1.2.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz"
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
+          "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "postcss": {
+          "version": "6.0.8",
+          "from": "postcss@>=6.0.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "from": "regexpu-core@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "from": "supports-color@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+        }
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "1.1.0",
+      "from": "postcss-modules-scope@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-1.1.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz"
+        },
+        "css-selector-tokenizer": {
+          "version": "0.7.0",
+          "from": "css-selector-tokenizer@>=0.7.0 <0.8.0",
+          "resolved": "http://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.0.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "postcss": {
+          "version": "6.0.8",
+          "from": "postcss@>=6.0.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+        },
+        "regexpu-core": {
+          "version": "1.0.0",
+          "from": "regexpu-core@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz"
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "from": "supports-color@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+        }
+      }
+    },
+    "postcss-modules-values": {
+      "version": "1.3.0",
+      "from": "postcss-modules-values@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-1.3.0.tgz",
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "from": "ansi-styles@>=3.1.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz"
+        },
+        "chalk": {
+          "version": "2.0.1",
+          "from": "chalk@>=2.0.1 <3.0.0",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.0.1.tgz"
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "from": "has-flag@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz"
+        },
+        "postcss": {
+          "version": "6.0.8",
+          "from": "postcss@>=6.0.1 <7.0.0",
+          "resolved": "http://registry.npmjs.org/postcss/-/postcss-6.0.8.tgz"
+        },
+        "supports-color": {
+          "version": "4.2.1",
+          "from": "supports-color@>=4.2.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-4.2.1.tgz"
+        }
+      }
+    },
+    "postcss-normalize-charset": {
+      "version": "1.1.1",
+      "from": "postcss-normalize-charset@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-1.1.1.tgz"
+    },
+    "postcss-normalize-url": {
+      "version": "3.0.8",
+      "from": "postcss-normalize-url@>=3.0.7 <4.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-3.0.8.tgz"
+    },
+    "postcss-ordered-values": {
+      "version": "2.2.3",
+      "from": "postcss-ordered-values@>=2.1.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-2.2.3.tgz"
+    },
+    "postcss-reduce-idents": {
+      "version": "2.4.0",
+      "from": "postcss-reduce-idents@>=2.2.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-idents/-/postcss-reduce-idents-2.4.0.tgz"
+    },
+    "postcss-reduce-initial": {
+      "version": "1.0.1",
+      "from": "postcss-reduce-initial@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-1.0.1.tgz"
+    },
+    "postcss-reduce-transforms": {
+      "version": "1.0.4",
+      "from": "postcss-reduce-transforms@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-1.0.4.tgz"
+    },
+    "postcss-selector-parser": {
+      "version": "2.2.3",
+      "from": "postcss-selector-parser@>=2.2.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-2.2.3.tgz"
+    },
+    "postcss-svgo": {
+      "version": "2.1.6",
+      "from": "postcss-svgo@>=2.1.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-svgo/-/postcss-svgo-2.1.6.tgz"
+    },
+    "postcss-unique-selectors": {
+      "version": "2.0.2",
+      "from": "postcss-unique-selectors@>=2.0.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-2.0.2.tgz"
+    },
+    "postcss-value-parser": {
+      "version": "3.3.0",
+      "from": "postcss-value-parser@>=3.2.3 <4.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.0.tgz"
+    },
+    "postcss-zindex": {
+      "version": "2.2.0",
+      "from": "postcss-zindex@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/postcss-zindex/-/postcss-zindex-2.2.0.tgz"
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "from": "prelude-ls@>=1.1.2 <1.2.0",
+      "resolved": "http://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "dev": true
+    },
+    "prepend-http": {
+      "version": "1.0.4",
+      "from": "prepend-http@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz"
+    },
+    "preserve": {
+      "version": "0.2.0",
+      "from": "preserve@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
+    },
+    "private": {
+      "version": "0.1.7",
+      "from": "private@>=0.1.6 <0.2.0",
+      "resolved": "http://registry.npmjs.org/private/-/private-0.1.7.tgz"
+    },
+    "process": {
+      "version": "0.5.2",
+      "from": "process@>=0.5.1 <0.6.0",
+      "resolved": "http://registry.npmjs.org/process/-/process-0.5.2.tgz"
+    },
+    "process-nextick-args": {
+      "version": "1.0.7",
+      "from": "process-nextick-args@>=1.0.6 <1.1.0",
+      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+    },
+    "progress": {
+      "version": "1.1.8",
+      "from": "progress@>=1.1.8 <2.0.0",
+      "resolved": "http://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "dev": true
+    },
+    "promise": {
+      "version": "7.3.1",
+      "from": "promise@>=7.1.1 <8.0.0",
+      "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz"
     },
     "prop-types": {
       "version": "15.5.10",
       "from": "prop-types@>=15.5.10 <16.0.0",
-      "resolved": "http://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.12",
-          "from": "fbjs@>=0.8.9 <0.9.0",
-          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.7.1",
-                  "from": "node-fetch@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "from": "encoding@>=0.1.11 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.18",
-                          "from": "iconv-lite@>=0.4.13 <0.5.0",
-                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                        }
-                      }
-                    },
-                    "is-stream": {
-                      "version": "1.1.0",
-                      "from": "is-stream@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "2.0.3",
-                  "from": "whatwg-fetch@>=0.10.0",
-                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            },
-            "promise": {
-              "version": "7.3.1",
-              "from": "promise@>=7.1.1 <8.0.0",
-              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.6",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                }
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "from": "setimmediate@>=1.0.5 <2.0.0",
-              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-            },
-            "ua-parser-js": {
-              "version": "0.7.14",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
-              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-            }
-          }
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.3.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/prop-types/-/prop-types-15.5.10.tgz"
+    },
+    "prop-types-extra": {
+      "version": "1.0.1",
+      "from": "prop-types-extra@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.0.1.tgz"
+    },
+    "proxy-addr": {
+      "version": "1.1.5",
+      "from": "proxy-addr@>=1.1.4 <1.2.0",
+      "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz"
+    },
+    "prr": {
+      "version": "0.0.0",
+      "from": "prr@>=0.0.0 <0.1.0",
+      "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "from": "pseudomap@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+    },
+    "punycode": {
+      "version": "1.4.1",
+      "from": "punycode@>=1.4.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+    },
+    "q": {
+      "version": "1.5.0",
+      "from": "q@>=1.1.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/q/-/q-1.5.0.tgz"
+    },
+    "qs": {
+      "version": "6.4.0",
+      "from": "qs@>=6.4.0 <6.5.0",
+      "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+    },
+    "query-string": {
+      "version": "4.3.4",
+      "from": "query-string@>=4.1.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz"
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "from": "querystring@0.2.0",
+      "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+    },
+    "querystring-es3": {
+      "version": "0.2.1",
+      "from": "querystring-es3@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
+    },
+    "querystringify": {
+      "version": "0.0.4",
+      "from": "querystringify@>=0.0.0 <0.1.0",
+      "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
+    },
+    "rafl": {
+      "version": "1.2.2",
+      "from": "rafl@>=1.2.1 <1.3.0",
+      "resolved": "http://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz"
     },
     "rails-erb-loader": {
       "version": "3.0.0",
       "from": "rails-erb-loader@3.0.0",
       "resolved": "http://registry.npmjs.org/rails-erb-loader/-/rails-erb-loader-3.0.0.tgz",
       "dependencies": {
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.16 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "lodash.defaults": {
-          "version": "4.2.0",
-          "from": "lodash.defaults@>=4.2.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz"
-        },
         "node-uuid": {
           "version": "1.4.8",
           "from": "node-uuid@>=1.4.7 <2.0.0",
@@ -9577,789 +4311,308 @@
         }
       }
     },
+    "randomatic": {
+      "version": "1.1.7",
+      "from": "randomatic@>=1.1.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
+      "dependencies": {
+        "is-number": {
+          "version": "3.0.0",
+          "from": "is-number@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+          "dependencies": {
+            "kind-of": {
+              "version": "3.2.2",
+              "from": "kind-of@^3.0.2",
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+            }
+          }
+        },
+        "kind-of": {
+          "version": "4.0.0",
+          "from": "kind-of@>=4.0.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz"
+        }
+      }
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "from": "range-parser@>=1.2.0 <1.3.0",
+      "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+    },
+    "raw-body": {
+      "version": "2.2.0",
+      "from": "raw-body@>=2.2.0 <2.3.0",
+      "resolved": "http://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.15",
+          "from": "iconv-lite@0.4.15",
+          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
+        }
+      }
+    },
     "rc-pagination": {
       "version": "1.10.1",
       "from": "rc-pagination@>=1.9.7 <2.0.0",
-      "resolved": "http://registry.npmjs.org/rc-pagination/-/rc-pagination-1.10.1.tgz",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.23.0 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/rc-pagination/-/rc-pagination-1.10.1.tgz"
     },
     "react": {
       "version": "15.6.1",
       "from": "react@>=15.4.0 <16.0.0",
-      "resolved": "http://registry.npmjs.org/react/-/react-15.6.1.tgz",
-      "dependencies": {
-        "create-react-class": {
-          "version": "15.6.0",
-          "from": "create-react-class@>=15.6.0 <16.0.0",
-          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz"
-        },
-        "fbjs": {
-          "version": "0.8.12",
-          "from": "fbjs@>=0.8.9 <0.9.0",
-          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.7.1",
-                  "from": "node-fetch@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "from": "encoding@>=0.1.11 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.18",
-                          "from": "iconv-lite@>=0.4.13 <0.5.0",
-                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                        }
-                      }
-                    },
-                    "is-stream": {
-                      "version": "1.1.0",
-                      "from": "is-stream@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "2.0.3",
-                  "from": "whatwg-fetch@>=0.10.0",
-                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.3.1",
-              "from": "promise@>=7.1.1 <8.0.0",
-              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.6",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                }
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "from": "setimmediate@>=1.0.5 <2.0.0",
-              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-            },
-            "ua-parser-js": {
-              "version": "0.7.14",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
-              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-            }
-          }
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react/-/react-15.6.1.tgz"
     },
     "react-addons-shallow-compare": {
       "version": "15.6.0",
       "from": "react-addons-shallow-compare@>=15.5.2 <16.0.0",
-      "resolved": "http://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.0.tgz",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.12",
-          "from": "fbjs@>=0.8.4 <0.9.0",
-          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.7.1",
-                  "from": "node-fetch@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "from": "encoding@>=0.1.11 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.18",
-                          "from": "iconv-lite@>=0.4.13 <0.5.0",
-                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                        }
-                      }
-                    },
-                    "is-stream": {
-                      "version": "1.1.0",
-                      "from": "is-stream@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "2.0.3",
-                  "from": "whatwg-fetch@>=0.10.0",
-                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                }
-              }
-            },
-            "loose-envify": {
-              "version": "1.3.1",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "3.0.2",
-                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.3.1",
-              "from": "promise@>=7.1.1 <8.0.0",
-              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.6",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                }
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "from": "setimmediate@>=1.0.5 <2.0.0",
-              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-            },
-            "ua-parser-js": {
-              "version": "0.7.14",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
-              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.1 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.0.tgz"
     },
     "react-addons-test-utils": {
       "version": "15.6.0",
       "from": "react-addons-test-utils@>=15.4.0 <16.0.0",
-      "resolved": "http://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz"
+      "resolved": "http://registry.npmjs.org/react-addons-test-utils/-/react-addons-test-utils-15.6.0.tgz",
+      "dev": true
+    },
+    "react-autobind": {
+      "version": "1.0.6",
+      "from": "react-autobind@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz"
     },
     "react-bootstrap": {
       "version": "0.31.1",
       "from": "react-bootstrap@>=0.31.0 <0.32.0",
-      "resolved": "http://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.1.tgz",
-      "dependencies": {
-        "babel-runtime": {
-          "version": "6.23.0",
-          "from": "babel-runtime@>=6.11.6 <7.0.0",
-          "resolved": "http://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "2.4.1",
-              "from": "core-js@>=2.4.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz"
-            },
-            "regenerator-runtime": {
-              "version": "0.10.5",
-              "from": "regenerator-runtime@>=0.10.0 <0.11.0",
-              "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
-            }
-          }
-        },
-        "classnames": {
-          "version": "2.2.5",
-          "from": "classnames@>=2.2.5 <3.0.0",
-          "resolved": "http://registry.npmjs.org/classnames/-/classnames-2.2.5.tgz"
-        },
-        "dom-helpers": {
-          "version": "3.2.1",
-          "from": "dom-helpers@>=3.2.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz"
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "from": "invariant@>=2.2.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.3.1",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "3.0.2",
-                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "keycode": {
-          "version": "2.1.9",
-          "from": "keycode@>=2.1.2 <3.0.0",
-          "resolved": "http://registry.npmjs.org/keycode/-/keycode-2.1.9.tgz"
-        },
-        "prop-types-extra": {
-          "version": "1.0.1",
-          "from": "prop-types-extra@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/prop-types-extra/-/prop-types-extra-1.0.1.tgz"
-        },
-        "react-overlays": {
-          "version": "0.7.0",
-          "from": "react-overlays@>=0.7.0 <0.8.0",
-          "resolved": "http://registry.npmjs.org/react-overlays/-/react-overlays-0.7.0.tgz"
-        },
-        "react-prop-types": {
-          "version": "0.4.0",
-          "from": "react-prop-types@>=0.4.0 <0.5.0",
-          "resolved": "http://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz"
-        },
-        "uncontrollable": {
-          "version": "4.1.0",
-          "from": "uncontrollable@>=4.1.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz"
-        },
-        "warning": {
-          "version": "3.0.0",
-          "from": "warning@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-          "dependencies": {
-            "loose-envify": {
-              "version": "1.3.1",
-              "from": "loose-envify@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-              "dependencies": {
-                "js-tokens": {
-                  "version": "3.0.2",
-                  "from": "js-tokens@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react-bootstrap/-/react-bootstrap-0.31.1.tgz"
     },
     "react-dom": {
       "version": "15.6.1",
       "from": "react-dom@>=15.4.0 <16.0.0",
-      "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz",
-      "dependencies": {
-        "fbjs": {
-          "version": "0.8.12",
-          "from": "fbjs@>=0.8.9 <0.9.0",
-          "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-          "dependencies": {
-            "core-js": {
-              "version": "1.2.7",
-              "from": "core-js@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-            },
-            "isomorphic-fetch": {
-              "version": "2.2.1",
-              "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-              "dependencies": {
-                "node-fetch": {
-                  "version": "1.7.1",
-                  "from": "node-fetch@>=1.0.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                  "dependencies": {
-                    "encoding": {
-                      "version": "0.1.12",
-                      "from": "encoding@>=0.1.11 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                      "dependencies": {
-                        "iconv-lite": {
-                          "version": "0.4.18",
-                          "from": "iconv-lite@>=0.4.13 <0.5.0",
-                          "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                        }
-                      }
-                    },
-                    "is-stream": {
-                      "version": "1.1.0",
-                      "from": "is-stream@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                    }
-                  }
-                },
-                "whatwg-fetch": {
-                  "version": "2.0.3",
-                  "from": "whatwg-fetch@>=0.10.0",
-                  "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                }
-              }
-            },
-            "promise": {
-              "version": "7.3.1",
-              "from": "promise@>=7.1.1 <8.0.0",
-              "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-              "dependencies": {
-                "asap": {
-                  "version": "2.0.6",
-                  "from": "asap@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                }
-              }
-            },
-            "setimmediate": {
-              "version": "1.0.5",
-              "from": "setimmediate@>=1.0.5 <2.0.0",
-              "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-            },
-            "ua-parser-js": {
-              "version": "0.7.14",
-              "from": "ua-parser-js@>=0.7.9 <0.8.0",
-              "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-            }
-          }
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react-dom/-/react-dom-15.6.1.tgz"
     },
     "react-joyride": {
       "version": "1.10.1",
       "from": "react-joyride@>=1.10.1 <2.0.0",
-      "resolved": "http://registry.npmjs.org/react-joyride/-/react-joyride-1.10.1.tgz",
-      "dependencies": {
-        "nested-property": {
-          "version": "0.0.7",
-          "from": "nested-property@>=0.0.7 <0.0.8",
-          "resolved": "http://registry.npmjs.org/nested-property/-/nested-property-0.0.7.tgz"
-        },
-        "react-autobind": {
-          "version": "1.0.6",
-          "from": "react-autobind@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/react-autobind/-/react-autobind-1.0.6.tgz"
-        },
-        "scroll": {
-          "version": "2.0.0",
-          "from": "scroll@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/scroll/-/scroll-2.0.0.tgz",
-          "dependencies": {
-            "rafl": {
-              "version": "1.2.2",
-              "from": "rafl@>=1.2.1 <1.3.0",
-              "resolved": "http://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
-              "dependencies": {
-                "global": {
-                  "version": "4.3.2",
-                  "from": "global@>=4.3.0 <4.4.0",
-                  "resolved": "http://registry.npmjs.org/global/-/global-4.3.2.tgz",
-                  "dependencies": {
-                    "min-document": {
-                      "version": "2.19.0",
-                      "from": "min-document@>=2.19.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
-                      "dependencies": {
-                        "dom-walk": {
-                          "version": "0.1.1",
-                          "from": "dom-walk@>=0.1.0 <0.2.0",
-                          "resolved": "http://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz"
-                        }
-                      }
-                    },
-                    "process": {
-                      "version": "0.5.2",
-                      "from": "process@>=0.5.1 <0.6.0",
-                      "resolved": "http://registry.npmjs.org/process/-/process-0.5.2.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react-joyride/-/react-joyride-1.10.1.tgz"
+    },
+    "react-overlays": {
+      "version": "0.7.0",
+      "from": "react-overlays@>=0.7.0 <0.8.0",
+      "resolved": "http://registry.npmjs.org/react-overlays/-/react-overlays-0.7.0.tgz"
+    },
+    "react-prop-types": {
+      "version": "0.4.0",
+      "from": "react-prop-types@>=0.4.0 <0.5.0",
+      "resolved": "http://registry.npmjs.org/react-prop-types/-/react-prop-types-0.4.0.tgz"
     },
     "react-redux": {
       "version": "4.4.8",
       "from": "react-redux@>=4.4.6 <5.0.0",
-      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-4.4.8.tgz",
-      "dependencies": {
-        "create-react-class": {
-          "version": "15.6.0",
-          "from": "create-react-class@>=15.5.1 <16.0.0",
-          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-          "dependencies": {
-            "fbjs": {
-              "version": "0.8.12",
-              "from": "fbjs@>=0.8.9 <0.9.0",
-              "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.7",
-                  "from": "core-js@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-                },
-                "isomorphic-fetch": {
-                  "version": "2.2.1",
-                  "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-                  "dependencies": {
-                    "node-fetch": {
-                      "version": "1.7.1",
-                      "from": "node-fetch@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "from": "encoding@>=0.1.11 <0.2.0",
-                          "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.18",
-                              "from": "iconv-lite@>=0.4.13 <0.5.0",
-                              "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                            }
-                          }
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "from": "is-stream@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "whatwg-fetch": {
-                      "version": "2.0.3",
-                      "from": "whatwg-fetch@>=0.10.0",
-                      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                    }
-                  }
-                },
-                "promise": {
-                  "version": "7.3.1",
-                  "from": "promise@>=7.1.1 <8.0.0",
-                  "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.6",
-                      "from": "asap@>=2.0.3 <2.1.0",
-                      "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                    }
-                  }
-                },
-                "setimmediate": {
-                  "version": "1.0.5",
-                  "from": "setimmediate@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-                },
-                "ua-parser-js": {
-                  "version": "0.7.14",
-                  "from": "ua-parser-js@>=0.7.9 <0.8.0",
-                  "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "from": "hoist-non-react-statics@>=1.0.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "from": "invariant@>=2.0.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/react-redux/-/react-redux-4.4.8.tgz"
     },
     "react-router": {
       "version": "3.0.5",
       "from": "react-router@>=3.0.1 <4.0.0",
-      "resolved": "http://registry.npmjs.org/react-router/-/react-router-3.0.5.tgz",
+      "resolved": "http://registry.npmjs.org/react-router/-/react-router-3.0.5.tgz"
+    },
+    "read-pkg": {
+      "version": "1.1.0",
+      "from": "read-pkg@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz"
+    },
+    "read-pkg-up": {
+      "version": "1.0.1",
+      "from": "read-pkg-up@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz"
+    },
+    "readable-stream": {
+      "version": "2.3.3",
+      "from": "readable-stream@>=2.0.6 <3.0.0",
+      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz"
+    },
+    "readdirp": {
+      "version": "2.1.0",
+      "from": "readdirp@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz"
+    },
+    "readline2": {
+      "version": "1.0.1",
+      "from": "readline2@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+      "dev": true
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "from": "rechoir@>=0.6.2 <0.7.0",
+      "resolved": "http://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "dev": true
+    },
+    "redent": {
+      "version": "1.0.0",
+      "from": "redent@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz"
+    },
+    "reduce-css-calc": {
+      "version": "1.3.0",
+      "from": "reduce-css-calc@>=1.2.6 <2.0.0",
+      "resolved": "http://registry.npmjs.org/reduce-css-calc/-/reduce-css-calc-1.3.0.tgz",
       "dependencies": {
-        "create-react-class": {
-          "version": "15.6.0",
-          "from": "create-react-class@>=15.5.1 <16.0.0",
-          "resolved": "http://registry.npmjs.org/create-react-class/-/create-react-class-15.6.0.tgz",
-          "dependencies": {
-            "fbjs": {
-              "version": "0.8.12",
-              "from": "fbjs@>=0.8.9 <0.9.0",
-              "resolved": "http://registry.npmjs.org/fbjs/-/fbjs-0.8.12.tgz",
-              "dependencies": {
-                "core-js": {
-                  "version": "1.2.7",
-                  "from": "core-js@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
-                },
-                "isomorphic-fetch": {
-                  "version": "2.2.1",
-                  "from": "isomorphic-fetch@>=2.1.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-                  "dependencies": {
-                    "node-fetch": {
-                      "version": "1.7.1",
-                      "from": "node-fetch@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-                      "dependencies": {
-                        "encoding": {
-                          "version": "0.1.12",
-                          "from": "encoding@>=0.1.11 <0.2.0",
-                          "resolved": "http://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-                          "dependencies": {
-                            "iconv-lite": {
-                              "version": "0.4.18",
-                              "from": "iconv-lite@>=0.4.13 <0.5.0",
-                              "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.18.tgz"
-                            }
-                          }
-                        },
-                        "is-stream": {
-                          "version": "1.1.0",
-                          "from": "is-stream@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
-                        }
-                      }
-                    },
-                    "whatwg-fetch": {
-                      "version": "2.0.3",
-                      "from": "whatwg-fetch@>=0.10.0",
-                      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
-                    }
-                  }
-                },
-                "promise": {
-                  "version": "7.3.1",
-                  "from": "promise@>=7.1.1 <8.0.0",
-                  "resolved": "http://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-                  "dependencies": {
-                    "asap": {
-                      "version": "2.0.6",
-                      "from": "asap@>=2.0.3 <2.1.0",
-                      "resolved": "http://registry.npmjs.org/asap/-/asap-2.0.6.tgz"
-                    }
-                  }
-                },
-                "setimmediate": {
-                  "version": "1.0.5",
-                  "from": "setimmediate@>=1.0.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-                },
-                "ua-parser-js": {
-                  "version": "0.7.14",
-                  "from": "ua-parser-js@>=0.7.9 <0.8.0",
-                  "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
-                }
-              }
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "history": {
-          "version": "3.3.0",
-          "from": "history@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/history/-/history-3.3.0.tgz",
-          "dependencies": {
-            "query-string": {
-              "version": "4.3.4",
-              "from": "query-string@>=4.2.2 <5.0.0",
-              "resolved": "http://registry.npmjs.org/query-string/-/query-string-4.3.4.tgz",
-              "dependencies": {
-                "object-assign": {
-                  "version": "4.1.1",
-                  "from": "object-assign@>=4.1.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "hoist-non-react-statics": {
-          "version": "1.2.0",
-          "from": "hoist-non-react-statics@>=1.2.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-1.2.0.tgz"
-        },
-        "invariant": {
-          "version": "2.2.2",
-          "from": "invariant@>=2.2.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz"
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.2.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "warning": {
-          "version": "3.0.0",
-          "from": "warning@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.2 <0.5.0",
+          "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
+        }
+      }
+    },
+    "reduce-function-call": {
+      "version": "1.0.2",
+      "from": "reduce-function-call@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/reduce-function-call/-/reduce-function-call-1.0.2.tgz",
+      "dependencies": {
+        "balanced-match": {
+          "version": "0.4.2",
+          "from": "balanced-match@>=0.4.2 <0.5.0",
+          "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
         }
       }
     },
     "redux": {
       "version": "3.7.2",
       "from": "redux@>=3.6.0 <4.0.0",
-      "resolved": "http://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "dependencies": {
-        "lodash-es": {
-          "version": "4.17.4",
-          "from": "lodash-es@>=4.2.1 <5.0.0",
-          "resolved": "http://registry.npmjs.org/lodash-es/-/lodash-es-4.17.4.tgz"
-        },
-        "loose-envify": {
-          "version": "1.3.1",
-          "from": "loose-envify@>=1.1.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-          "dependencies": {
-            "js-tokens": {
-              "version": "3.0.2",
-              "from": "js-tokens@>=3.0.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz"
-            }
-          }
-        },
-        "symbol-observable": {
-          "version": "1.0.4",
-          "from": "symbol-observable@>=1.0.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/redux/-/redux-3.7.2.tgz"
     },
     "redux-devtools": {
       "version": "3.4.0",
       "from": "redux-devtools@>=3.3.1 <4.0.0",
-      "resolved": "http://registry.npmjs.org/redux-devtools/-/redux-devtools-3.4.0.tgz",
-      "dependencies": {
-        "redux-devtools-instrument": {
-          "version": "1.8.2",
-          "from": "redux-devtools-instrument@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz",
-          "dependencies": {
-            "symbol-observable": {
-              "version": "1.0.4",
-              "from": "symbol-observable@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/redux-devtools/-/redux-devtools-3.4.0.tgz"
+    },
+    "redux-devtools-instrument": {
+      "version": "1.8.2",
+      "from": "redux-devtools-instrument@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.8.2.tgz"
     },
     "redux-logger": {
       "version": "2.10.2",
       "from": "redux-logger@>=2.7.4 <3.0.0",
-      "resolved": "http://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz",
+      "resolved": "http://registry.npmjs.org/redux-logger/-/redux-logger-2.10.2.tgz"
+    },
+    "redux-promise-middleware": {
+      "version": "4.2.1",
+      "from": "redux-promise-middleware@4.2.1",
+      "resolved": "http://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-4.2.1.tgz"
+    },
+    "regenerate": {
+      "version": "1.3.2",
+      "from": "regenerate@>=1.2.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz"
+    },
+    "regenerator-runtime": {
+      "version": "0.10.5",
+      "from": "regenerator-runtime@>=0.10.0 <0.11.0",
+      "resolved": "http://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz"
+    },
+    "regenerator-transform": {
+      "version": "0.9.11",
+      "from": "regenerator-transform@0.9.11",
+      "resolved": "http://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.9.11.tgz"
+    },
+    "regex-cache": {
+      "version": "0.4.3",
+      "from": "regex-cache@>=0.4.2 <0.5.0",
+      "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz"
+    },
+    "regexpu-core": {
+      "version": "2.0.0",
+      "from": "regexpu-core@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz"
+    },
+    "regjsgen": {
+      "version": "0.2.0",
+      "from": "regjsgen@>=0.2.0 <0.3.0",
+      "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+    },
+    "regjsparser": {
+      "version": "0.1.5",
+      "from": "regjsparser@>=0.1.4 <0.2.0",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "dependencies": {
-        "deep-diff": {
-          "version": "0.3.4",
-          "from": "deep-diff@0.3.4",
-          "resolved": "http://registry.npmjs.org/deep-diff/-/deep-diff-0.3.4.tgz"
+        "jsesc": {
+          "version": "0.5.0",
+          "from": "jsesc@>=0.5.0 <0.6.0",
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
         }
       }
     },
-    "redux-promise-middleware": {
-      "version": "4.3.0",
-      "from": "redux-promise-middleware@>=4.2.0 <5.0.0",
-      "resolved": "http://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-4.3.0.tgz"
+    "remove-trailing-separator": {
+      "version": "1.0.2",
+      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
+    },
+    "repeat-element": {
+      "version": "1.1.2",
+      "from": "repeat-element@>=1.1.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
+    },
+    "repeat-string": {
+      "version": "1.6.1",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+    },
+    "repeating": {
+      "version": "2.0.1",
+      "from": "repeating@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz"
+    },
+    "request": {
+      "version": "2.81.0",
+      "from": "request@>=2.61.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/request/-/request-2.81.0.tgz"
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "from": "require-directory@>=2.1.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz"
+    },
+    "require-from-string": {
+      "version": "1.2.1",
+      "from": "require-from-string@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/require-from-string/-/require-from-string-1.2.1.tgz"
+    },
+    "require-main-filename": {
+      "version": "1.0.1",
+      "from": "require-main-filename@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz"
+    },
+    "require-uncached": {
+      "version": "1.0.3",
+      "from": "require-uncached@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "from": "requires-port@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
     },
     "reselect": {
       "version": "2.5.4",
       "from": "reselect@>=2.5.4 <3.0.0",
       "resolved": "http://registry.npmjs.org/reselect/-/reselect-2.5.4.tgz"
+    },
+    "resolve": {
+      "version": "1.4.0",
+      "from": "resolve@>=1.1.6 <2.0.0",
+      "resolved": "http://registry.npmjs.org/resolve/-/resolve-1.4.0.tgz",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "1.0.1",
+      "from": "resolve-from@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+      "dev": true
+    },
+    "resolve-url": {
+      "version": "0.2.1",
+      "from": "resolve-url@>=0.2.1 <0.3.0",
+      "resolved": "http://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
     },
     "resolve-url-loader": {
       "version": "1.6.1",
@@ -10371,177 +4624,82 @@
           "from": "camelcase@>=1.2.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
         },
-        "convert-source-map": {
-          "version": "1.5.0",
-          "from": "convert-source-map@>=1.1.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz"
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.0.1 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
+        "lodash.assign": {
+          "version": "3.2.0",
+          "from": "lodash.assign@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz"
         },
         "lodash.defaults": {
           "version": "3.1.2",
           "from": "lodash.defaults@>=3.1.2 <4.0.0",
-          "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-          "dependencies": {
-            "lodash.assign": {
-              "version": "3.2.0",
-              "from": "lodash.assign@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-              "dependencies": {
-                "lodash._baseassign": {
-                  "version": "3.2.0",
-                  "from": "lodash._baseassign@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-                  "dependencies": {
-                    "lodash._basecopy": {
-                      "version": "3.0.1",
-                      "from": "lodash._basecopy@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._basecopy/-/lodash._basecopy-3.0.1.tgz"
-                    }
-                  }
-                },
-                "lodash._createassigner": {
-                  "version": "3.1.1",
-                  "from": "lodash._createassigner@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-                  "dependencies": {
-                    "lodash._bindcallback": {
-                      "version": "3.0.1",
-                      "from": "lodash._bindcallback@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz"
-                    },
-                    "lodash._isiterateecall": {
-                      "version": "3.0.9",
-                      "from": "lodash._isiterateecall@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._isiterateecall/-/lodash._isiterateecall-3.0.9.tgz"
-                    }
-                  }
-                },
-                "lodash.keys": {
-                  "version": "3.1.2",
-                  "from": "lodash.keys@>=3.0.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-                  "dependencies": {
-                    "lodash._getnative": {
-                      "version": "3.9.1",
-                      "from": "lodash._getnative@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash._getnative/-/lodash._getnative-3.9.1.tgz"
-                    },
-                    "lodash.isarguments": {
-                      "version": "3.1.0",
-                      "from": "lodash.isarguments@>=3.0.0 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz"
-                    },
-                    "lodash.isarray": {
-                      "version": "3.0.4",
-                      "from": "lodash.isarray@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/lodash.isarray/-/lodash.isarray-3.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "lodash.restparam": {
-              "version": "3.6.1",
-              "from": "lodash.restparam@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz"
-            }
-          }
-        },
-        "rework": {
-          "version": "1.0.1",
-          "from": "rework@>=1.0.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
-          "dependencies": {
-            "css": {
-              "version": "2.2.1",
-              "from": "css@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/css/-/css-2.2.1.tgz",
-              "dependencies": {
-                "source-map-resolve": {
-                  "version": "0.3.1",
-                  "from": "source-map-resolve@>=0.3.0 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
-                  "dependencies": {
-                    "source-map-url": {
-                      "version": "0.3.0",
-                      "from": "source-map-url@>=0.3.0 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
-                    },
-                    "atob": {
-                      "version": "1.1.3",
-                      "from": "atob@>=1.1.0 <1.2.0",
-                      "resolved": "http://registry.npmjs.org/atob/-/atob-1.1.3.tgz"
-                    },
-                    "resolve-url": {
-                      "version": "0.2.1",
-                      "from": "resolve-url@>=0.2.1 <0.3.0",
-                      "resolved": "http://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz"
-                    }
-                  }
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "convert-source-map": {
-              "version": "0.3.5",
-              "from": "convert-source-map@>=0.3.3 <0.4.0",
-              "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
-            }
-          }
-        },
-        "rework-visit": {
-          "version": "1.0.0",
-          "from": "rework-visit@>=1.0.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz"
+          "resolved": "http://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz"
         },
         "source-map": {
           "version": "0.1.43",
           "from": "source-map@>=0.1.43 <0.2.0",
-          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
-          "dependencies": {
-            "amdefine": {
-              "version": "1.0.1",
-              "from": "amdefine@>=0.0.4",
-              "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-            }
-          }
-        },
-        "urix": {
-          "version": "0.1.0",
-          "from": "urix@>=0.1.0 <0.2.0",
-          "resolved": "http://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+          "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz"
         }
       }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "from": "restore-cursor@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "dev": true
+    },
+    "rework": {
+      "version": "1.0.1",
+      "from": "rework@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/rework/-/rework-1.0.1.tgz",
+      "dependencies": {
+        "convert-source-map": {
+          "version": "0.3.5",
+          "from": "convert-source-map@>=0.3.3 <0.4.0",
+          "resolved": "http://registry.npmjs.org/convert-source-map/-/convert-source-map-0.3.5.tgz"
+        }
+      }
+    },
+    "rework-visit": {
+      "version": "1.0.0",
+      "from": "rework-visit@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/rework-visit/-/rework-visit-1.0.0.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz"
+    },
+    "rimraf": {
+      "version": "2.6.1",
+      "from": "rimraf@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
+    },
+    "ripemd160": {
+      "version": "0.2.0",
+      "from": "ripemd160@0.2.0",
+      "resolved": "http://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
+    },
+    "run-async": {
+      "version": "0.1.0",
+      "from": "run-async@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+      "dev": true
+    },
+    "rx-lite": {
+      "version": "3.1.2",
+      "from": "rx-lite@>=3.1.2 <4.0.0",
+      "resolved": "http://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+      "dev": true
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "from": "safe-buffer@>=5.1.1 <5.2.0",
+      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+    },
+    "sass-graph": {
+      "version": "2.2.4",
+      "from": "sass-graph@>=2.1.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/sass-graph/-/sass-graph-2.2.4.tgz"
     },
     "sass-loader": {
       "version": "4.1.1",
@@ -10552,33 +4710,201 @@
           "version": "2.5.0",
           "from": "async@>=2.0.1 <3.0.0",
           "resolved": "http://registry.npmjs.org/async/-/async-2.5.0.tgz"
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.15 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "from": "object-assign@>=4.1.0 <5.0.0",
-          "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
+        }
+      }
+    },
+    "sax": {
+      "version": "1.2.4",
+      "from": "sax@>=1.2.1 <1.3.0",
+      "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.4.tgz"
+    },
+    "scroll": {
+      "version": "2.0.0",
+      "from": "scroll@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/scroll/-/scroll-2.0.0.tgz"
+    },
+    "scss-tokenizer": {
+      "version": "0.2.3",
+      "from": "scss-tokenizer@>=0.2.3 <0.3.0",
+      "resolved": "http://registry.npmjs.org/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.2 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+        }
+      }
+    },
+    "semver": {
+      "version": "5.4.1",
+      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
+      "resolved": "http://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+    },
+    "send": {
+      "version": "0.15.3",
+      "from": "send@0.15.3",
+      "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.6.7",
+          "from": "debug@2.6.7",
+          "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz"
+        }
+      }
+    },
+    "serve-index": {
+      "version": "1.9.0",
+      "from": "serve-index@>=1.7.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz"
+    },
+    "serve-static": {
+      "version": "1.12.3",
+      "from": "serve-static@1.12.3",
+      "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "from": "set-blocking@>=2.0.0 <2.1.0",
+      "resolved": "http://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
+    },
+    "set-immediate-shim": {
+      "version": "1.0.1",
+      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "from": "setimmediate@>=1.0.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
+    },
+    "setprototypeof": {
+      "version": "1.0.3",
+      "from": "setprototypeof@1.0.3",
+      "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+    },
+    "sha.js": {
+      "version": "2.2.6",
+      "from": "sha.js@2.2.6",
+      "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
+    },
+    "shelljs": {
+      "version": "0.7.8",
+      "from": "shelljs@>=0.7.5 <0.8.0",
+      "resolved": "http://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+      "dev": true,
+      "dependencies": {
+        "interpret": {
+          "version": "1.0.3",
+          "from": "interpret@>=1.0.0 <2.0.0",
+          "resolved": "http://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+          "dev": true
+        }
+      }
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "from": "signal-exit@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
+    },
+    "slash": {
+      "version": "1.0.0",
+      "from": "slash@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz"
+    },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "from": "slice-ansi@0.0.4",
+      "resolved": "http://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "dev": true
+    },
+    "sntp": {
+      "version": "1.0.9",
+      "from": "sntp@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+    },
+    "sockjs": {
+      "version": "0.3.18",
+      "from": "sockjs@>=0.3.15 <0.4.0",
+      "resolved": "http://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
+      "dependencies": {
+        "uuid": {
+          "version": "2.0.3",
+          "from": "uuid@>=2.0.2 <3.0.0",
+          "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
+        }
+      }
+    },
+    "sockjs-client": {
+      "version": "1.1.4",
+      "from": "sockjs-client@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
+      "dependencies": {
+        "faye-websocket": {
+          "version": "0.11.1",
+          "from": "faye-websocket@>=0.11.0 <0.12.0",
+          "resolved": "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz"
+        }
+      }
+    },
+    "sort-keys": {
+      "version": "1.1.2",
+      "from": "sort-keys@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz"
+    },
+    "source-list-map": {
+      "version": "0.1.8",
+      "from": "source-list-map@>=0.1.4 <0.2.0",
+      "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
+    },
+    "source-map": {
+      "version": "0.5.6",
+      "from": "source-map@>=0.5.6 <0.6.0",
+      "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
+    },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "from": "source-map-resolve@>=0.3.0 <0.4.0",
+      "resolved": "http://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz"
+    },
+    "source-map-support": {
+      "version": "0.4.15",
+      "from": "source-map-support@>=0.4.2 <0.5.0",
+      "resolved": "http://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz"
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "from": "source-map-url@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz"
+    },
+    "spdx-correct": {
+      "version": "1.0.2",
+      "from": "spdx-correct@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz"
+    },
+    "spdx-expression-parse": {
+      "version": "1.0.4",
+      "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
+      "resolved": "http://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+    },
+    "spdx-license-ids": {
+      "version": "1.2.2",
+      "from": "spdx-license-ids@>=1.0.2 <2.0.0",
+      "resolved": "http://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "from": "sprintf-js@>=1.0.2 <1.1.0",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
+    },
+    "sshpk": {
+      "version": "1.13.1",
+      "from": "sshpk@>=1.7.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "from": "assert-plus@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
         }
       }
     },
@@ -10587,10 +4913,76 @@
       "from": "stats-webpack-plugin@>=0.2.1 <0.3.0",
       "resolved": "http://registry.npmjs.org/stats-webpack-plugin/-/stats-webpack-plugin-0.2.2.tgz"
     },
+    "statuses": {
+      "version": "1.3.1",
+      "from": "statuses@>=1.3.1 <1.4.0",
+      "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+    },
+    "stream-browserify": {
+      "version": "2.0.1",
+      "from": "stream-browserify@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz"
+    },
+    "stream-cache": {
+      "version": "0.0.2",
+      "from": "stream-cache@>=0.0.1 <0.1.0",
+      "resolved": "http://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
+    },
+    "stream-consume": {
+      "version": "0.1.0",
+      "from": "stream-consume@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/stream-consume/-/stream-consume-0.1.0.tgz"
+    },
+    "stream-http": {
+      "version": "2.7.2",
+      "from": "stream-http@>=2.3.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz"
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "from": "streamsearch@0.1.2",
+      "resolved": "http://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
+    },
     "strict-uri-encode": {
       "version": "1.1.0",
       "from": "strict-uri-encode@1.1.0",
       "resolved": "http://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz"
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "from": "string_decoder@>=1.0.3 <1.1.0",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+    },
+    "string-width": {
+      "version": "1.0.2",
+      "from": "string-width@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
+    },
+    "stringstream": {
+      "version": "0.0.5",
+      "from": "stringstream@>=0.0.4 <0.1.0",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "from": "strip-ansi@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
+    },
+    "strip-bom": {
+      "version": "2.0.0",
+      "from": "strip-bom@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz"
+    },
+    "strip-indent": {
+      "version": "1.0.1",
+      "from": "strip-indent@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "from": "strip-json-comments@>=2.0.1 <2.1.0",
+      "resolved": "http://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "dev": true
     },
     "style-loader": {
       "version": "0.13.2",
@@ -10600,719 +4992,319 @@
         "loader-utils": {
           "version": "1.1.0",
           "from": "loader-utils@>=1.0.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
         }
       }
+    },
+    "supports-color": {
+      "version": "3.2.3",
+      "from": "supports-color@>=3.2.3 <4.0.0",
+      "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz"
+    },
+    "svgo": {
+      "version": "0.7.2",
+      "from": "svgo@>=0.7.0 <0.8.0",
+      "resolved": "http://registry.npmjs.org/svgo/-/svgo-0.7.2.tgz"
     },
     "swagger-cli": {
       "version": "1.0.0-beta.2",
       "from": "swagger-cli@>=1.0.0-beta.2 <2.0.0",
       "resolved": "http://registry.npmjs.org/swagger-cli/-/swagger-cli-1.0.0-beta.2.tgz",
       "dependencies": {
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.1 <2.0.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "from": "commander@>=2.8.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-        },
-        "es6-promise": {
-          "version": "3.3.1",
-          "from": "es6-promise@>=3.0.2 <4.0.0",
-          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz"
-        },
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        }
+      }
+    },
+    "swagger-express-middleware": {
+      "version": "1.0.0-alpha.12",
+      "from": "swagger-express-middleware@>=1.0.0-alpha.12",
+      "resolved": "http://registry.npmjs.org/swagger-express-middleware/-/swagger-express-middleware-1.0.0-alpha.12.tgz",
+      "dependencies": {
         "lodash": {
           "version": "3.10.1",
           "from": "lodash@>=3.10.1 <4.0.0",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
         },
-        "swagger-parser": {
-          "version": "3.4.1",
-          "from": "swagger-parser@>=3.1.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/swagger-parser/-/swagger-parser-3.4.1.tgz",
-          "dependencies": {
-            "call-me-maybe": {
-              "version": "1.0.1",
-              "from": "call-me-maybe@>=1.0.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.1.tgz"
-            },
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "json-schema-ref-parser": {
-              "version": "1.4.1",
-              "from": "json-schema-ref-parser@>=1.4.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-1.4.1.tgz",
-              "dependencies": {
-                "js-yaml": {
-                  "version": "3.9.0",
-                  "from": "js-yaml@>=3.4.6 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/js-yaml/-/js-yaml-3.9.0.tgz",
-                  "dependencies": {
-                    "argparse": {
-                      "version": "1.0.9",
-                      "from": "argparse@>=1.0.7 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-                      "dependencies": {
-                        "sprintf-js": {
-                          "version": "1.0.3",
-                          "from": "sprintf-js@>=1.0.2 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz"
-                        }
-                      }
-                    },
-                    "esprima": {
-                      "version": "4.0.0",
-                      "from": "esprima@>=4.0.0 <5.0.0",
-                      "resolved": "http://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "ono": {
-              "version": "2.2.5",
-              "from": "ono@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/ono/-/ono-2.2.5.tgz"
-            },
-            "swagger-methods": {
-              "version": "1.0.0",
-              "from": "swagger-methods@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz"
-            },
-            "swagger-schema-official": {
-              "version": "2.0.0-bab6bed",
-              "from": "swagger-schema-official@2.0.0-bab6bed",
-              "resolved": "http://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz"
-            },
-            "z-schema": {
-              "version": "3.18.2",
-              "from": "z-schema@>=3.16.1 <4.0.0",
-              "resolved": "http://registry.npmjs.org/z-schema/-/z-schema-3.18.2.tgz",
-              "dependencies": {
-                "lodash.get": {
-                  "version": "4.4.2",
-                  "from": "lodash.get@>=4.1.2 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz"
-                },
-                "lodash.isequal": {
-                  "version": "4.5.0",
-                  "from": "lodash.isequal@>=4.4.0 <5.0.0",
-                  "resolved": "http://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz"
-                },
-                "validator": {
-                  "version": "6.3.0",
-                  "from": "validator@>=6.0.0 <7.0.0",
-                  "resolved": "http://registry.npmjs.org/validator/-/validator-6.3.0.tgz"
-                }
-              }
-            }
-          }
+        "ono": {
+          "version": "1.0.22",
+          "from": "ono@>=1.0.22 <2.0.0",
+          "resolved": "http://registry.npmjs.org/ono/-/ono-1.0.22.tgz"
+        }
+      }
+    },
+    "swagger-methods": {
+      "version": "1.0.0",
+      "from": "swagger-methods@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz"
+    },
+    "swagger-parser": {
+      "version": "3.4.1",
+      "from": "swagger-parser@>=3.1.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/swagger-parser/-/swagger-parser-3.4.1.tgz"
+    },
+    "swagger-schema-official": {
+      "version": "2.0.0-bab6bed",
+      "from": "swagger-schema-official@2.0.0-bab6bed",
+      "resolved": "http://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz"
+    },
+    "swagger-server": {
+      "version": "1.0.0-alpha.18",
+      "from": "swagger-server@>=1.0.0-alpha.18 <2.0.0",
+      "resolved": "http://registry.npmjs.org/swagger-server/-/swagger-server-1.0.0-alpha.18.tgz",
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "from": "lodash@>=3.10.1 <4.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+        }
+      }
+    },
+    "symbol-observable": {
+      "version": "1.0.4",
+      "from": "symbol-observable@>=1.0.3 <2.0.0",
+      "resolved": "http://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz"
+    },
+    "symbol-tree": {
+      "version": "3.2.2",
+      "from": "symbol-tree@>=3.2.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
+      "dev": true
+    },
+    "table": {
+      "version": "3.8.3",
+      "from": "table@>=3.7.8 <4.0.0",
+      "resolved": "http://registry.npmjs.org/table/-/table-3.8.3.tgz",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "from": "ansi-regex@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "dev": true
         },
-        "swagger-server": {
-          "version": "1.0.0-alpha.18",
-          "from": "swagger-server@>=1.0.0-alpha.18 <2.0.0",
-          "resolved": "http://registry.npmjs.org/swagger-server/-/swagger-server-1.0.0-alpha.18.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@>=2.2.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "directory-search": {
-              "version": "0.0.32",
-              "from": "directory-search@0.0.32",
-              "resolved": "http://registry.npmjs.org/directory-search/-/directory-search-0.0.32.tgz"
-            },
-            "express": {
-              "version": "4.15.3",
-              "from": "express@>=4.13.3 <5.0.0",
-              "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
-              "dependencies": {
-                "accepts": {
-                  "version": "1.3.3",
-                  "from": "accepts@>=1.3.3 <1.4.0",
-                  "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-                  "dependencies": {
-                    "mime-types": {
-                      "version": "2.1.16",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.29.0",
-                          "from": "mime-db@>=1.29.0 <1.30.0",
-                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                        }
-                      }
-                    },
-                    "negotiator": {
-                      "version": "0.6.1",
-                      "from": "negotiator@0.6.1",
-                      "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                    }
-                  }
-                },
-                "array-flatten": {
-                  "version": "1.1.1",
-                  "from": "array-flatten@1.1.1",
-                  "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-                },
-                "content-disposition": {
-                  "version": "0.5.2",
-                  "from": "content-disposition@0.5.2",
-                  "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
-                },
-                "content-type": {
-                  "version": "1.0.2",
-                  "from": "content-type@>=1.0.2 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-                },
-                "cookie": {
-                  "version": "0.3.1",
-                  "from": "cookie@0.3.1",
-                  "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-                },
-                "cookie-signature": {
-                  "version": "1.0.6",
-                  "from": "cookie-signature@1.0.6",
-                  "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-                },
-                "debug": {
-                  "version": "2.6.7",
-                  "from": "debug@2.6.7",
-                  "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-                  "dependencies": {
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "depd": {
-                  "version": "1.1.0",
-                  "from": "depd@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-                },
-                "encodeurl": {
-                  "version": "1.0.1",
-                  "from": "encodeurl@>=1.0.1 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
-                },
-                "escape-html": {
-                  "version": "1.0.3",
-                  "from": "escape-html@>=1.0.3 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-                },
-                "etag": {
-                  "version": "1.8.0",
-                  "from": "etag@>=1.8.0 <1.9.0",
-                  "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
-                },
-                "finalhandler": {
-                  "version": "1.0.3",
-                  "from": "finalhandler@>=1.0.3 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-                  "dependencies": {
-                    "unpipe": {
-                      "version": "1.0.0",
-                      "from": "unpipe@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                    }
-                  }
-                },
-                "fresh": {
-                  "version": "0.5.0",
-                  "from": "fresh@0.5.0",
-                  "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
-                },
-                "merge-descriptors": {
-                  "version": "1.0.1",
-                  "from": "merge-descriptors@1.0.1",
-                  "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-                },
-                "methods": {
-                  "version": "1.1.2",
-                  "from": "methods@>=1.1.2 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-                },
-                "on-finished": {
-                  "version": "2.3.0",
-                  "from": "on-finished@>=2.3.0 <2.4.0",
-                  "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                  "dependencies": {
-                    "ee-first": {
-                      "version": "1.1.1",
-                      "from": "ee-first@1.1.1",
-                      "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                    }
-                  }
-                },
-                "parseurl": {
-                  "version": "1.3.1",
-                  "from": "parseurl@>=1.3.1 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-                },
-                "path-to-regexp": {
-                  "version": "0.1.7",
-                  "from": "path-to-regexp@0.1.7",
-                  "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-                },
-                "proxy-addr": {
-                  "version": "1.1.4",
-                  "from": "proxy-addr@>=1.1.4 <1.2.0",
-                  "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-                  "dependencies": {
-                    "forwarded": {
-                      "version": "0.1.0",
-                      "from": "forwarded@>=0.1.0 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
-                    },
-                    "ipaddr.js": {
-                      "version": "1.3.0",
-                      "from": "ipaddr.js@1.3.0",
-                      "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
-                    }
-                  }
-                },
-                "qs": {
-                  "version": "6.4.0",
-                  "from": "qs@6.4.0",
-                  "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-                },
-                "range-parser": {
-                  "version": "1.2.0",
-                  "from": "range-parser@>=1.2.0 <1.3.0",
-                  "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-                },
-                "send": {
-                  "version": "0.15.3",
-                  "from": "send@0.15.3",
-                  "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
-                  "dependencies": {
-                    "destroy": {
-                      "version": "1.0.4",
-                      "from": "destroy@>=1.0.4 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-                    },
-                    "http-errors": {
-                      "version": "1.6.1",
-                      "from": "http-errors@>=1.6.1 <1.7.0",
-                      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@2.0.3",
-                          "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        }
-                      }
-                    },
-                    "mime": {
-                      "version": "1.3.4",
-                      "from": "mime@1.3.4",
-                      "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                    },
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    }
-                  }
-                },
-                "serve-static": {
-                  "version": "1.12.3",
-                  "from": "serve-static@1.12.3",
-                  "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
-                },
-                "setprototypeof": {
-                  "version": "1.0.3",
-                  "from": "setprototypeof@1.0.3",
-                  "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-                },
-                "statuses": {
-                  "version": "1.3.1",
-                  "from": "statuses@>=1.3.1 <1.4.0",
-                  "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-                },
-                "type-is": {
-                  "version": "1.6.15",
-                  "from": "type-is@>=1.6.15 <1.7.0",
-                  "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-                  "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "from": "media-typer@0.3.0",
-                      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.16",
-                      "from": "mime-types@>=2.1.11 <2.2.0",
-                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.29.0",
-                          "from": "mime-db@>=1.29.0 <1.30.0",
-                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "utils-merge": {
-                  "version": "1.0.0",
-                  "from": "utils-merge@1.0.0",
-                  "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-                },
-                "vary": {
-                  "version": "1.1.1",
-                  "from": "vary@>=1.1.1 <1.2.0",
-                  "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
-                }
-              }
-            },
-            "swagger-express-middleware": {
-              "version": "1.0.0-alpha.12",
-              "from": "swagger-express-middleware@>=1.0.0-alpha.12",
-              "resolved": "http://registry.npmjs.org/swagger-express-middleware/-/swagger-express-middleware-1.0.0-alpha.12.tgz",
-              "dependencies": {
-                "body-parser": {
-                  "version": "1.17.2",
-                  "from": "body-parser@>=1.13.3 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-                  "dependencies": {
-                    "bytes": {
-                      "version": "2.4.0",
-                      "from": "bytes@2.4.0",
-                      "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz"
-                    },
-                    "content-type": {
-                      "version": "1.0.2",
-                      "from": "content-type@>=1.0.2 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.7",
-                      "from": "debug@2.6.7",
-                      "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-                      "dependencies": {
-                        "ms": {
-                          "version": "2.0.0",
-                          "from": "ms@2.0.0",
-                          "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "depd": {
-                      "version": "1.1.0",
-                      "from": "depd@>=1.1.0 <1.2.0",
-                      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-                    },
-                    "http-errors": {
-                      "version": "1.6.1",
-                      "from": "http-errors@>=1.6.1 <1.7.0",
-                      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-                      "dependencies": {
-                        "inherits": {
-                          "version": "2.0.3",
-                          "from": "inherits@2.0.3",
-                          "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                        },
-                        "setprototypeof": {
-                          "version": "1.0.3",
-                          "from": "setprototypeof@1.0.3",
-                          "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-                        },
-                        "statuses": {
-                          "version": "1.3.1",
-                          "from": "statuses@>=1.3.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-                        }
-                      }
-                    },
-                    "iconv-lite": {
-                      "version": "0.4.15",
-                      "from": "iconv-lite@0.4.15",
-                      "resolved": "http://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz"
-                    },
-                    "on-finished": {
-                      "version": "2.3.0",
-                      "from": "on-finished@>=2.3.0 <2.4.0",
-                      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-                      "dependencies": {
-                        "ee-first": {
-                          "version": "1.1.1",
-                          "from": "ee-first@1.1.1",
-                          "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                        }
-                      }
-                    },
-                    "qs": {
-                      "version": "6.4.0",
-                      "from": "qs@6.4.0",
-                      "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-                    },
-                    "raw-body": {
-                      "version": "2.2.0",
-                      "from": "raw-body@>=2.2.0 <2.3.0",
-                      "resolved": "http://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-                      "dependencies": {
-                        "unpipe": {
-                          "version": "1.0.0",
-                          "from": "unpipe@1.0.0",
-                          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                },
-                "cookie-parser": {
-                  "version": "1.4.3",
-                  "from": "cookie-parser@>=1.3.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/cookie-parser/-/cookie-parser-1.4.3.tgz",
-                  "dependencies": {
-                    "cookie": {
-                      "version": "0.3.1",
-                      "from": "cookie@0.3.1",
-                      "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-                    },
-                    "cookie-signature": {
-                      "version": "1.0.6",
-                      "from": "cookie-signature@1.0.6",
-                      "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-                    }
-                  }
-                },
-                "mkdirp": {
-                  "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "dependencies": {
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    }
-                  }
-                },
-                "multer": {
-                  "version": "0.1.8",
-                  "from": "multer@>=0.1.8 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
-                  "dependencies": {
-                    "busboy": {
-                      "version": "0.2.14",
-                      "from": "busboy@>=0.2.9 <0.3.0",
-                      "resolved": "http://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-                      "dependencies": {
-                        "dicer": {
-                          "version": "0.2.5",
-                          "from": "dicer@0.2.5",
-                          "resolved": "http://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-                          "dependencies": {
-                            "streamsearch": {
-                              "version": "0.1.2",
-                              "from": "streamsearch@0.1.2",
-                              "resolved": "http://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
-                            }
-                          }
-                        },
-                        "readable-stream": {
-                          "version": "1.1.14",
-                          "from": "readable-stream@>=1.1.0 <1.2.0",
-                          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-                          "dependencies": {
-                            "core-util-is": {
-                              "version": "1.0.2",
-                              "from": "core-util-is@>=1.0.0 <1.1.0",
-                              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                            },
-                            "isarray": {
-                              "version": "0.0.1",
-                              "from": "isarray@0.0.1",
-                              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
-                            },
-                            "string_decoder": {
-                              "version": "0.10.31",
-                              "from": "string_decoder@>=0.10.0 <0.11.0",
-                              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-                            },
-                            "inherits": {
-                              "version": "2.0.3",
-                              "from": "inherits@>=2.0.1 <2.1.0",
-                              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "mkdirp": {
-                      "version": "0.3.5",
-                      "from": "mkdirp@>=0.3.5 <0.4.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
-                    },
-                    "qs": {
-                      "version": "1.2.2",
-                      "from": "qs@>=1.2.2 <1.3.0",
-                      "resolved": "http://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
-                    },
-                    "type-is": {
-                      "version": "1.5.7",
-                      "from": "type-is@>=1.5.2 <1.6.0",
-                      "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
-                      "dependencies": {
-                        "media-typer": {
-                          "version": "0.3.0",
-                          "from": "media-typer@0.3.0",
-                          "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                        },
-                        "mime-types": {
-                          "version": "2.0.14",
-                          "from": "mime-types@>=2.0.9 <2.1.0",
-                          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
-                          "dependencies": {
-                            "mime-db": {
-                              "version": "1.12.0",
-                              "from": "mime-db@>=1.12.0 <1.13.0",
-                              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "ono": {
-                  "version": "1.0.22",
-                  "from": "ono@>=1.0.22 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/ono/-/ono-1.0.22.tgz"
-                },
-                "tmp": {
-                  "version": "0.0.27",
-                  "from": "tmp@0.0.27",
-                  "resolved": "http://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz",
-                  "dependencies": {
-                    "os-tmpdir": {
-                      "version": "1.0.2",
-                      "from": "os-tmpdir@>=1.0.0 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                    }
-                  }
-                },
-                "tv4": {
-                  "version": "1.3.0",
-                  "from": "tv4@>=1.2.5 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz"
-                },
-                "type-is": {
-                  "version": "1.6.15",
-                  "from": "type-is@>=1.6.8 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-                  "dependencies": {
-                    "media-typer": {
-                      "version": "0.3.0",
-                      "from": "media-typer@0.3.0",
-                      "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.16",
-                      "from": "mime-types@>=2.1.15 <2.2.0",
-                      "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                      "dependencies": {
-                        "mime-db": {
-                          "version": "1.29.0",
-                          "from": "mime-db@>=1.29.0 <1.30.0",
-                          "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "swagger-methods": {
-              "version": "1.0.0",
-              "from": "swagger-methods@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/swagger-methods/-/swagger-methods-1.0.0.tgz"
-            }
-          }
+        "is-fullwidth-code-point": {
+          "version": "2.0.0",
+          "from": "is-fullwidth-code-point@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+          "dev": true
+        },
+        "string-width": {
+          "version": "2.1.1",
+          "from": "string-width@>=2.0.0 <3.0.0",
+          "resolved": "http://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "4.0.0",
+          "from": "strip-ansi@>=4.0.0 <5.0.0",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+          "dev": true
+        }
+      }
+    },
+    "tapable": {
+      "version": "0.1.10",
+      "from": "tapable@>=0.1.8 <0.2.0",
+      "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
+    },
+    "tar": {
+      "version": "2.2.1",
+      "from": "tar@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "from": "text-table@>=0.2.0 <0.3.0",
+      "resolved": "http://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "from": "through@>=2.3.6 <3.0.0",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "dev": true
+    },
+    "timers-browserify": {
+      "version": "2.0.2",
+      "from": "timers-browserify@>=2.0.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz"
+    },
+    "tmp": {
+      "version": "0.0.27",
+      "from": "tmp@0.0.27",
+      "resolved": "http://registry.npmjs.org/tmp/-/tmp-0.0.27.tgz"
+    },
+    "to-arraybuffer": {
+      "version": "1.0.1",
+      "from": "to-arraybuffer@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
+    },
+    "to-fast-properties": {
+      "version": "1.0.3",
+      "from": "to-fast-properties@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz"
+    },
+    "tough-cookie": {
+      "version": "2.3.2",
+      "from": "tough-cookie@>=2.3.0 <2.4.0",
+      "resolved": "http://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
+    },
+    "tr46": {
+      "version": "0.0.3",
+      "from": "tr46@>=0.0.3 <0.1.0",
+      "resolved": "http://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "dev": true
+    },
+    "trim-newlines": {
+      "version": "1.0.0",
+      "from": "trim-newlines@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+    },
+    "trim-right": {
+      "version": "1.0.1",
+      "from": "trim-right@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz"
+    },
+    "tryit": {
+      "version": "1.0.3",
+      "from": "tryit@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+      "dev": true
+    },
+    "tty-browserify": {
+      "version": "0.0.0",
+      "from": "tty-browserify@0.0.0",
+      "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "from": "tunnel-agent@>=0.6.0 <0.7.0",
+      "resolved": "http://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+    },
+    "tv4": {
+      "version": "1.3.0",
+      "from": "tv4@>=1.2.5 <2.0.0",
+      "resolved": "http://registry.npmjs.org/tv4/-/tv4-1.3.0.tgz"
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "from": "tweetnacl@>=0.14.0 <0.15.0",
+      "resolved": "http://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "optional": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "from": "type-check@>=0.3.2 <0.4.0",
+      "resolved": "http://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "dev": true
+    },
+    "type-detect": {
+      "version": "1.0.0",
+      "from": "type-detect@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/type-detect/-/type-detect-1.0.0.tgz",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.15",
+      "from": "type-is@>=1.6.15 <1.7.0",
+      "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "from": "typedarray@>=0.0.6 <0.0.7",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "dev": true
+    },
+    "ua-parser-js": {
+      "version": "0.7.14",
+      "from": "ua-parser-js@>=0.7.9 <0.8.0",
+      "resolved": "http://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.14.tgz"
+    },
+    "uglify-js": {
+      "version": "2.7.5",
+      "from": "uglify-js@>=2.7.3 <2.8.0",
+      "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@>=0.2.6 <0.3.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "camelcase": {
+          "version": "1.2.1",
+          "from": "camelcase@>=1.0.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
+        },
+        "cliui": {
+          "version": "2.1.0",
+          "from": "cliui@>=2.1.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz"
+        },
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+        },
+        "yargs": {
+          "version": "3.10.0",
+          "from": "yargs@>=3.10.0 <3.11.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz"
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
+    },
+    "ultron": {
+      "version": "1.1.0",
+      "from": "ultron@>=1.1.0 <1.2.0",
+      "resolved": "http://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
+      "dev": true
+    },
+    "uncontrollable": {
+      "version": "4.1.0",
+      "from": "uncontrollable@>=4.1.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/uncontrollable/-/uncontrollable-4.1.0.tgz"
+    },
+    "uniq": {
+      "version": "1.0.1",
+      "from": "uniq@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz"
+    },
+    "uniqid": {
+      "version": "4.1.1",
+      "from": "uniqid@>=4.0.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz"
+    },
+    "uniqs": {
+      "version": "2.0.0",
+      "from": "uniqs@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/uniqs/-/uniqs-2.0.0.tgz"
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "from": "unpipe@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+    },
+    "urix": {
+      "version": "0.1.0",
+      "from": "urix@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/urix/-/urix-0.1.0.tgz"
+    },
+    "url": {
+      "version": "0.11.0",
+      "from": "url@>=0.11.0 <0.12.0",
+      "resolved": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
+      "dependencies": {
+        "punycode": {
+          "version": "1.3.2",
+          "from": "punycode@1.3.2",
+          "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
         }
       }
     },
@@ -11324,3007 +5316,318 @@
         "loader-utils": {
           "version": "1.1.0",
           "from": "loader-utils@>=1.0.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            }
-          }
-        },
-        "mime": {
-          "version": "1.3.6",
-          "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
+          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz"
         }
       }
+    },
+    "url-parse": {
+      "version": "1.1.9",
+      "from": "url-parse@>=1.1.8 <2.0.0",
+      "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
+      "dependencies": {
+        "querystringify": {
+          "version": "1.0.0",
+          "from": "querystringify@>=1.0.0 <1.1.0",
+          "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
+        }
+      }
+    },
+    "user-home": {
+      "version": "2.0.0",
+      "from": "user-home@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+      "dev": true
+    },
+    "util": {
+      "version": "0.10.3",
+      "from": "util@>=0.10.3 <0.11.0",
+      "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2.0.1",
+          "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        }
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "from": "util-deprecate@>=1.0.1 <1.1.0",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+    },
+    "utils-merge": {
+      "version": "1.0.0",
+      "from": "utils-merge@1.0.0",
+      "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+    },
+    "uuid": {
+      "version": "3.1.0",
+      "from": "uuid@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.1",
+      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz"
+    },
+    "validator": {
+      "version": "6.3.0",
+      "from": "validator@>=6.0.0 <7.0.0",
+      "resolved": "http://registry.npmjs.org/validator/-/validator-6.3.0.tgz"
+    },
+    "vary": {
+      "version": "1.1.1",
+      "from": "vary@>=1.1.1 <1.2.0",
+      "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
+    },
+    "vendors": {
+      "version": "1.0.1",
+      "from": "vendors@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/vendors/-/vendors-1.0.1.tgz"
+    },
+    "verror": {
+      "version": "1.3.6",
+      "from": "verror@1.3.6",
+      "resolved": "http://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+    },
+    "vm-browserify": {
+      "version": "0.0.4",
+      "from": "vm-browserify@0.0.4",
+      "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz"
+    },
+    "warning": {
+      "version": "3.0.0",
+      "from": "warning@>=3.0.0 <4.0.0",
+      "resolved": "http://registry.npmjs.org/warning/-/warning-3.0.0.tgz"
+    },
+    "watchpack": {
+      "version": "0.2.9",
+      "from": "watchpack@>=0.2.1 <0.3.0",
+      "resolved": "http://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz"
+        }
+      }
+    },
+    "webidl-conversions": {
+      "version": "4.0.1",
+      "from": "webidl-conversions@>=4.0.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.1.tgz",
+      "dev": true
     },
     "webpack": {
       "version": "1.15.0",
       "from": "webpack@>=1.9.11 <2.0.0",
-      "resolved": "http://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz",
-      "dependencies": {
-        "acorn": {
-          "version": "3.3.0",
-          "from": "acorn@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz"
-        },
-        "async": {
-          "version": "1.5.2",
-          "from": "async@>=1.3.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
-        },
-        "clone": {
-          "version": "1.0.2",
-          "from": "clone@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.2.tgz"
-        },
-        "enhanced-resolve": {
-          "version": "0.9.1",
-          "from": "enhanced-resolve@>=0.9.0 <0.10.0",
-          "resolved": "http://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-0.9.1.tgz",
-          "dependencies": {
-            "memory-fs": {
-              "version": "0.2.0",
-              "from": "memory-fs@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.2.0.tgz"
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            }
-          }
-        },
-        "interpret": {
-          "version": "0.6.6",
-          "from": "interpret@>=0.6.4 <0.7.0",
-          "resolved": "http://registry.npmjs.org/interpret/-/interpret-0.6.6.tgz"
-        },
-        "loader-utils": {
-          "version": "0.2.17",
-          "from": "loader-utils@>=0.2.11 <0.3.0",
-          "resolved": "http://registry.npmjs.org/loader-utils/-/loader-utils-0.2.17.tgz",
-          "dependencies": {
-            "big.js": {
-              "version": "3.1.3",
-              "from": "big.js@>=3.1.3 <4.0.0",
-              "resolved": "http://registry.npmjs.org/big.js/-/big.js-3.1.3.tgz"
-            },
-            "emojis-list": {
-              "version": "2.1.0",
-              "from": "emojis-list@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz"
-            },
-            "json5": {
-              "version": "0.5.1",
-              "from": "json5@>=0.5.0 <0.6.0",
-              "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz"
-            },
-            "object-assign": {
-              "version": "4.1.1",
-              "from": "object-assign@>=4.1.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-            }
-          }
-        },
-        "memory-fs": {
-          "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
-          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
-              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
-                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.0 <0.6.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "node-libs-browser": {
-          "version": "0.7.0",
-          "from": "node-libs-browser@>=0.7.0 <0.8.0",
-          "resolved": "http://registry.npmjs.org/node-libs-browser/-/node-libs-browser-0.7.0.tgz",
-          "dependencies": {
-            "assert": {
-              "version": "1.4.1",
-              "from": "assert@>=1.1.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/assert/-/assert-1.4.1.tgz"
-            },
-            "browserify-zlib": {
-              "version": "0.1.4",
-              "from": "browserify-zlib@>=0.1.4 <0.2.0",
-              "resolved": "http://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.1.4.tgz",
-              "dependencies": {
-                "pako": {
-                  "version": "0.2.9",
-                  "from": "pako@>=0.2.0 <0.3.0",
-                  "resolved": "http://registry.npmjs.org/pako/-/pako-0.2.9.tgz"
-                }
-              }
-            },
-            "buffer": {
-              "version": "4.9.1",
-              "from": "buffer@>=4.9.0 <5.0.0",
-              "resolved": "http://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-              "dependencies": {
-                "base64-js": {
-                  "version": "1.2.1",
-                  "from": "base64-js@>=1.0.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/base64-js/-/base64-js-1.2.1.tgz"
-                },
-                "ieee754": {
-                  "version": "1.1.8",
-                  "from": "ieee754@>=1.1.4 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                }
-              }
-            },
-            "console-browserify": {
-              "version": "1.1.0",
-              "from": "console-browserify@>=1.1.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
-              "dependencies": {
-                "date-now": {
-                  "version": "0.1.4",
-                  "from": "date-now@>=0.1.4 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/date-now/-/date-now-0.1.4.tgz"
-                }
-              }
-            },
-            "constants-browserify": {
-              "version": "1.0.0",
-              "from": "constants-browserify@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz"
-            },
-            "crypto-browserify": {
-              "version": "3.3.0",
-              "from": "crypto-browserify@3.3.0",
-              "resolved": "http://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.3.0.tgz",
-              "dependencies": {
-                "pbkdf2-compat": {
-                  "version": "2.0.1",
-                  "from": "pbkdf2-compat@2.0.1",
-                  "resolved": "http://registry.npmjs.org/pbkdf2-compat/-/pbkdf2-compat-2.0.1.tgz"
-                },
-                "ripemd160": {
-                  "version": "0.2.0",
-                  "from": "ripemd160@0.2.0",
-                  "resolved": "http://registry.npmjs.org/ripemd160/-/ripemd160-0.2.0.tgz"
-                },
-                "sha.js": {
-                  "version": "2.2.6",
-                  "from": "sha.js@2.2.6",
-                  "resolved": "http://registry.npmjs.org/sha.js/-/sha.js-2.2.6.tgz"
-                },
-                "browserify-aes": {
-                  "version": "0.4.0",
-                  "from": "browserify-aes@0.4.0",
-                  "resolved": "http://registry.npmjs.org/browserify-aes/-/browserify-aes-0.4.0.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "domain-browser": {
-              "version": "1.1.7",
-              "from": "domain-browser@>=1.1.1 <2.0.0",
-              "resolved": "http://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz"
-            },
-            "events": {
-              "version": "1.1.1",
-              "from": "events@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/events/-/events-1.1.1.tgz"
-            },
-            "https-browserify": {
-              "version": "0.0.1",
-              "from": "https-browserify@0.0.1",
-              "resolved": "http://registry.npmjs.org/https-browserify/-/https-browserify-0.0.1.tgz"
-            },
-            "os-browserify": {
-              "version": "0.2.1",
-              "from": "os-browserify@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/os-browserify/-/os-browserify-0.2.1.tgz"
-            },
-            "path-browserify": {
-              "version": "0.0.0",
-              "from": "path-browserify@0.0.0",
-              "resolved": "http://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz"
-            },
-            "process": {
-              "version": "0.11.10",
-              "from": "process@>=0.11.0 <0.12.0",
-              "resolved": "http://registry.npmjs.org/process/-/process-0.11.10.tgz"
-            },
-            "punycode": {
-              "version": "1.4.1",
-              "from": "punycode@>=1.2.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-            },
-            "querystring-es3": {
-              "version": "0.2.1",
-              "from": "querystring-es3@>=0.2.0 <0.3.0",
-              "resolved": "http://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz"
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "from": "readable-stream@>=2.0.5 <3.0.0",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            },
-            "stream-browserify": {
-              "version": "2.0.1",
-              "from": "stream-browserify@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                }
-              }
-            },
-            "stream-http": {
-              "version": "2.7.2",
-              "from": "stream-http@>=2.3.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/stream-http/-/stream-http-2.7.2.tgz",
-              "dependencies": {
-                "builtin-status-codes": {
-                  "version": "3.0.0",
-                  "from": "builtin-status-codes@>=3.0.0 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "to-arraybuffer": {
-                  "version": "1.0.1",
-                  "from": "to-arraybuffer@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz"
-                },
-                "xtend": {
-                  "version": "4.0.1",
-                  "from": "xtend@>=4.0.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                }
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "from": "string_decoder@>=0.10.25 <0.11.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
-            },
-            "timers-browserify": {
-              "version": "2.0.2",
-              "from": "timers-browserify@>=2.0.2 <3.0.0",
-              "resolved": "http://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.2.tgz",
-              "dependencies": {
-                "setimmediate": {
-                  "version": "1.0.5",
-                  "from": "setimmediate@>=1.0.4 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz"
-                }
-              }
-            },
-            "tty-browserify": {
-              "version": "0.0.0",
-              "from": "tty-browserify@0.0.0",
-              "resolved": "http://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz"
-            },
-            "url": {
-              "version": "0.11.0",
-              "from": "url@>=0.11.0 <0.12.0",
-              "resolved": "http://registry.npmjs.org/url/-/url-0.11.0.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.3.2",
-                  "from": "punycode@1.3.2",
-                  "resolved": "http://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
-                },
-                "querystring": {
-                  "version": "0.2.0",
-                  "from": "querystring@0.2.0",
-                  "resolved": "http://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
-                }
-              }
-            },
-            "util": {
-              "version": "0.10.3",
-              "from": "util@>=0.10.3 <0.11.0",
-              "resolved": "http://registry.npmjs.org/util/-/util-0.10.3.tgz",
-              "dependencies": {
-                "inherits": {
-                  "version": "2.0.1",
-                  "from": "inherits@2.0.1",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
-                }
-              }
-            },
-            "vm-browserify": {
-              "version": "0.0.4",
-              "from": "vm-browserify@0.0.4",
-              "resolved": "http://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-              "dependencies": {
-                "indexof": {
-                  "version": "0.0.1",
-                  "from": "indexof@0.0.1",
-                  "resolved": "http://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz"
-                }
-              }
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "from": "supports-color@>=3.1.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
-        },
-        "tapable": {
-          "version": "0.1.10",
-          "from": "tapable@>=0.1.8 <0.2.0",
-          "resolved": "http://registry.npmjs.org/tapable/-/tapable-0.1.10.tgz"
-        },
-        "uglify-js": {
-          "version": "2.7.5",
-          "from": "uglify-js@>=2.7.3 <2.8.0",
-          "resolved": "http://registry.npmjs.org/uglify-js/-/uglify-js-2.7.5.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.2.10",
-              "from": "async@>=0.2.6 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
-            },
-            "source-map": {
-              "version": "0.5.6",
-              "from": "source-map@>=0.5.1 <0.6.0",
-              "resolved": "http://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz"
-            },
-            "uglify-to-browserify": {
-              "version": "1.0.2",
-              "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz"
-            },
-            "yargs": {
-              "version": "3.10.0",
-              "from": "yargs@>=3.10.0 <3.11.0",
-              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-              "dependencies": {
-                "camelcase": {
-                  "version": "1.2.1",
-                  "from": "camelcase@>=1.0.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
-                },
-                "cliui": {
-                  "version": "2.1.0",
-                  "from": "cliui@>=2.1.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
-                  "dependencies": {
-                    "center-align": {
-                      "version": "0.1.3",
-                      "from": "center-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.2.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "is-buffer@>=1.1.5 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                            }
-                          }
-                        },
-                        "lazy-cache": {
-                          "version": "1.0.4",
-                          "from": "lazy-cache@>=1.0.3 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz"
-                        }
-                      }
-                    },
-                    "right-align": {
-                      "version": "0.1.3",
-                      "from": "right-align@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-                      "dependencies": {
-                        "align-text": {
-                          "version": "0.1.4",
-                          "from": "align-text@>=0.1.1 <0.2.0",
-                          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
-                          "dependencies": {
-                            "kind-of": {
-                              "version": "3.2.2",
-                              "from": "kind-of@>=3.0.2 <4.0.0",
-                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                              "dependencies": {
-                                "is-buffer": {
-                                  "version": "1.1.5",
-                                  "from": "is-buffer@>=1.1.5 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                }
-                              }
-                            },
-                            "longest": {
-                              "version": "1.0.1",
-                              "from": "longest@>=1.0.1 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "wordwrap": {
-                      "version": "0.0.2",
-                      "from": "wordwrap@0.0.2",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
-                    }
-                  }
-                },
-                "decamelize": {
-                  "version": "1.2.0",
-                  "from": "decamelize@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
-                },
-                "window-size": {
-                  "version": "0.1.0",
-                  "from": "window-size@0.1.0",
-                  "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "watchpack": {
-          "version": "0.2.9",
-          "from": "watchpack@>=0.2.1 <0.3.0",
-          "resolved": "http://registry.npmjs.org/watchpack/-/watchpack-0.2.9.tgz",
-          "dependencies": {
-            "async": {
-              "version": "0.9.2",
-              "from": "async@>=0.9.0 <0.10.0",
-              "resolved": "http://registry.npmjs.org/async/-/async-0.9.2.tgz"
-            },
-            "chokidar": {
-              "version": "1.7.0",
-              "from": "chokidar@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
-              "dependencies": {
-                "anymatch": {
-                  "version": "1.3.0",
-                  "from": "anymatch@>=1.3.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/anymatch/-/anymatch-1.3.0.tgz",
-                  "dependencies": {
-                    "arrify": {
-                      "version": "1.0.1",
-                      "from": "arrify@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz"
-                    },
-                    "micromatch": {
-                      "version": "2.3.11",
-                      "from": "micromatch@>=2.1.5 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-                      "dependencies": {
-                        "arr-diff": {
-                          "version": "2.0.0",
-                          "from": "arr-diff@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                          "dependencies": {
-                            "arr-flatten": {
-                              "version": "1.1.0",
-                              "from": "arr-flatten@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
-                            }
-                          }
-                        },
-                        "array-unique": {
-                          "version": "0.2.1",
-                          "from": "array-unique@>=0.2.1 <0.3.0",
-                          "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                        },
-                        "braces": {
-                          "version": "1.8.5",
-                          "from": "braces@>=1.8.2 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                          "dependencies": {
-                            "expand-range": {
-                              "version": "1.8.2",
-                              "from": "expand-range@>=1.8.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                              "dependencies": {
-                                "fill-range": {
-                                  "version": "2.2.3",
-                                  "from": "fill-range@>=2.1.0 <3.0.0",
-                                  "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                                  "dependencies": {
-                                    "is-number": {
-                                      "version": "2.1.0",
-                                      "from": "is-number@>=2.1.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                                    },
-                                    "isobject": {
-                                      "version": "2.1.0",
-                                      "from": "isobject@>=2.0.0 <3.0.0",
-                                      "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                                      "dependencies": {
-                                        "isarray": {
-                                          "version": "1.0.0",
-                                          "from": "isarray@1.0.0",
-                                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                                        }
-                                      }
-                                    },
-                                    "randomatic": {
-                                      "version": "1.1.7",
-                                      "from": "randomatic@>=1.1.3 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                                      "dependencies": {
-                                        "is-number": {
-                                          "version": "3.0.0",
-                                          "from": "is-number@>=3.0.0 <4.0.0",
-                                          "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                                          "dependencies": {
-                                            "kind-of": {
-                                              "version": "3.2.2",
-                                              "from": "kind-of@>=3.0.2 <4.0.0",
-                                              "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                              "dependencies": {
-                                                "is-buffer": {
-                                                  "version": "1.1.5",
-                                                  "from": "is-buffer@>=1.1.5 <2.0.0",
-                                                  "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                                }
-                                              }
-                                            }
-                                          }
-                                        },
-                                        "kind-of": {
-                                          "version": "4.0.0",
-                                          "from": "kind-of@>=4.0.0 <5.0.0",
-                                          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                                          "dependencies": {
-                                            "is-buffer": {
-                                              "version": "1.1.5",
-                                              "from": "is-buffer@>=1.1.5 <2.0.0",
-                                              "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                            }
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "repeat-string": {
-                                      "version": "1.6.1",
-                                      "from": "repeat-string@>=1.5.2 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "preserve": {
-                              "version": "0.2.0",
-                              "from": "preserve@>=0.2.0 <0.3.0",
-                              "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                            },
-                            "repeat-element": {
-                              "version": "1.1.2",
-                              "from": "repeat-element@>=1.1.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                            }
-                          }
-                        },
-                        "expand-brackets": {
-                          "version": "0.1.5",
-                          "from": "expand-brackets@>=0.1.4 <0.2.0",
-                          "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                          "dependencies": {
-                            "is-posix-bracket": {
-                              "version": "0.1.1",
-                              "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                              "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-                            }
-                          }
-                        },
-                        "extglob": {
-                          "version": "0.3.2",
-                          "from": "extglob@>=0.3.1 <0.4.0",
-                          "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-                        },
-                        "filename-regex": {
-                          "version": "2.0.1",
-                          "from": "filename-regex@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
-                        },
-                        "is-extglob": {
-                          "version": "1.0.0",
-                          "from": "is-extglob@>=1.0.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                        },
-                        "kind-of": {
-                          "version": "3.2.2",
-                          "from": "kind-of@>=3.0.2 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                          "dependencies": {
-                            "is-buffer": {
-                              "version": "1.1.5",
-                              "from": "is-buffer@>=1.1.5 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                            }
-                          }
-                        },
-                        "normalize-path": {
-                          "version": "2.1.1",
-                          "from": "normalize-path@>=2.0.1 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                          "dependencies": {
-                            "remove-trailing-separator": {
-                              "version": "1.0.2",
-                              "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-                            }
-                          }
-                        },
-                        "object.omit": {
-                          "version": "2.0.1",
-                          "from": "object.omit@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                          "dependencies": {
-                            "for-own": {
-                              "version": "0.1.5",
-                              "from": "for-own@>=0.1.4 <0.2.0",
-                              "resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                              "dependencies": {
-                                "for-in": {
-                                  "version": "1.0.2",
-                                  "from": "for-in@>=1.0.1 <2.0.0",
-                                  "resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-                                }
-                              }
-                            },
-                            "is-extendable": {
-                              "version": "0.1.1",
-                              "from": "is-extendable@>=0.1.1 <0.2.0",
-                              "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                            }
-                          }
-                        },
-                        "parse-glob": {
-                          "version": "3.0.4",
-                          "from": "parse-glob@>=3.0.4 <4.0.0",
-                          "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                          "dependencies": {
-                            "glob-base": {
-                              "version": "0.3.0",
-                              "from": "glob-base@>=0.3.0 <0.4.0",
-                              "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz"
-                            },
-                            "is-dotfile": {
-                              "version": "1.0.3",
-                              "from": "is-dotfile@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
-                            }
-                          }
-                        },
-                        "regex-cache": {
-                          "version": "0.4.3",
-                          "from": "regex-cache@>=0.4.2 <0.5.0",
-                          "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                          "dependencies": {
-                            "is-equal-shallow": {
-                              "version": "0.1.3",
-                              "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-                              "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                            },
-                            "is-primitive": {
-                              "version": "2.0.0",
-                              "from": "is-primitive@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                },
-                "async-each": {
-                  "version": "1.0.1",
-                  "from": "async-each@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz"
-                },
-                "glob-parent": {
-                  "version": "2.0.0",
-                  "from": "glob-parent@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "is-binary-path": {
-                  "version": "1.0.1",
-                  "from": "is-binary-path@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
-                  "dependencies": {
-                    "binary-extensions": {
-                      "version": "1.9.0",
-                      "from": "binary-extensions@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz"
-                    }
-                  }
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "from": "is-glob@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
-                  "dependencies": {
-                    "is-extglob": {
-                      "version": "1.0.0",
-                      "from": "is-extglob@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                    }
-                  }
-                },
-                "path-is-absolute": {
-                  "version": "1.0.1",
-                  "from": "path-is-absolute@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                },
-                "readdirp": {
-                  "version": "2.1.0",
-                  "from": "readdirp@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
-                  "dependencies": {
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@>=3.0.2 <4.0.0",
-                      "resolved": "http://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-                      "dependencies": {
-                        "brace-expansion": {
-                          "version": "1.1.8",
-                          "from": "brace-expansion@>=1.1.7 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-                          "dependencies": {
-                            "balanced-match": {
-                              "version": "1.0.0",
-                              "from": "balanced-match@>=1.0.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
-                            },
-                            "concat-map": {
-                              "version": "0.0.1",
-                              "from": "concat-map@0.0.1",
-                              "resolved": "http://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "readable-stream": {
-                      "version": "2.3.3",
-                      "from": "readable-stream@>=2.0.2 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                      "dependencies": {
-                        "core-util-is": {
-                          "version": "1.0.2",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                        },
-                        "isarray": {
-                          "version": "1.0.0",
-                          "from": "isarray@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                        },
-                        "process-nextick-args": {
-                          "version": "1.0.7",
-                          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                          "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                        },
-                        "safe-buffer": {
-                          "version": "5.1.1",
-                          "from": "safe-buffer@>=5.1.1 <5.2.0",
-                          "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                        },
-                        "string_decoder": {
-                          "version": "1.0.3",
-                          "from": "string_decoder@>=1.0.3 <1.1.0",
-                          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                        },
-                        "util-deprecate": {
-                          "version": "1.0.2",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "set-immediate-shim": {
-                      "version": "1.0.1",
-                      "from": "set-immediate-shim@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz"
-                    }
-                  }
-                },
-                "fsevents": {
-                  "version": "1.1.2",
-                  "from": "fsevents@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/fsevents/-/fsevents-1.1.2.tgz",
-                  "dependencies": {
-                    "nan": {
-                      "version": "2.6.2",
-                      "from": "nan@>=2.3.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/nan/-/nan-2.6.2.tgz"
-                    },
-                    "node-pre-gyp": {
-                      "version": "0.6.36",
-                      "from": "node-pre-gyp@^0.6.36",
-                      "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.6.36.tgz"
-                    },
-                    "abbrev": {
-                      "version": "1.1.0",
-                      "from": "abbrev@1.1.0",
-                      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz"
-                    },
-                    "ansi-regex": {
-                      "version": "2.1.1",
-                      "from": "ansi-regex@2.1.1",
-                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                    },
-                    "ajv": {
-                      "version": "4.11.8",
-                      "from": "ajv@4.11.8",
-                      "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz"
-                    },
-                    "are-we-there-yet": {
-                      "version": "1.1.4",
-                      "from": "are-we-there-yet@1.1.4",
-                      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz"
-                    },
-                    "aproba": {
-                      "version": "1.1.1",
-                      "from": "aproba@1.1.1",
-                      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.1.1.tgz"
-                    },
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@0.2.3",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "0.2.0",
-                      "from": "assert-plus@0.2.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                    },
-                    "asynckit": {
-                      "version": "0.4.0",
-                      "from": "asynckit@0.4.0",
-                      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                    },
-                    "aws-sign2": {
-                      "version": "0.6.0",
-                      "from": "aws-sign2@0.6.0",
-                      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-                    },
-                    "balanced-match": {
-                      "version": "0.4.2",
-                      "from": "balanced-match@0.4.2",
-                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz"
-                    },
-                    "aws4": {
-                      "version": "1.6.0",
-                      "from": "aws4@1.6.0",
-                      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@1.0.1",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz"
-                    },
-                    "block-stream": {
-                      "version": "0.0.9",
-                      "from": "block-stream@0.0.9",
-                      "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.9.tgz"
-                    },
-                    "boom": {
-                      "version": "2.10.1",
-                      "from": "boom@2.10.1",
-                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                    },
-                    "brace-expansion": {
-                      "version": "1.1.7",
-                      "from": "brace-expansion@1.1.7",
-                      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz"
-                    },
-                    "buffer-shims": {
-                      "version": "1.0.0",
-                      "from": "buffer-shims@1.0.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
-                    },
-                    "caseless": {
-                      "version": "0.12.0",
-                      "from": "caseless@0.12.0",
-                      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-                    },
-                    "co": {
-                      "version": "4.6.0",
-                      "from": "co@4.6.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-                    },
-                    "code-point-at": {
-                      "version": "1.1.0",
-                      "from": "code-point-at@1.1.0",
-                      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz"
-                    },
-                    "combined-stream": {
-                      "version": "1.0.5",
-                      "from": "combined-stream@1.0.5",
-                      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-                    },
-                    "concat-map": {
-                      "version": "0.0.1",
-                      "from": "concat-map@0.0.1",
-                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
-                    },
-                    "console-control-strings": {
-                      "version": "1.1.0",
-                      "from": "console-control-strings@1.1.0",
-                      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz"
-                    },
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@1.0.2",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "cryptiles": {
-                      "version": "2.0.5",
-                      "from": "cryptiles@2.0.5",
-                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                    },
-                    "debug": {
-                      "version": "2.6.8",
-                      "from": "debug@2.6.8",
-                      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz"
-                    },
-                    "deep-extend": {
-                      "version": "0.4.2",
-                      "from": "deep-extend@0.4.2",
-                      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz"
-                    },
-                    "delayed-stream": {
-                      "version": "1.0.0",
-                      "from": "delayed-stream@1.0.0",
-                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                    },
-                    "delegates": {
-                      "version": "1.0.0",
-                      "from": "delegates@1.0.0",
-                      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
-                    },
-                    "extend": {
-                      "version": "3.0.1",
-                      "from": "extend@3.0.1",
-                      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-                    },
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "forever-agent": {
-                      "version": "0.6.1",
-                      "from": "forever-agent@0.6.1",
-                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-                    },
-                    "form-data": {
-                      "version": "2.1.4",
-                      "from": "form-data@2.1.4",
-                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz"
-                    },
-                    "fstream": {
-                      "version": "1.0.11",
-                      "from": "fstream@1.0.11",
-                      "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.11.tgz"
-                    },
-                    "fs.realpath": {
-                      "version": "1.0.0",
-                      "from": "fs.realpath@1.0.0",
-                      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-                    },
-                    "fstream-ignore": {
-                      "version": "1.0.5",
-                      "from": "fstream-ignore@1.0.5",
-                      "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-1.0.5.tgz"
-                    },
-                    "gauge": {
-                      "version": "2.7.4",
-                      "from": "gauge@2.7.4",
-                      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz"
-                    },
-                    "glob": {
-                      "version": "7.1.2",
-                      "from": "glob@7.1.2",
-                      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
-                    },
-                    "graceful-fs": {
-                      "version": "4.1.11",
-                      "from": "graceful-fs@4.1.11",
-                      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-                    },
-                    "har-schema": {
-                      "version": "1.0.5",
-                      "from": "har-schema@1.0.5",
-                      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
-                    },
-                    "har-validator": {
-                      "version": "4.2.1",
-                      "from": "har-validator@4.2.1",
-                      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz"
-                    },
-                    "has-unicode": {
-                      "version": "2.0.1",
-                      "from": "has-unicode@2.0.1",
-                      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz"
-                    },
-                    "hawk": {
-                      "version": "3.1.3",
-                      "from": "hawk@3.1.3",
-                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz"
-                    },
-                    "hoek": {
-                      "version": "2.16.3",
-                      "from": "hoek@2.16.3",
-                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                    },
-                    "http-signature": {
-                      "version": "1.1.1",
-                      "from": "http-signature@1.1.1",
-                      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz"
-                    },
-                    "inflight": {
-                      "version": "1.0.6",
-                      "from": "inflight@1.0.6",
-                      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "ini": {
-                      "version": "1.3.4",
-                      "from": "ini@1.3.4",
-                      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
-                    },
-                    "is-fullwidth-code-point": {
-                      "version": "1.0.0",
-                      "from": "is-fullwidth-code-point@1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz"
-                    },
-                    "is-typedarray": {
-                      "version": "1.0.0",
-                      "from": "is-typedarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-                    },
-                    "isstream": {
-                      "version": "0.1.2",
-                      "from": "isstream@0.1.2",
-                      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@1.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@1.0.2",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
-                    },
-                    "jsbn": {
-                      "version": "0.1.1",
-                      "from": "jsbn@0.1.1",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "json-stringify-safe": {
-                      "version": "5.0.1",
-                      "from": "json-stringify-safe@5.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-                    },
-                    "json-stable-stringify": {
-                      "version": "1.0.1",
-                      "from": "json-stable-stringify@1.0.1",
-                      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz"
-                    },
-                    "jsonify": {
-                      "version": "0.0.0",
-                      "from": "jsonify@0.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
-                    },
-                    "mime-types": {
-                      "version": "2.1.15",
-                      "from": "mime-types@2.1.15",
-                      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz"
-                    },
-                    "mime-db": {
-                      "version": "1.27.0",
-                      "from": "mime-db@1.27.0",
-                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz"
-                    },
-                    "minimatch": {
-                      "version": "3.0.4",
-                      "from": "minimatch@3.0.4",
-                      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
-                    },
-                    "minimist": {
-                      "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-                    },
-                    "ms": {
-                      "version": "2.0.0",
-                      "from": "ms@2.0.0",
-                      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                    },
-                    "mkdirp": {
-                      "version": "0.5.1",
-                      "from": "mkdirp@0.5.1",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
-                    },
-                    "nopt": {
-                      "version": "4.0.1",
-                      "from": "nopt@4.0.1",
-                      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz"
-                    },
-                    "npmlog": {
-                      "version": "4.1.0",
-                      "from": "npmlog@4.1.0",
-                      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.0.tgz"
-                    },
-                    "number-is-nan": {
-                      "version": "1.0.1",
-                      "from": "number-is-nan@1.0.1",
-                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
-                    },
-                    "oauth-sign": {
-                      "version": "0.8.2",
-                      "from": "oauth-sign@0.8.2",
-                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-                    },
-                    "object-assign": {
-                      "version": "4.1.1",
-                      "from": "object-assign@4.1.1",
-                      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz"
-                    },
-                    "once": {
-                      "version": "1.4.0",
-                      "from": "once@1.4.0",
-                      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
-                    },
-                    "os-homedir": {
-                      "version": "1.0.2",
-                      "from": "os-homedir@1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz"
-                    },
-                    "os-tmpdir": {
-                      "version": "1.0.2",
-                      "from": "os-tmpdir@1.0.2",
-                      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
-                    },
-                    "path-is-absolute": {
-                      "version": "1.0.1",
-                      "from": "path-is-absolute@1.0.1",
-                      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-                    },
-                    "osenv": {
-                      "version": "0.1.4",
-                      "from": "osenv@0.1.4",
-                      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.4.tgz"
-                    },
-                    "performance-now": {
-                      "version": "0.2.0",
-                      "from": "performance-now@0.2.0",
-                      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@1.0.7",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "punycode": {
-                      "version": "1.4.1",
-                      "from": "punycode@1.4.1",
-                      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                    },
-                    "qs": {
-                      "version": "6.4.0",
-                      "from": "qs@6.4.0",
-                      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-                    },
-                    "readable-stream": {
-                      "version": "2.2.9",
-                      "from": "readable-stream@2.2.9",
-                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.9.tgz"
-                    },
-                    "request": {
-                      "version": "2.81.0",
-                      "from": "request@2.81.0",
-                      "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz"
-                    },
-                    "rimraf": {
-                      "version": "2.6.1",
-                      "from": "rimraf@2.6.1",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.0.1",
-                      "from": "safe-buffer@5.0.1",
-                      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-                    },
-                    "semver": {
-                      "version": "5.3.0",
-                      "from": "semver@5.3.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
-                    },
-                    "set-blocking": {
-                      "version": "2.0.0",
-                      "from": "set-blocking@2.0.0",
-                      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz"
-                    },
-                    "signal-exit": {
-                      "version": "3.0.2",
-                      "from": "signal-exit@3.0.2",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz"
-                    },
-                    "sntp": {
-                      "version": "1.0.9",
-                      "from": "sntp@1.0.9",
-                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                    },
-                    "string-width": {
-                      "version": "1.0.2",
-                      "from": "string-width@1.0.2",
-                      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.1",
-                      "from": "string_decoder@1.0.1",
-                      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.1.tgz"
-                    },
-                    "strip-json-comments": {
-                      "version": "2.0.1",
-                      "from": "strip-json-comments@2.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
-                    },
-                    "stringstream": {
-                      "version": "0.0.5",
-                      "from": "stringstream@0.0.5",
-                      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@3.0.1",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz"
-                    },
-                    "tar": {
-                      "version": "2.2.1",
-                      "from": "tar@2.2.1",
-                      "resolved": "https://registry.npmjs.org/tar/-/tar-2.2.1.tgz"
-                    },
-                    "tar-pack": {
-                      "version": "3.4.0",
-                      "from": "tar-pack@3.4.0",
-                      "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-3.4.0.tgz"
-                    },
-                    "tough-cookie": {
-                      "version": "2.3.2",
-                      "from": "tough-cookie@2.3.2",
-                      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz"
-                    },
-                    "tunnel-agent": {
-                      "version": "0.6.0",
-                      "from": "tunnel-agent@0.6.0",
-                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.5",
-                      "from": "tweetnacl@0.14.5",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz"
-                    },
-                    "uid-number": {
-                      "version": "0.0.6",
-                      "from": "uid-number@0.0.6",
-                      "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.6.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@1.0.2",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    },
-                    "uuid": {
-                      "version": "3.0.1",
-                      "from": "uuid@3.0.1",
-                      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    },
-                    "wide-align": {
-                      "version": "1.1.2",
-                      "from": "wide-align@1.1.2",
-                      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
-                    },
-                    "wrappy": {
-                      "version": "1.0.2",
-                      "from": "wrappy@1.0.2",
-                      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
-                    },
-                    "dashdash": {
-                      "version": "1.14.1",
-                      "from": "dashdash@1.14.1",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "jsprim": {
-                      "version": "1.4.0",
-                      "from": "jsprim@1.4.0",
-                      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "sshpk": {
-                      "version": "1.13.0",
-                      "from": "sshpk@1.13.0",
-                      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.0.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "getpass": {
-                      "version": "0.1.7",
-                      "from": "getpass@0.1.7",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-                      "dependencies": {
-                        "assert-plus": {
-                          "version": "1.0.0",
-                          "from": "assert-plus@1.0.0",
-                          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                        }
-                      }
-                    },
-                    "rc": {
-                      "version": "1.2.1",
-                      "from": "rc@1.2.1",
-                      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.1.tgz",
-                      "dependencies": {
-                        "minimist": {
-                          "version": "1.2.0",
-                          "from": "minimist@1.2.0",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.1.11",
-              "from": "graceful-fs@>=4.1.2 <5.0.0",
-              "resolved": "http://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
-            }
-          }
-        },
-        "webpack-core": {
-          "version": "0.6.9",
-          "from": "webpack-core@>=0.6.9 <0.7.0",
-          "resolved": "http://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
-          "dependencies": {
-            "source-map": {
-              "version": "0.4.4",
-              "from": "source-map@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
-              "dependencies": {
-                "amdefine": {
-                  "version": "1.0.1",
-                  "from": "amdefine@>=0.0.4",
-                  "resolved": "http://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
-                }
-              }
-            },
-            "source-list-map": {
-              "version": "0.1.8",
-              "from": "source-list-map@>=0.1.7 <0.2.0",
-              "resolved": "http://registry.npmjs.org/source-list-map/-/source-list-map-0.1.8.tgz"
-            }
-          }
-        }
-      }
+      "resolved": "http://registry.npmjs.org/webpack/-/webpack-1.15.0.tgz"
     },
     "webpack-bundle-analyzer": {
       "version": "2.8.3",
       "from": "webpack-bundle-analyzer@>=2.8.2 <3.0.0",
       "resolved": "http://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-2.8.3.tgz",
+      "dev": true,
       "dependencies": {
         "acorn": {
           "version": "5.1.1",
           "from": "acorn@>=5.1.1 <6.0.0",
-          "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz"
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "from": "chalk@>=1.1.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "dependencies": {
-            "ansi-styles": {
-              "version": "2.2.1",
-              "from": "ansi-styles@>=2.2.1 <3.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-            },
-            "escape-string-regexp": {
-              "version": "1.0.5",
-              "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-            },
-            "has-ansi": {
-              "version": "2.0.0",
-              "from": "has-ansi@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "strip-ansi": {
-              "version": "3.0.1",
-              "from": "strip-ansi@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-              "dependencies": {
-                "ansi-regex": {
-                  "version": "2.1.1",
-                  "from": "ansi-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-                }
-              }
-            },
-            "supports-color": {
-              "version": "2.0.0",
-              "from": "supports-color@>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-            }
-          }
-        },
-        "commander": {
-          "version": "2.11.0",
-          "from": "commander@>=2.9.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-2.11.0.tgz"
-        },
-        "ejs": {
-          "version": "2.5.6",
-          "from": "ejs@>=2.5.6 <3.0.0",
-          "resolved": "http://registry.npmjs.org/ejs/-/ejs-2.5.6.tgz"
-        },
-        "express": {
-          "version": "4.15.3",
-          "from": "express@>=4.15.2 <5.0.0",
-          "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.3.3",
-              "from": "accepts@>=1.3.3 <1.4.0",
-              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.16",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.29.0",
-                      "from": "mime-db@>=1.29.0 <1.30.0",
-                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.6.1",
-                  "from": "negotiator@0.6.1",
-                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                }
-              }
-            },
-            "array-flatten": {
-              "version": "1.1.1",
-              "from": "array-flatten@1.1.1",
-              "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-            },
-            "content-disposition": {
-              "version": "0.5.2",
-              "from": "content-disposition@0.5.2",
-              "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
-            },
-            "content-type": {
-              "version": "1.0.2",
-              "from": "content-type@>=1.0.2 <1.1.0",
-              "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-            },
-            "cookie": {
-              "version": "0.3.1",
-              "from": "cookie@0.3.1",
-              "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-            },
-            "cookie-signature": {
-              "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
-              "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-            },
-            "debug": {
-              "version": "2.6.7",
-              "from": "debug@2.6.7",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "depd": {
-              "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-            },
-            "encodeurl": {
-              "version": "1.0.1",
-              "from": "encodeurl@>=1.0.1 <1.1.0",
-              "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-            },
-            "etag": {
-              "version": "1.8.0",
-              "from": "etag@>=1.8.0 <1.9.0",
-              "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
-            },
-            "finalhandler": {
-              "version": "1.0.3",
-              "from": "finalhandler@>=1.0.3 <1.1.0",
-              "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-              "dependencies": {
-                "unpipe": {
-                  "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                }
-              }
-            },
-            "fresh": {
-              "version": "0.5.0",
-              "from": "fresh@0.5.0",
-              "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
-            },
-            "merge-descriptors": {
-              "version": "1.0.1",
-              "from": "merge-descriptors@1.0.1",
-              "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-            },
-            "methods": {
-              "version": "1.1.2",
-              "from": "methods@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-            },
-            "on-finished": {
-              "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "dependencies": {
-                "ee-first": {
-                  "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
-                  "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-            },
-            "path-to-regexp": {
-              "version": "0.1.7",
-              "from": "path-to-regexp@0.1.7",
-              "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-            },
-            "proxy-addr": {
-              "version": "1.1.4",
-              "from": "proxy-addr@>=1.1.4 <1.2.0",
-              "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-              "dependencies": {
-                "forwarded": {
-                  "version": "0.1.0",
-                  "from": "forwarded@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
-                },
-                "ipaddr.js": {
-                  "version": "1.3.0",
-                  "from": "ipaddr.js@1.3.0",
-                  "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@6.4.0",
-              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "range-parser": {
-              "version": "1.2.0",
-              "from": "range-parser@>=1.2.0 <1.3.0",
-              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-            },
-            "send": {
-              "version": "0.15.3",
-              "from": "send@0.15.3",
-              "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
-              "dependencies": {
-                "destroy": {
-                  "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-                },
-                "http-errors": {
-                  "version": "1.6.1",
-                  "from": "http-errors@>=1.6.1 <1.7.0",
-                  "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@1.3.4",
-                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                },
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.12.3",
-              "from": "serve-static@1.12.3",
-              "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "from": "setprototypeof@1.0.3",
-              "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-            },
-            "statuses": {
-              "version": "1.3.1",
-              "from": "statuses@>=1.3.1 <1.4.0",
-              "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-            },
-            "type-is": {
-              "version": "1.6.15",
-              "from": "type-is@>=1.6.15 <1.7.0",
-              "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-              "dependencies": {
-                "media-typer": {
-                  "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
-                  "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.16",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.29.0",
-                      "from": "mime-db@>=1.29.0 <1.30.0",
-                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
-              "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-            },
-            "vary": {
-              "version": "1.1.1",
-              "from": "vary@>=1.1.1 <1.2.0",
-              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
-            }
-          }
-        },
-        "filesize": {
-          "version": "3.5.10",
-          "from": "filesize@>=3.5.9 <4.0.0",
-          "resolved": "http://registry.npmjs.org/filesize/-/filesize-3.5.10.tgz"
-        },
-        "gzip-size": {
-          "version": "3.0.0",
-          "from": "gzip-size@>=3.0.0 <4.0.0",
-          "resolved": "http://registry.npmjs.org/gzip-size/-/gzip-size-3.0.0.tgz",
-          "dependencies": {
-            "duplexer": {
-              "version": "0.1.1",
-              "from": "duplexer@>=0.1.1 <0.2.0",
-              "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz"
-            }
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "from": "mkdirp@>=0.5.1 <0.6.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-          "dependencies": {
-            "minimist": {
-              "version": "0.0.8",
-              "from": "minimist@0.0.8",
-              "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
-            }
-          }
-        },
-        "opener": {
-          "version": "1.4.3",
-          "from": "opener@>=1.4.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/opener/-/opener-1.4.3.tgz"
-        },
-        "ws": {
-          "version": "2.3.1",
-          "from": "ws@>=2.3.1 <3.0.0",
-          "resolved": "http://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
-          "dependencies": {
-            "safe-buffer": {
-              "version": "5.0.1",
-              "from": "safe-buffer@>=5.0.1 <5.1.0",
-              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
-            },
-            "ultron": {
-              "version": "1.1.0",
-              "from": "ultron@>=1.1.0 <1.2.0",
-              "resolved": "http://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz"
-            }
-          }
+          "resolved": "http://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "webpack-core": {
+      "version": "0.6.9",
+      "from": "webpack-core@>=0.6.9 <0.7.0",
+      "resolved": "http://registry.npmjs.org/webpack-core/-/webpack-core-0.6.9.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.4.4",
+          "from": "source-map@>=0.4.1 <0.5.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
         }
       }
     },
     "webpack-dev-middleware": {
       "version": "1.7.0",
       "from": "webpack-dev-middleware@1.7.0",
-      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.7.0.tgz",
-      "dependencies": {
-        "memory-fs": {
-          "version": "0.3.0",
-          "from": "memory-fs@>=0.3.0 <0.4.0",
-          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.3.0.tgz",
-          "dependencies": {
-            "errno": {
-              "version": "0.1.4",
-              "from": "errno@>=0.1.3 <0.2.0",
-              "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-              "dependencies": {
-                "prr": {
-                  "version": "0.0.0",
-                  "from": "prr@>=0.0.0 <0.1.0",
-                  "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                }
-              }
-            },
-            "readable-stream": {
-              "version": "2.3.3",
-              "from": "readable-stream@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-              "dependencies": {
-                "core-util-is": {
-                  "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@>=2.0.3 <2.1.0",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "isarray": {
-                  "version": "1.0.0",
-                  "from": "isarray@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                },
-                "process-nextick-args": {
-                  "version": "1.0.7",
-                  "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                },
-                "safe-buffer": {
-                  "version": "5.1.1",
-                  "from": "safe-buffer@>=5.1.1 <5.2.0",
-                  "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                },
-                "string_decoder": {
-                  "version": "1.0.3",
-                  "from": "string_decoder@>=1.0.3 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                },
-                "util-deprecate": {
-                  "version": "1.0.2",
-                  "from": "util-deprecate@>=1.0.1 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                }
-              }
-            }
-          }
-        },
-        "mime": {
-          "version": "1.3.6",
-          "from": "mime@>=1.3.4 <2.0.0",
-          "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
-        },
-        "range-parser": {
-          "version": "1.2.0",
-          "from": "range-parser@>=1.0.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-        }
-      }
+      "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.7.0.tgz"
     },
     "webpack-dev-server": {
       "version": "1.16.5",
       "from": "webpack-dev-server@>=1.9.0 <2.0.0",
       "resolved": "http://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-1.16.5.tgz",
       "dependencies": {
-        "compression": {
-          "version": "1.7.0",
-          "from": "compression@>=1.5.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.3.3",
-              "from": "accepts@>=1.3.3 <1.4.0",
-              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.16",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.29.0",
-                      "from": "mime-db@>=1.29.0 <1.30.0",
-                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.6.1",
-                  "from": "negotiator@0.6.1",
-                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                }
-              }
-            },
-            "bytes": {
-              "version": "2.5.0",
-              "from": "bytes@2.5.0",
-              "resolved": "http://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz"
-            },
-            "compressible": {
-              "version": "2.0.10",
-              "from": "compressible@>=2.0.10 <2.1.0",
-              "resolved": "http://registry.npmjs.org/compressible/-/compressible-2.0.10.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.29.0",
-                  "from": "mime-db@>=1.27.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                }
-              }
-            },
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@2.6.8",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "on-headers": {
-              "version": "1.0.1",
-              "from": "on-headers@>=1.0.1 <1.1.0",
-              "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz"
-            },
-            "safe-buffer": {
-              "version": "5.1.1",
-              "from": "safe-buffer@5.1.1",
-              "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-            },
-            "vary": {
-              "version": "1.1.1",
-              "from": "vary@>=1.1.1 <1.2.0",
-              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
-            }
-          }
-        },
-        "connect-history-api-fallback": {
-          "version": "1.3.0",
-          "from": "connect-history-api-fallback@>=1.3.0 <2.0.0",
-          "resolved": "http://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.3.0.tgz"
-        },
-        "express": {
-          "version": "4.15.3",
-          "from": "express@>=4.13.3 <5.0.0",
-          "resolved": "http://registry.npmjs.org/express/-/express-4.15.3.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.3.3",
-              "from": "accepts@>=1.3.3 <1.4.0",
-              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-              "dependencies": {
-                "mime-types": {
-                  "version": "2.1.16",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.29.0",
-                      "from": "mime-db@>=1.29.0 <1.30.0",
-                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                    }
-                  }
-                },
-                "negotiator": {
-                  "version": "0.6.1",
-                  "from": "negotiator@0.6.1",
-                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                }
-              }
-            },
-            "array-flatten": {
-              "version": "1.1.1",
-              "from": "array-flatten@1.1.1",
-              "resolved": "http://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
-            },
-            "content-disposition": {
-              "version": "0.5.2",
-              "from": "content-disposition@0.5.2",
-              "resolved": "http://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
-            },
-            "content-type": {
-              "version": "1.0.2",
-              "from": "content-type@>=1.0.2 <1.1.0",
-              "resolved": "http://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz"
-            },
-            "cookie": {
-              "version": "0.3.1",
-              "from": "cookie@0.3.1",
-              "resolved": "http://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
-            },
-            "cookie-signature": {
-              "version": "1.0.6",
-              "from": "cookie-signature@1.0.6",
-              "resolved": "http://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
-            },
-            "debug": {
-              "version": "2.6.7",
-              "from": "debug@2.6.7",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "depd": {
-              "version": "1.1.0",
-              "from": "depd@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-            },
-            "encodeurl": {
-              "version": "1.0.1",
-              "from": "encodeurl@>=1.0.1 <1.1.0",
-              "resolved": "http://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-            },
-            "etag": {
-              "version": "1.8.0",
-              "from": "etag@>=1.8.0 <1.9.0",
-              "resolved": "http://registry.npmjs.org/etag/-/etag-1.8.0.tgz"
-            },
-            "finalhandler": {
-              "version": "1.0.3",
-              "from": "finalhandler@>=1.0.3 <1.1.0",
-              "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.0.3.tgz",
-              "dependencies": {
-                "unpipe": {
-                  "version": "1.0.0",
-                  "from": "unpipe@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
-                }
-              }
-            },
-            "fresh": {
-              "version": "0.5.0",
-              "from": "fresh@0.5.0",
-              "resolved": "http://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz"
-            },
-            "merge-descriptors": {
-              "version": "1.0.1",
-              "from": "merge-descriptors@1.0.1",
-              "resolved": "http://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
-            },
-            "methods": {
-              "version": "1.1.2",
-              "from": "methods@>=1.1.2 <1.2.0",
-              "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
-            },
-            "on-finished": {
-              "version": "2.3.0",
-              "from": "on-finished@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-              "dependencies": {
-                "ee-first": {
-                  "version": "1.1.1",
-                  "from": "ee-first@1.1.1",
-                  "resolved": "http://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-            },
-            "path-to-regexp": {
-              "version": "0.1.7",
-              "from": "path-to-regexp@0.1.7",
-              "resolved": "http://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
-            },
-            "proxy-addr": {
-              "version": "1.1.4",
-              "from": "proxy-addr@>=1.1.4 <1.2.0",
-              "resolved": "http://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.4.tgz",
-              "dependencies": {
-                "forwarded": {
-                  "version": "0.1.0",
-                  "from": "forwarded@>=0.1.0 <0.2.0",
-                  "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
-                },
-                "ipaddr.js": {
-                  "version": "1.3.0",
-                  "from": "ipaddr.js@1.3.0",
-                  "resolved": "http://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.3.0.tgz"
-                }
-              }
-            },
-            "qs": {
-              "version": "6.4.0",
-              "from": "qs@6.4.0",
-              "resolved": "http://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
-            },
-            "range-parser": {
-              "version": "1.2.0",
-              "from": "range-parser@>=1.2.0 <1.3.0",
-              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-            },
-            "send": {
-              "version": "0.15.3",
-              "from": "send@0.15.3",
-              "resolved": "http://registry.npmjs.org/send/-/send-0.15.3.tgz",
-              "dependencies": {
-                "destroy": {
-                  "version": "1.0.4",
-                  "from": "destroy@>=1.0.4 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
-                },
-                "http-errors": {
-                  "version": "1.6.1",
-                  "from": "http-errors@>=1.6.1 <1.7.0",
-                  "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-                  "dependencies": {
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@2.0.3",
-                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    }
-                  }
-                },
-                "mime": {
-                  "version": "1.3.4",
-                  "from": "mime@1.3.4",
-                  "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
-                },
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "serve-static": {
-              "version": "1.12.3",
-              "from": "serve-static@1.12.3",
-              "resolved": "http://registry.npmjs.org/serve-static/-/serve-static-1.12.3.tgz"
-            },
-            "setprototypeof": {
-              "version": "1.0.3",
-              "from": "setprototypeof@1.0.3",
-              "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-            },
-            "statuses": {
-              "version": "1.3.1",
-              "from": "statuses@>=1.3.1 <1.4.0",
-              "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-            },
-            "type-is": {
-              "version": "1.6.15",
-              "from": "type-is@>=1.6.15 <1.7.0",
-              "resolved": "http://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
-              "dependencies": {
-                "media-typer": {
-                  "version": "0.3.0",
-                  "from": "media-typer@0.3.0",
-                  "resolved": "http://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
-                },
-                "mime-types": {
-                  "version": "2.1.16",
-                  "from": "mime-types@>=2.1.11 <2.2.0",
-                  "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-                  "dependencies": {
-                    "mime-db": {
-                      "version": "1.29.0",
-                      "from": "mime-db@>=1.29.0 <1.30.0",
-                      "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "utils-merge": {
-              "version": "1.0.0",
-              "from": "utils-merge@1.0.0",
-              "resolved": "http://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
-            },
-            "vary": {
-              "version": "1.1.1",
-              "from": "vary@>=1.1.1 <1.2.0",
-              "resolved": "http://registry.npmjs.org/vary/-/vary-1.1.1.tgz"
-            }
-          }
-        },
-        "optimist": {
-          "version": "0.6.1",
-          "from": "optimist@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-          "dependencies": {
-            "wordwrap": {
-              "version": "0.0.3",
-              "from": "wordwrap@>=0.0.2 <0.1.0",
-              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
-            },
-            "minimist": {
-              "version": "0.0.10",
-              "from": "minimist@>=0.0.1 <0.1.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
-            }
-          }
-        },
-        "open": {
-          "version": "0.0.5",
-          "from": "open@0.0.5",
-          "resolved": "http://registry.npmjs.org/open/-/open-0.0.5.tgz"
-        },
-        "serve-index": {
-          "version": "1.9.0",
-          "from": "serve-index@>=1.7.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/serve-index/-/serve-index-1.9.0.tgz",
-          "dependencies": {
-            "accepts": {
-              "version": "1.3.3",
-              "from": "accepts@>=1.3.3 <1.4.0",
-              "resolved": "http://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
-              "dependencies": {
-                "negotiator": {
-                  "version": "0.6.1",
-                  "from": "negotiator@0.6.1",
-                  "resolved": "http://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
-                }
-              }
-            },
-            "batch": {
-              "version": "0.6.1",
-              "from": "batch@0.6.1",
-              "resolved": "http://registry.npmjs.org/batch/-/batch-0.6.1.tgz"
-            },
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@2.6.8",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "escape-html": {
-              "version": "1.0.3",
-              "from": "escape-html@>=1.0.3 <1.1.0",
-              "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
-            },
-            "http-errors": {
-              "version": "1.6.1",
-              "from": "http-errors@>=1.6.1 <1.7.0",
-              "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.1.tgz",
-              "dependencies": {
-                "depd": {
-                  "version": "1.1.0",
-                  "from": "depd@1.1.0",
-                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
-                },
-                "inherits": {
-                  "version": "2.0.3",
-                  "from": "inherits@2.0.3",
-                  "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                },
-                "setprototypeof": {
-                  "version": "1.0.3",
-                  "from": "setprototypeof@1.0.3",
-                  "resolved": "http://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
-                },
-                "statuses": {
-                  "version": "1.3.1",
-                  "from": "statuses@>=1.3.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
-                }
-              }
-            },
-            "mime-types": {
-              "version": "2.1.16",
-              "from": "mime-types@>=2.1.15 <2.2.0",
-              "resolved": "http://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.29.0",
-                  "from": "mime-db@>=1.29.0 <1.30.0",
-                  "resolved": "http://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz"
-                }
-              }
-            },
-            "parseurl": {
-              "version": "1.3.1",
-              "from": "parseurl@>=1.3.1 <1.4.0",
-              "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz"
-            }
-          }
-        },
-        "sockjs": {
-          "version": "0.3.18",
-          "from": "sockjs@>=0.3.15 <0.4.0",
-          "resolved": "http://registry.npmjs.org/sockjs/-/sockjs-0.3.18.tgz",
-          "dependencies": {
-            "faye-websocket": {
-              "version": "0.10.0",
-              "from": "faye-websocket@>=0.10.0 <0.11.0",
-              "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.10.0.tgz",
-              "dependencies": {
-                "websocket-driver": {
-                  "version": "0.6.5",
-                  "from": "websocket-driver@>=0.5.1",
-                  "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                  "dependencies": {
-                    "websocket-extensions": {
-                      "version": "0.1.1",
-                      "from": "websocket-extensions@>=0.1.1",
-                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "uuid": {
-              "version": "2.0.3",
-              "from": "uuid@>=2.0.2 <3.0.0",
-              "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz"
-            }
-          }
-        },
-        "sockjs-client": {
-          "version": "1.1.4",
-          "from": "sockjs-client@>=1.0.3 <2.0.0",
-          "resolved": "http://registry.npmjs.org/sockjs-client/-/sockjs-client-1.1.4.tgz",
-          "dependencies": {
-            "debug": {
-              "version": "2.6.8",
-              "from": "debug@>=2.6.6 <3.0.0",
-              "resolved": "http://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-              "dependencies": {
-                "ms": {
-                  "version": "2.0.0",
-                  "from": "ms@2.0.0",
-                  "resolved": "http://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
-                }
-              }
-            },
-            "eventsource": {
-              "version": "0.1.6",
-              "from": "eventsource@0.1.6",
-              "resolved": "http://registry.npmjs.org/eventsource/-/eventsource-0.1.6.tgz",
-              "dependencies": {
-                "original": {
-                  "version": "1.0.0",
-                  "from": "original@>=0.0.5",
-                  "resolved": "http://registry.npmjs.org/original/-/original-1.0.0.tgz",
-                  "dependencies": {
-                    "url-parse": {
-                      "version": "1.0.5",
-                      "from": "url-parse@>=1.0.0 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.0.5.tgz",
-                      "dependencies": {
-                        "querystringify": {
-                          "version": "0.0.4",
-                          "from": "querystringify@>=0.0.0 <0.1.0",
-                          "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-0.0.4.tgz"
-                        },
-                        "requires-port": {
-                          "version": "1.0.0",
-                          "from": "requires-port@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            },
-            "faye-websocket": {
-              "version": "0.11.1",
-              "from": "faye-websocket@>=0.11.0 <0.12.0",
-              "resolved": "http://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
-              "dependencies": {
-                "websocket-driver": {
-                  "version": "0.6.5",
-                  "from": "websocket-driver@>=0.5.1",
-                  "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz",
-                  "dependencies": {
-                    "websocket-extensions": {
-                      "version": "0.1.1",
-                      "from": "websocket-extensions@>=0.1.1",
-                      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "inherits": {
-              "version": "2.0.3",
-              "from": "inherits@>=2.0.1 <3.0.0",
-              "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-            },
-            "json3": {
-              "version": "3.3.2",
-              "from": "json3@>=3.3.2 <4.0.0",
-              "resolved": "http://registry.npmjs.org/json3/-/json3-3.3.2.tgz"
-            },
-            "url-parse": {
-              "version": "1.1.9",
-              "from": "url-parse@>=1.1.8 <2.0.0",
-              "resolved": "http://registry.npmjs.org/url-parse/-/url-parse-1.1.9.tgz",
-              "dependencies": {
-                "querystringify": {
-                  "version": "1.0.0",
-                  "from": "querystringify@>=1.0.0 <1.1.0",
-                  "resolved": "http://registry.npmjs.org/querystringify/-/querystringify-1.0.0.tgz"
-                },
-                "requires-port": {
-                  "version": "1.0.0",
-                  "from": "requires-port@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-                }
-              }
-            }
-          }
-        },
-        "stream-cache": {
-          "version": "0.0.2",
-          "from": "stream-cache@>=0.0.1 <0.1.0",
-          "resolved": "http://registry.npmjs.org/stream-cache/-/stream-cache-0.0.2.tgz"
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "from": "strip-ansi@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "dependencies": {
-            "ansi-regex": {
-              "version": "2.1.1",
-              "from": "ansi-regex@>=2.0.0 <3.0.0",
-              "resolved": "http://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz"
-            }
-          }
-        },
-        "supports-color": {
-          "version": "3.2.3",
-          "from": "supports-color@>=3.1.1 <4.0.0",
-          "resolved": "http://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
-          "dependencies": {
-            "has-flag": {
-              "version": "1.0.0",
-              "from": "has-flag@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
-            }
-          }
+        "memory-fs": {
+          "version": "0.4.1",
+          "from": "memory-fs@>=0.4.1 <0.5.0",
+          "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz"
         },
         "webpack-dev-middleware": {
           "version": "1.11.0",
           "from": "webpack-dev-middleware@>=1.10.2 <2.0.0",
-          "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz",
-          "dependencies": {
-            "memory-fs": {
-              "version": "0.4.1",
-              "from": "memory-fs@>=0.4.1 <0.5.0",
-              "resolved": "http://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
-              "dependencies": {
-                "errno": {
-                  "version": "0.1.4",
-                  "from": "errno@>=0.1.3 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/errno/-/errno-0.1.4.tgz",
-                  "dependencies": {
-                    "prr": {
-                      "version": "0.0.0",
-                      "from": "prr@>=0.0.0 <0.1.0",
-                      "resolved": "http://registry.npmjs.org/prr/-/prr-0.0.0.tgz"
-                    }
-                  }
-                },
-                "readable-stream": {
-                  "version": "2.3.3",
-                  "from": "readable-stream@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
-                  "dependencies": {
-                    "core-util-is": {
-                      "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-                    },
-                    "inherits": {
-                      "version": "2.0.3",
-                      "from": "inherits@>=2.0.3 <2.1.0",
-                      "resolved": "http://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
-                    },
-                    "isarray": {
-                      "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                    },
-                    "process-nextick-args": {
-                      "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
-                    },
-                    "safe-buffer": {
-                      "version": "5.1.1",
-                      "from": "safe-buffer@>=5.1.1 <5.2.0",
-                      "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-                    },
-                    "string_decoder": {
-                      "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.3 <1.1.0",
-                      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
-                    },
-                    "util-deprecate": {
-                      "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "mime": {
-              "version": "1.3.6",
-              "from": "mime@>=1.3.4 <2.0.0",
-              "resolved": "http://registry.npmjs.org/mime/-/mime-1.3.6.tgz"
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "from": "path-is-absolute@>=1.0.0 <2.0.0",
-              "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-            },
-            "range-parser": {
-              "version": "1.2.0",
-              "from": "range-parser@>=1.0.3 <2.0.0",
-              "resolved": "http://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
-            }
-          }
-        },
-        "http-proxy-middleware": {
-          "version": "0.17.4",
-          "from": "http-proxy-middleware@>=0.17.1 <0.18.0",
-          "resolved": "http://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-0.17.4.tgz",
-          "dependencies": {
-            "http-proxy": {
-              "version": "1.16.2",
-              "from": "http-proxy@>=1.16.2 <2.0.0",
-              "resolved": "http://registry.npmjs.org/http-proxy/-/http-proxy-1.16.2.tgz",
-              "dependencies": {
-                "eventemitter3": {
-                  "version": "1.2.0",
-                  "from": "eventemitter3@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-1.2.0.tgz"
-                },
-                "requires-port": {
-                  "version": "1.0.0",
-                  "from": "requires-port@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz"
-                }
-              }
-            },
-            "is-glob": {
-              "version": "3.1.0",
-              "from": "is-glob@>=3.1.0 <4.0.0",
-              "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-              "dependencies": {
-                "is-extglob": {
-                  "version": "2.1.1",
-                  "from": "is-extglob@>=2.1.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
-                }
-              }
-            },
-            "micromatch": {
-              "version": "2.3.11",
-              "from": "micromatch@>=2.3.11 <3.0.0",
-              "resolved": "http://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
-              "dependencies": {
-                "arr-diff": {
-                  "version": "2.0.0",
-                  "from": "arr-diff@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
-                  "dependencies": {
-                    "arr-flatten": {
-                      "version": "1.1.0",
-                      "from": "arr-flatten@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz"
-                    }
-                  }
-                },
-                "array-unique": {
-                  "version": "0.2.1",
-                  "from": "array-unique@>=0.2.1 <0.3.0",
-                  "resolved": "http://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz"
-                },
-                "braces": {
-                  "version": "1.8.5",
-                  "from": "braces@>=1.8.2 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
-                  "dependencies": {
-                    "expand-range": {
-                      "version": "1.8.2",
-                      "from": "expand-range@>=1.8.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
-                      "dependencies": {
-                        "fill-range": {
-                          "version": "2.2.3",
-                          "from": "fill-range@>=2.1.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-                          "dependencies": {
-                            "is-number": {
-                              "version": "2.1.0",
-                              "from": "is-number@>=2.1.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz"
-                            },
-                            "isobject": {
-                              "version": "2.1.0",
-                              "from": "isobject@>=2.0.0 <3.0.0",
-                              "resolved": "http://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-                              "dependencies": {
-                                "isarray": {
-                                  "version": "1.0.0",
-                                  "from": "isarray@1.0.0",
-                                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
-                                }
-                              }
-                            },
-                            "randomatic": {
-                              "version": "1.1.7",
-                              "from": "randomatic@>=1.1.3 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-                              "dependencies": {
-                                "is-number": {
-                                  "version": "3.0.0",
-                                  "from": "is-number@>=3.0.0 <4.0.0",
-                                  "resolved": "http://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-                                  "dependencies": {
-                                    "kind-of": {
-                                      "version": "3.2.2",
-                                      "from": "kind-of@>=3.0.2 <4.0.0",
-                                      "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                                      "dependencies": {
-                                        "is-buffer": {
-                                          "version": "1.1.5",
-                                          "from": "is-buffer@>=1.1.5 <2.0.0",
-                                          "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                        }
-                                      }
-                                    }
-                                  }
-                                },
-                                "kind-of": {
-                                  "version": "4.0.0",
-                                  "from": "kind-of@>=4.0.0 <5.0.0",
-                                  "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-                                  "dependencies": {
-                                    "is-buffer": {
-                                      "version": "1.1.5",
-                                      "from": "is-buffer@>=1.1.5 <2.0.0",
-                                      "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                                    }
-                                  }
-                                }
-                              }
-                            },
-                            "repeat-string": {
-                              "version": "1.6.1",
-                              "from": "repeat-string@>=1.5.2 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
-                            }
-                          }
-                        }
-                      }
-                    },
-                    "preserve": {
-                      "version": "0.2.0",
-                      "from": "preserve@>=0.2.0 <0.3.0",
-                      "resolved": "http://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz"
-                    },
-                    "repeat-element": {
-                      "version": "1.1.2",
-                      "from": "repeat-element@>=1.1.2 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz"
-                    }
-                  }
-                },
-                "expand-brackets": {
-                  "version": "0.1.5",
-                  "from": "expand-brackets@>=0.1.4 <0.2.0",
-                  "resolved": "http://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
-                  "dependencies": {
-                    "is-posix-bracket": {
-                      "version": "0.1.1",
-                      "from": "is-posix-bracket@>=0.1.0 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz"
-                    }
-                  }
-                },
-                "extglob": {
-                  "version": "0.3.2",
-                  "from": "extglob@>=0.3.1 <0.4.0",
-                  "resolved": "http://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz"
-                },
-                "filename-regex": {
-                  "version": "2.0.1",
-                  "from": "filename-regex@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz"
-                },
-                "is-extglob": {
-                  "version": "1.0.0",
-                  "from": "is-extglob@>=1.0.0 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz"
-                },
-                "is-glob": {
-                  "version": "2.0.1",
-                  "from": "is-glob@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz"
-                },
-                "kind-of": {
-                  "version": "3.2.2",
-                  "from": "kind-of@>=3.0.2 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                  "dependencies": {
-                    "is-buffer": {
-                      "version": "1.1.5",
-                      "from": "is-buffer@>=1.1.5 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz"
-                    }
-                  }
-                },
-                "normalize-path": {
-                  "version": "2.1.1",
-                  "from": "normalize-path@>=2.0.1 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
-                  "dependencies": {
-                    "remove-trailing-separator": {
-                      "version": "1.0.2",
-                      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz"
-                    }
-                  }
-                },
-                "object.omit": {
-                  "version": "2.0.1",
-                  "from": "object.omit@>=2.0.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
-                  "dependencies": {
-                    "for-own": {
-                      "version": "0.1.5",
-                      "from": "for-own@>=0.1.4 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
-                      "dependencies": {
-                        "for-in": {
-                          "version": "1.0.2",
-                          "from": "for-in@>=1.0.1 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "is-extendable": {
-                      "version": "0.1.1",
-                      "from": "is-extendable@>=0.1.1 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz"
-                    }
-                  }
-                },
-                "parse-glob": {
-                  "version": "3.0.4",
-                  "from": "parse-glob@>=3.0.4 <4.0.0",
-                  "resolved": "http://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
-                  "dependencies": {
-                    "glob-base": {
-                      "version": "0.3.0",
-                      "from": "glob-base@>=0.3.0 <0.4.0",
-                      "resolved": "http://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
-                      "dependencies": {
-                        "glob-parent": {
-                          "version": "2.0.0",
-                          "from": "glob-parent@>=2.0.0 <3.0.0",
-                          "resolved": "http://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "is-dotfile": {
-                      "version": "1.0.3",
-                      "from": "is-dotfile@>=1.0.0 <2.0.0",
-                      "resolved": "http://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz"
-                    }
-                  }
-                },
-                "regex-cache": {
-                  "version": "0.4.3",
-                  "from": "regex-cache@>=0.4.2 <0.5.0",
-                  "resolved": "http://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-                  "dependencies": {
-                    "is-equal-shallow": {
-                      "version": "0.1.3",
-                      "from": "is-equal-shallow@>=0.1.3 <0.2.0",
-                      "resolved": "http://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz"
-                    },
-                    "is-primitive": {
-                      "version": "2.0.0",
-                      "from": "is-primitive@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz"
-                    }
-                  }
-                }
-              }
-            }
-          }
+          "resolved": "http://registry.npmjs.org/webpack-dev-middleware/-/webpack-dev-middleware-1.11.0.tgz"
         }
       }
+    },
+    "webpack-sources": {
+      "version": "0.1.5",
+      "from": "webpack-sources@>=0.1.0 <0.2.0",
+      "resolved": "http://registry.npmjs.org/webpack-sources/-/webpack-sources-0.1.5.tgz"
+    },
+    "websocket-driver": {
+      "version": "0.6.5",
+      "from": "websocket-driver@>=0.5.1",
+      "resolved": "http://registry.npmjs.org/websocket-driver/-/websocket-driver-0.6.5.tgz"
+    },
+    "websocket-extensions": {
+      "version": "0.1.1",
+      "from": "websocket-extensions@>=0.1.1",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.1.tgz"
+    },
+    "whatwg-encoding": {
+      "version": "1.0.1",
+      "from": "whatwg-encoding@>=1.0.1 <2.0.0",
+      "resolved": "http://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.4.13",
+          "from": "iconv-lite@0.4.13",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+          "dev": true
+        }
+      }
+    },
+    "whatwg-fetch": {
+      "version": "2.0.3",
+      "from": "whatwg-fetch@>=0.10.0",
+      "resolved": "http://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.3.tgz"
+    },
+    "whatwg-url": {
+      "version": "4.8.0",
+      "from": "whatwg-url@>=4.3.0 <5.0.0",
+      "resolved": "http://registry.npmjs.org/whatwg-url/-/whatwg-url-4.8.0.tgz",
+      "dev": true,
+      "dependencies": {
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "from": "webidl-conversions@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "whet.extend": {
+      "version": "0.9.9",
+      "from": "whet.extend@>=0.9.9 <0.10.0",
+      "resolved": "http://registry.npmjs.org/whet.extend/-/whet.extend-0.9.9.tgz"
+    },
+    "which": {
+      "version": "1.2.14",
+      "from": "which@>=1.2.9 <2.0.0",
+      "resolved": "http://registry.npmjs.org/which/-/which-1.2.14.tgz"
+    },
+    "which-module": {
+      "version": "1.0.0",
+      "from": "which-module@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/which-module/-/which-module-1.0.0.tgz"
+    },
+    "wide-align": {
+      "version": "1.1.2",
+      "from": "wide-align@>=1.1.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz"
+    },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "http://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz"
+    },
+    "wordwrap": {
+      "version": "0.0.3",
+      "from": "wordwrap@>=0.0.2 <0.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+    },
+    "wrap-ansi": {
+      "version": "2.1.0",
+      "from": "wrap-ansi@>=2.0.0 <3.0.0",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz"
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "from": "wrappy@>=1.0.0 <2.0.0",
+      "resolved": "http://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+    },
+    "write": {
+      "version": "0.2.1",
+      "from": "write@>=0.2.1 <0.3.0",
+      "resolved": "http://registry.npmjs.org/write/-/write-0.2.1.tgz",
+      "dev": true
+    },
+    "ws": {
+      "version": "2.3.1",
+      "from": "ws@>=2.3.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/ws/-/ws-2.3.1.tgz",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.0.1",
+          "from": "safe-buffer@>=5.0.1 <5.1.0",
+          "resolved": "http://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+          "dev": true
+        }
+      }
+    },
+    "xml-name-validator": {
+      "version": "2.0.1",
+      "from": "xml-name-validator@>=2.0.1 <3.0.0",
+      "resolved": "http://registry.npmjs.org/xml-name-validator/-/xml-name-validator-2.0.1.tgz",
+      "dev": true
+    },
+    "xtend": {
+      "version": "4.0.1",
+      "from": "xtend@>=4.0.0 <5.0.0",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+    },
+    "y18n": {
+      "version": "3.2.1",
+      "from": "y18n@>=3.2.1 <4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz"
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "from": "yallist@>=2.1.2 <3.0.0",
+      "resolved": "http://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+    },
+    "yargs": {
+      "version": "7.1.0",
+      "from": "yargs@>=7.0.0 <8.0.0",
+      "resolved": "http://registry.npmjs.org/yargs/-/yargs-7.1.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        }
+      }
+    },
+    "yargs-parser": {
+      "version": "5.0.0",
+      "from": "yargs-parser@>=5.0.0 <6.0.0",
+      "resolved": "http://registry.npmjs.org/yargs-parser/-/yargs-parser-5.0.0.tgz",
+      "dependencies": {
+        "camelcase": {
+          "version": "3.0.0",
+          "from": "camelcase@>=3.0.0 <4.0.0",
+          "resolved": "http://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz"
+        }
+      }
+    },
+    "z-schema": {
+      "version": "3.18.2",
+      "from": "z-schema@>=3.16.1 <4.0.0",
+      "resolved": "http://registry.npmjs.org/z-schema/-/z-schema-3.18.2.tgz"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "redux": "^3.6.0",
     "redux-devtools": "^3.3.1",
     "redux-logger": "^2.7.4",
-    "redux-promise-middleware": "^4.2.0",
+    "redux-promise-middleware": "4.2.1",
     "reselect": "^2.5.4",
     "resolve-url-loader": "^1.6.0",
     "sass-loader": "^4.0.2",


### PR DESCRIPTION
This PR adds an NPM shrink-wrap file to lock down our versions. Doing this makes builds more reproducible. It does slightly complicate updating and changing, to do so, delete the shrink-wrap file, change you dependency, then run `npm shrinkwrap --dev` 

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop