### PR TITLE
[SDPV-3] Fixing the position of forms and questions

### DIFF
--- a/lib/sdp/importers/spreadsheet.rb
+++ b/lib/sdp/importers/spreadsheet.rb
@@ -101,7 +101,8 @@ module SDP
           f = Form.new(name: name || "Imported Form ##{f_position + 1}", created_by: @user)
           f.concepts << Concept.new(display_name: 'MMG Tab Name', value: @config[:de_tab_name])
           f.save!
-          s.survey_forms.create(form: f, position: f_position += 1)
+          s.survey_forms.create(form: f, position: f_position)
+          f_position += 1
           q_position = 0
           elements.each do |element|
             rs = nil
@@ -113,7 +114,8 @@ module SDP
             q = question_for(element)
             q.save!
             q.question_response_sets.create(response_set: rs) if rs
-            f.form_questions.create(question: q, program_var: element[:program_var], response_set: rs, position: q_position += 1)
+            f.form_questions.create(question: q, program_var: element[:program_var], response_set: rs, position: q_position)
+            q_position += 1
             q.index
           end
           UpdateIndexJob.perform_now('form', f)

--- a/test/unit/lib/mmg_test.rb
+++ b/test/unit/lib/mmg_test.rb
@@ -35,7 +35,11 @@ class MMGTest < ActiveSupport::TestCase
     assert form.present?
     assert_equal form.questions.count, 1
     assert_equal form.concepts.count, 1
+    assert_equal form.form_questions.first.position, 0
     assert_equal form.concepts.first.value, 'Data Elements'
-    assert Survey.where(name: f).first.forms.count, FORM_COUNT
+
+    survey = Survey.where(name: f).first
+    assert survey.forms.count, FORM_COUNT
+    assert survey.survey_forms.first.position, 0
   end
 end


### PR DESCRIPTION
MMG importer used to have 1-based position. This changes it to be
0-based so that it is aligned with the web application.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
