### PR TITLE
[SDPV-23] Making item delete in elasicsearch blocking

### DIFF
--- a/app/controllers/forms_controller.rb
+++ b/app/controllers/forms_controller.rb
@@ -70,6 +70,7 @@ class FormsController < ApplicationController
   def destroy
     if @form.status == 'draft'
       @form.destroy
+      SDP::Elasticsearch.delete_item('form', @form.id, true)
       render json: @form
     else
       render json: @form.errors, status: :unprocessable_entity

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -115,6 +115,7 @@ class QuestionsController < ApplicationController
   def destroy
     if @question.status == 'draft'
       @question.destroy
+      SDP::Elasticsearch.delete_item('question', @question.id, true)
       render json: @question
     else
       render json: @question.errors, status: :unprocessable_entity

--- a/app/controllers/response_sets_controller.rb
+++ b/app/controllers/response_sets_controller.rb
@@ -103,6 +103,7 @@ class ResponseSetsController < ApplicationController
   def destroy
     if @response_set.status == 'draft'
       @response_set.destroy
+      SDP::Elasticsearch.delete_item('response_set', @response_set.id, true)
       render json: @response_set
     else
       render json: @response_set.errors, status: :unprocessable_entity

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -49,6 +49,7 @@ class SurveysController < ApplicationController
   def destroy
     if @survey.status == 'draft'
       @survey.destroy
+      SDP::Elasticsearch.delete_item('survey', @survey.id, true)
       render json: @survey
     else
       render json: @survey.errors, status: :unprocessable_entity

--- a/app/jobs/delete_from_index_job.rb
+++ b/app/jobs/delete_from_index_job.rb
@@ -8,11 +8,6 @@ class DeleteFromIndexJob < ApplicationJob
   end
 
   def perform(type, id)
-    SDP::Elasticsearch.ensure_index
-    SDP::Elasticsearch.with_client do |client|
-      if client.exists?(index: 'vocabulary', type: type.underscore, id: id)
-        client.delete index: 'vocabulary', type: type.underscore, id: id
-      end
-    end
+    SDP::Elasticsearch.delete_item(type, id)
   end
 end

--- a/app/models/form.rb
+++ b/app/models/form.rb
@@ -24,7 +24,6 @@ class Form < ApplicationRecord
   after_destroy :update_surveys
 
   after_commit :index, on: [:create, :update]
-  after_commit :delete_index, on: :destroy
 
   def update_surveys
     survey_array = surveys.to_a
@@ -34,10 +33,6 @@ class Form < ApplicationRecord
 
   def index
     UpdateIndexJob.perform_later('form', id)
-  end
-
-  def delete_index
-    DeleteFromIndexJob.perform_later('form', id)
   end
 
   def update_question_positions

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -23,7 +23,6 @@ class Question < ApplicationRecord
   after_destroy :update_forms
 
   after_commit :index, on: [:create, :update]
-  after_commit :delete_index, on: :destroy
 
   def update_forms
     form_array = forms.to_a
@@ -33,10 +32,6 @@ class Question < ApplicationRecord
 
   def index
     UpdateIndexJob.perform_later('question', id)
-  end
-
-  def delete_index
-    DeleteFromIndexJob.perform_later('question', id)
   end
 
   def publish(publisher)

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -23,14 +23,9 @@ class ResponseSet < ApplicationRecord
   accepts_nested_attributes_for :responses, allow_destroy: true
 
   after_commit :index, on: [:create, :update]
-  after_commit :delete_index, on: :destroy
 
   def index
     UpdateIndexJob.perform_later('response_set', id)
-  end
-
-  def delete_index
-    DeleteFromIndexJob.perform_later('response_set', id)
   end
 
   def publish(publisher)

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -21,7 +21,6 @@ class Survey < ApplicationRecord
   accepts_nested_attributes_for :forms, allow_destroy: true
 
   after_commit :index, on: [:create, :update]
-  after_commit :delete_index, on: :destroy
 
   def questions
     Question.joins(form_questions: { form: { survey_forms: :survey } }).where(surveys: { id: id }).all
@@ -29,10 +28,6 @@ class Survey < ApplicationRecord
 
   def index
     UpdateIndexJob.perform_later('survey', id)
-  end
-
-  def delete_index
-    DeleteFromIndexJob.perform_later('survey', id)
   end
 
   def update_form_positions

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -122,6 +122,15 @@ module SDP
       end
     end
 
+    def self.delete_item(type, id, refresh = false)
+      ensure_index
+      with_client do |client|
+        if client.exists?(index: 'vocabulary', type: type.underscore, id: id)
+          client.delete index: 'vocabulary', type: type.underscore, id: id, refresh: refresh
+        end
+      end
+    end
+
     def self.sync
       sync_forms
       sync_questions

--- a/test/controllers/survey_controller_test.rb
+++ b/test/controllers/survey_controller_test.rb
@@ -50,7 +50,7 @@ class SurveysControllerTest < ActionDispatch::IntegrationTest
         end
       end
     end
-    assert_enqueued_jobs 5
+    assert_enqueued_jobs 4
   end
 
   test 'should not publish a published survey' do

--- a/test/jobs/delete_from_index_job_test.rb
+++ b/test/jobs/delete_from_index_job_test.rb
@@ -8,6 +8,6 @@ class DeleteFromIndexJobTest < ActiveJob::TestCase
     DeleteFromIndexJob.perform_now('form', 1)
     req = FakeWeb.last_request
     assert_equal 'DELETE', req.method
-    assert_equal '/vocabulary/form/1', req.path
+    assert_equal '/vocabulary/form/1?refresh=false', req.path
   end
 end


### PR DESCRIPTION
Prior to this change, when deleting an item through its controller, a
background job would be created to delete the item from the
elasticsearch index. Dependent relationships would also kick off their
own background jobs to update more in the index.

This change pulls the elasticsearch index delete into the request
response cycle for the controller. Updates to the index for dependent
items still take place in a background job.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
