### PR TITLE
[SDP-740,746,755] Form show normalizr

### DIFF
--- a/test/frontend/components/forms/form_show_test.js
+++ b/test/frontend/components/forms/form_show_test.js
@@ -8,11 +8,13 @@ describe('FormQuestionList', () => {
   beforeEach(() => {
     const router = new MockRouter();
     const questions = [];
+    const formQuestions = [];
     for (var i = 1; i < 20; i++) {
-      questions.push({id: 1, content: `Is your favorite number ${i}?`, status: 'draft', createdById: 1});
+      questions.push({id: i, content: `Is your favorite number ${i}?`, status: 'draft', createdById: 1});
+      formQuestions.push({id: i, questionId: i});
     }
     const props  = {
-      form: {id: 6, name: "Test Form", questions: [1], versionIndependentId: "F-1", version: 1, formQuestions: questions},
+      form: {id: 6, name: "Test Form", questions: questions, versionIndependentId: "F-1", version: 1, formQuestions: formQuestions},
       publishForm: ()=>{},
       deleteForm: ()=>{},
       formSubmitter:  ()=>{},

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -24,14 +24,21 @@ export default class SearchResult extends Component {
   isRevisable(source) {
     // Needs concept of source.mostRecent === source.version
     // Currently no way to do this in ES schema
-    return source.status === 'published' &&
-      (source.createdById || source.createdBy.id) === this.props.currentUser.id;
+    if (source.createdById || source.createdBy) {
+      return source.status === 'published' &&
+        (source.createdById || source.createdBy.id) === this.props.currentUser.id;
+    } else {
+      return false;
+    }
   }
 
   isEditable(source) {
-    // Needs concept of source.mostRecent === source.version
-    return source.status === 'draft' &&
-      (source.createdById || source.createdBy.id) === this.props.currentUser.id;
+    if (source.createdById || source.createdBy) {
+      return source.status === 'draft' &&
+        (source.createdById || source.createdBy.id) === this.props.currentUser.id;
+    } else {
+      return false;
+    }
   }
 
   isExtendable(source) {

--- a/webpack/components/forms/FormShow.js
+++ b/webpack/components/forms/FormShow.js
@@ -63,10 +63,24 @@ class FormShow extends Component {
     this.setState({page: nextPage});
   }
 
-  questionsForPage() {
+  questionsForPage(form) {
     const startIndex = (this.state.page - 1) * PAGE_SIZE;
     const endIndex = this.state.page * PAGE_SIZE;
-    return this.props.form.formQuestions.slice(startIndex, endIndex);
+    const formQuestionPage = form.formQuestions.slice(startIndex, endIndex);
+    return formQuestionPage.map((fq) => {
+      var formQuestion = Object.assign({}, form.questions.find(q => q.id === fq.questionId));
+      formQuestion.programVar = fq.programVar || '';
+      formQuestion.responseSets = [{name: 'None'}];
+      if (fq.responseSetId) {
+        var responseSet = form.responseSets.find(rs => rs.id === fq.responseSetId);
+        if(responseSet) {
+          formQuestion.responseSets = [responseSet];
+        } else {
+          formQuestion.responseSets = [{name: 'Loading...'}];
+        }
+      }
+      return formQuestion;
+    });
   }
 
   mainContent(form) {
@@ -140,7 +154,7 @@ class FormShow extends Component {
           </div>
           {this.props.form.formQuestions && this.props.form.formQuestions.length > 0 &&
             <div>
-              <FormQuestionList questions={this.questionsForPage()} />
+              <FormQuestionList questions={this.questionsForPage(form)} />
               {this.props.form.formQuestions.length > 10 &&
               <Pagination onChange={this.pageChange} current={this.state.page} total={this.props.form.formQuestions.length} />
               }

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -2,7 +2,6 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link } from 'react-router';
-import $ from 'jquery';
 
 import Header from './Header';
 import LogInModal from '../components/accounts/LogInModal';
@@ -76,8 +75,9 @@ class App extends Component {
       <div>
         <text className="sr-only">Welcome to the vocabulary service. Click the next link to skip navigation and go to main content.</text>
         <a href="#main-content" id="skip-nav" className="sr-only sr-only-focusable" tabIndex="1" onClick={() => {
-          $('a[tabindex=2]').attr('tabindex', '-1');
-          $('a[tabindex=1]').attr('tabindex', '-1');
+          var element = document.getElementById('main-content');
+          element.tabIndex = -1;
+          element.focus();
         }}>Skip to main content</a>
         <Header currentUser={this.props.currentUser}
                 disableUserRegistration={DISABLE_USER_REGISTRATION}

--- a/webpack/containers/forms/FormShowContainer.js
+++ b/webpack/containers/forms/FormShowContainer.js
@@ -52,30 +52,6 @@ class FormShowContainer extends Component {
     }
   }
 
-  // this.props.form.formQuestions doesn't have all the needed data
-  // Also, if you just modify the props directly to add the data, things can break
-  // So this function takes the form, clones it, then adds the extra data
-  getCompleteForm(){
-    var form = Object.assign({}, this.props.form);
-    if (form.questions && form.formQuestions && form.formQuestions.length > 0) {
-      form.formQuestions = this.props.form.formQuestions.map((fq) => {
-        var formQuestion = Object.assign({}, form.questions.find(q => q.id === fq.questionId));
-        formQuestion.programVar = fq.programVar || '';
-        formQuestion.responseSets = [{name: 'None'}];
-        if (fq.responseSetId) {
-          var responseSet = form.responseSets.find(rs => rs.id === fq.responseSetId);
-          if(responseSet) {
-            formQuestion.responseSets = [responseSet];
-          } else {
-            formQuestion.responseSets = [{name: 'Loading...'}];
-          }
-        }
-        return formQuestion;
-      });
-    }
-    return form;
-  }
-
   render() {
     if(!this.props.form){
       return (
@@ -86,7 +62,7 @@ class FormShowContainer extends Component {
       <div className="container">
         <div className="row basic-bg">
           <div className="col-md-12">
-            <FormShow form={this.getCompleteForm()}
+            <FormShow form={this.props.form}
                       router={this.props.router}
                       currentUser={this.props.currentUser}
                       publishForm={this.props.publishForm}


### PR DESCRIPTION
- Bug fix on search results imported without createdBy not crashing dashboard.
- Form show container optimization thanks to denormalize use not requiring fetching from store (some changes were made in normalizr branch this improves them)
- Changed the way skip nav works to no longer lock out of navigation, in edge and chrome behaves as desired but in I.E. there is an issue still (skips all tabIndex explicit items unless you shift tab.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
