### PR TITLE
[SDPV-59] Implementation of the duplicate question finder service

### DIFF
--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -25,5 +25,18 @@ class ElasticsearchController < ApplicationController
               end
     render json: results
   end
+
+  def duplicate_questions
+    results = if SDP::Elasticsearch.ping
+                content = params[:content]
+                content ||= ''
+                description = params[:description]
+                description ||= ''
+                SDP::Elasticsearch.find_duplicate_questions(content, description)
+              else
+                SDP::SimpleSearch.find_duplicate_questions(params[:content]).target!
+              end
+    render json: results
+  end
 end
 # rubocop:enable Metrics/AbcSize

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :surveillance_programs, only: [:index, :show]
   get 'response_types', to: 'response_types#index', as: :response_types
   get 'elasticsearch', to: 'elasticsearch#index', as: :elasticsearch
+  get 'elasticsearch/duplicate_questions' => 'elasticsearch#duplicate_questions'
 
   get '/landing' => 'landing#index'
   get '/landing/stats' => 'landing#stats'

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -113,6 +113,16 @@ module SDP
       end
     end
 
+    def self.find_duplicate_questions(content, description)
+      with_client do |client|
+        client.search(index: 'vocabulary', type: 'question',
+                      body: { query: { bool: {
+                        filter: { match: { status: 'published' } },
+                        should: [{ match: { name: content } }, { match: { description: description } }]
+                      } } })
+      end
+    end
+
     def self.ensure_index
       with_client do |client|
         unless client.indices.exists? index: 'vocabulary'

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -3,6 +3,8 @@
 # rubocop:disable Metrics/ParameterLists
 module SDP
   module Elasticsearch
+    MAX_DUPLICATE_QUESTION_SUGGESTIONS = 10
+
     def self.with_client
       client = Vocabulary::Elasticsearch.client
       yield client if client.ping
@@ -116,10 +118,16 @@ module SDP
     def self.find_duplicate_questions(content, description)
       with_client do |client|
         client.search(index: 'vocabulary', type: 'question',
-                      body: { query: { bool: {
-                        filter: { match: { status: 'published' } },
-                        should: [{ match: { name: content } }, { match: { description: description } }]
-                      } } })
+                      body: {
+                        query: {
+                          bool: {
+                            filter: { match: { status: 'published' } },
+                            should: [{ match: { name: content } }, { match: { description: description } }],
+                            minimum_should_match: '75%'
+                          }
+                        },
+                        size: MAX_DUPLICATE_QUESTION_SUGGESTIONS
+                      })
       end
     end
 

--- a/lib/sdp/simple_search.rb
+++ b/lib/sdp/simple_search.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/ParameterLists
 module SDP
   module SimpleSearch
+    MAX_DUPLICATE_QUESTION_SUGGESTIONS = 10
+
     def self.search(type, query_string, current_user_id = nil, limit = 10, page = 1, publisher_search = false, my_stuff_search = false)
       current_user_id = current_user_id == -1 ? nil : current_user_id
       types = [type.camelize.constantize] if type
@@ -11,6 +13,14 @@ module SDP
         count = query.count()
         results[search_type] = { total: count, hits: query.limit(limit).offset(limit * (page - 1)).to_a }
       end
+      render_results(results)
+    end
+
+    def self.find_duplicate_questions(content)
+      query = Question.search(content)
+      results = {}
+      count = query.count()
+      results[Question] = { total: count, hits: query.limit(MAX_DUPLICATE_QUESTION_SUGGESTIONS).to_a }
       render_results(results)
     end
 

--- a/test/controllers/elasticsearch_controller_test.rb
+++ b/test/controllers/elasticsearch_controller_test.rb
@@ -3,12 +3,17 @@ require 'test_helper'
 class ElasticsearchControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
-  test 'should be able to call elastic_search test ' do
+  test 'should be able to call elastic_search' do
     get '/elasticsearch'
     assert_response :success
   end
 
-  test 'should be able to call search when ES is not running ' do
+  test 'should be able to call duplicate_questions' do
+    get '/elasticsearch/duplicate_questions'
+    assert_response :success
+  end
+
+  test 'should be able to call search when ES is not running' do
     FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, status: ['404', 'Not Found'])
     get '/elasticsearch'
     # reset so other tests do not fail

--- a/test/unit/lib/elastic_search_test.rb
+++ b/test/unit/lib/elastic_search_test.rb
@@ -37,4 +37,11 @@ class ElasticSearchTest < ActiveSupport::TestCase
     assert_equal 'POST', req.method
     assert_equal '/vocabulary/form/_delete_by_query', req.path
   end
+
+  def find_duplicate_questions
+    SDP::Elasticsearch.find_duplicate_questions('content', 'description')
+    req = FakeWeb.last_request
+    assert_equal 'GET', req.method
+    assert_equal '/vocabulary/question/_search', req.path
+  end
 end

--- a/test/unit/lib/simple_search_test.rb
+++ b/test/unit/lib/simple_search_test.rb
@@ -113,4 +113,10 @@ class SimpleSearchTest < ActiveSupport::TestCase
       end
     end
   end
+
+  test 'users can find duplicate questions' do
+    results = SDP::SimpleSearch.find_duplicate_questions('Search Question 1')
+    results_json = JSON.parse(results.target!)
+    assert_equal 1, results_json['hits']['total']
+  end
 end

--- a/webpack/_routes.js
+++ b/webpack/_routes.js
@@ -541,6 +541,9 @@ Based on Rails routes of Vocabulary::Application
 // elasticsearch => /elasticsearch(.:format)
   // function(options)
   elasticsearch_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"elasticsearch",false],[1,[2,[8,".",false],[3,"format",false]],false]]]),
+// elasticsearch_duplicate_questions => /elasticsearch/duplicate_questions(.:format)
+  // function(options)
+  elasticsearch_duplicate_questions_path: Utils.route([["format",false]], {}, [2,[7,"/",false],[2,[6,"elasticsearch",false],[2,[7,"/",false],[2,[6,"duplicate_questions",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]),
 // export_form => /forms/:id/export(.:format)
   // function(id, options)
   export_form_path: Utils.route([["id",true],["format",false]], {}, [2,[7,"/",false],[2,[6,"forms",false],[2,[7,"/",false],[2,[3,"id",false],[2,[7,"/",false],[2,[6,"export",false],[1,[2,[8,".",false],[3,"format",false]],false]]]]]]]),


### PR DESCRIPTION
This is the Rails side of the duplicate question finder (where you can send the service content and description to see if there are matching questions). Includes elasticsearch implementation and db fallback. Frontend implementation to follow.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any changes were made to config/routes.rb run `rake jsroutes:generate`