### PR TITLE
[SDP-745] Adding checkmark to response set search list on question edit page

### DIFF
--- a/features/edit_questions.feature
+++ b/features/edit_questions.feature
@@ -65,7 +65,8 @@ Feature: Edit Questions
     And I select the "Open Choice" option in the "Response Type" list
     And I click on the "select-Colors" link
     And I click on the "select-More colors" link
-    And I click on the "select-More colors" link
+    Then I should not see "select-More colors"
+    And I should see "Result Already Added"
     Then I should only see 1 copy of the "More colors" response set associated
 
   Scenario: Create New Question from List with Warning Modal

--- a/lib/sdp/simple_search.rb
+++ b/lib/sdp/simple_search.rb
@@ -29,7 +29,7 @@ module SDP
         total += type_results[:total]
         type_results[:hits].each do |tr|
           serializer = mapping[type]
-          res_json = { '_index' => 'vocabluary',
+          res_json = { '_index' => 'vocabulary',
                        '_type' => type.to_s.underscore,
                        '_id' => tr.id,
                        '_source' => serializer.new(tr).as_json }

--- a/webpack/containers/response_sets/ResponseSetDragWidget.js
+++ b/webpack/containers/response_sets/ResponseSetDragWidget.js
@@ -118,8 +118,10 @@ class ResponseSetDragWidget extends Component {
           <NestedSearchBar onSearchTermChange={this.search} modelName="Response Set" /><br/>
           <div className="fixed-height-list" name="linked_response_sets">
             {searchResults.hits && searchResults.hits.hits.map((rs, i) => {
+              var isSelected = this.props.selectedResponseSets.findIndex((r) => r.id == rs.Id) > -1;
               return <DraggableResponseSet key={i} type={rs.Type} result={rs}
                       currentUser={this.props.currentUser}
+                      isSelected ={isSelected}
                       handleSelectSearchResult={() => this.addRsButtonHandler(rs)} />;
             })}
             {searchResults.hits && searchResults.hits.total > 0 && this.state.page <= Math.floor((searchResults.hits.total-1) / 10) &&


### PR DESCRIPTION
Now when you select a response set on the question edit page, check marks appear!

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop

