### PR TITLE
[SDP-741] Clean up mapStateToProps in QuestionEditContainer

### DIFF
--- a/webpack/containers/forms/FormsEditContainer.js
+++ b/webpack/containers/forms/FormsEditContainer.js
@@ -89,7 +89,7 @@ class FormsEditContainer extends Component {
   }
 
   componentDidUpdate(prevProps) {
-    if(prevProps.params.formId != this.props.params.formId){
+    if(this.props.params.formId && prevProps.params.formId != this.props.params.formId){
       this.props.fetchForm(this.props.params.formId);
     }
     if(this.props.form && this.props.form.formQuestions) {

--- a/webpack/containers/questions/QuestionEditContainer.js
+++ b/webpack/containers/questions/QuestionEditContainer.js
@@ -111,9 +111,6 @@ function mapStateToProps(state, ownProps) {
           c.value = c.code;
         });
       }
-      props.question.questionType = props.question.category ? props.question.category : props.question.questionType;
-      props.question.questionTypeId = props.question.questionType ? props.question.questionType.id : undefined;
-      props.question.responseTypeId = props.question.responseType ? props.question.responseType.id : undefined;
     }
   }else{
     props.question = {version:1, concepts:[], responseSets:[]};

--- a/webpack/containers/questions/QuestionEditContainer.js
+++ b/webpack/containers/questions/QuestionEditContainer.js
@@ -105,12 +105,6 @@ function mapStateToProps(state, ownProps) {
       if(props.question.name) {
         props.question.content = props.question.name;
       }
-      if (props.question.codes) {
-        props.question.concepts = props.question.codes;
-        props.question.concepts.map((c) => {
-          c.value = c.code;
-        });
-      }
     }
   }else{
     props.question = {version:1, concepts:[], responseSets:[]};

--- a/webpack/containers/response_sets/ResponseSetEditContainer.js
+++ b/webpack/containers/response_sets/ResponseSetEditContainer.js
@@ -97,10 +97,6 @@ function mapStateToProps(state, ownProps) {
   const props = {};
   if (ownProps.params.rsId) {
     props.responseSet = state.responseSets[ownProps.params.rsId];
-    if (props.responseSet && props.responseSet.codes) {
-      props.responseSet.responses = props.responseSet.codes;
-      delete props.responseSet["codes"];
-    }
   } else {
     props.responseSet = {version: 1};
   }


### PR DESCRIPTION
Updated the QuestionEdit component so that it will now use questionType and responseType on question as opposed to questionTypeId and responseTypeId. This allowed me to git rid of those in mapStateToProps.

Changed how the payload is provided to ADD_ENTITIES_FULFILLED action from search results. Objects in search results have a codes property, which is different with how they are returned directly from the server. This change brings both payloads in line with each other.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
