### PR TITLE
[SDPV-106,114] Clear suggestions & api link

### DIFF
--- a/webpack/components/questions/QuestionEdit.js
+++ b/webpack/components/questions/QuestionEdit.js
@@ -50,6 +50,7 @@ class QuestionEdit extends Component {
         this.state.description !== nextState.description) &&
         (nextState.content.length >= 10 || nextState.description.length >= 10)) {
       this.props.fetchPotentialDuplicateQuestions(nextState.content, nextState.description);
+      this.setState({ showPotentialDuplicates: true });
     }
   }
 
@@ -97,7 +98,8 @@ class QuestionEdit extends Component {
   modalInitialState() {
     return {
       showWarningModal: false,
-      showResponseSetModal: false
+      showResponseSetModal: false,
+      showPotentialDuplicates: false
     };
   }
 
@@ -245,7 +247,7 @@ class QuestionEdit extends Component {
                 : ''}
               </div>
               <div>
-                { this.props.potentialDuplicates && this.props.potentialDuplicates.hits && this.props.potentialDuplicates.hits.total > 0 &&
+                { this.state.showPotentialDuplicates && this.props.potentialDuplicates && this.props.potentialDuplicates.hits && this.props.potentialDuplicates.hits.total > 0 &&
                   <SearchResultList searchResults={this.props.potentialDuplicates}
                                     isEditPage={false}
                                     currentUser={this.props.currentUser}

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -226,6 +226,7 @@ class Header extends Component {
                       return this.joyride.reset(true);
                     }}>Step-by-Step Walkthrough</a></li>
                   }
+                  <li className="nav-dropdown-item"><a href="/api/" tabIndex="2" target="_blank">Swagger API</a></li>
                   <li role="separator" className="divider"></li>
                   <li className="nav-dropdown-item"><span className="version-display">Release: v{this.props.appVersion}</span></li>
                 </ul>


### PR DESCRIPTION
2 changes:
- Fix question potential duplicate suggestions so that when you go to a question edit page after the suggestions have already been made in a previous edit screen, it hides the suggestion UI until the suggestions are updated
- Add a link to help drop down that links to the swagger API

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
