### PR TITLE
[SDPV-115] Version checks for questions-> response sets, forms -> questions

### DIFF
--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -37,27 +37,21 @@ module Versionable
   end
 
   def most_recent
-    if other_versions.present?
-      if other_versions[0].version > version
-        other_versions[0].version
-      else
-        version
-      end
+    latest_version = nil
+    latest_version = max_version if respond_to?(:max_version)
+    if latest_version.nil? && other_versions.present?
+      latest_version = other_versions[0].version
+    end
+    latest_version ||= 1
+    if latest_version >= version
+      latest_version
     else
       version
     end
   end
 
   def most_recent?
-    if other_versions.present?
-      if other_versions[0].version > version
-        false
-      else
-        true
-      end
-    else
-      true
-    end
+    most_recent == version
   end
 
   def as_json(options = {})

--- a/app/views/forms/_form.json.jbuilder
+++ b/app/views/forms/_form.json.jbuilder
@@ -4,9 +4,9 @@ json.extract! form, :id, :name, :description, :created_at, :updated_at, :concept
 json.user_id form.created_by.email if form.created_by.present?
 json.url form_url(form, format: :json)
 
-json.questions form.questions do |q|
+json.questions form.questions_with_most_recent do |q|
   json.extract! q, :id, :content, :created_at, :created_by_id, :updated_at, :question_type_id, :description, :status, \
-                :version, :version_independent_id, :response_type, \
+                :version, :version_independent_id, :response_type, :most_recent, \
                 :other_allowed
 end
 

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -65,3 +65,11 @@ search_3:
   response_type: one
   version: 1
   version_independent_id: Q-8
+
+new_two:
+  content: What is yet another question example?
+  created_by: admin
+  question_type: one
+  response_type: one
+  version: 2
+  version_independent_id: Q-2

--- a/test/frontend/components/search_result_test.js
+++ b/test/frontend/components/search_result_test.js
@@ -4,16 +4,19 @@ import SearchResult from '../../../webpack/components/SearchResult';
 describe('SearchResult', () => {
   let qComponent;
   let rsComponent;
+  let orsComponent;
   let fComponent;
 
   beforeEach(() => {
     const question = {Source: {id: 1, name: "Is this a question?", description: "This is a test question", responseSets: []}};
-    const responseSet = {Source: {id: 1, name: "Response Set Name", description: "RS Description", questions: []}};
+    const responseSet = {Source: {id: 1, name: "Response Set Name", description: "RS Description", version: 1, questions: []}};
+    const oldResponseSet = {Source: {id: 1, name: "Response Set Name", description: "RS Description", version: 1, mostRecent: 3, questions: []}};
     const form = {Source: {id: 1, name: "Form Name", description: "Form Description", questions: []}};
     const currentUser = {id: 1, email: "fake@gmail.com", name: "Fake Test"};
 
     qComponent = renderComponent(SearchResult, {type: "question", currentUser: currentUser, result: question});
     rsComponent = renderComponent(SearchResult, {type: "response_set", currentUser: currentUser, result: responseSet});
+    orsComponent = renderComponent(SearchResult, {type: "response_set", currentUser: currentUser, result: oldResponseSet});
     fComponent = renderComponent(SearchResult, {type: "form", currentUser: currentUser, result: form});
 
   });
@@ -22,5 +25,10 @@ describe('SearchResult', () => {
     expect(qComponent.find("div[class='result-description']")).to.contain('test question');
     expect(rsComponent.find("div[class='result-description']")).to.contain('RS');
     expect(fComponent.find("div[class='result-description']")).to.contain('Form');
+  });
+
+  it('should properly display version information', () => {
+    expect(rsComponent.find("div[class='result-analytics']")).to.contain('version 1');
+    expect(orsComponent.find("div[class='result-analytics']")).to.contain('version 1 (version 3 available)');
   });
 });

--- a/test/models/form_test.rb
+++ b/test/models/form_test.rb
@@ -80,4 +80,13 @@ class FormTest < ActiveSupport::TestCase
     assert_equal q1.id, f.form_questions[0].question_id
     assert_equal q3.id, f.form_questions[1].question_id
   end
+
+  test 'Getting questions with most_recent loaded' do
+    f = forms(:one)
+    qs = f.questions_with_most_recent
+    old_question = qs.find { |q| q.content == 'What is another question example?' }
+    assert_equal 1, old_question.version
+    assert_equal 2, old_question.max_version
+    assert_equal 2, old_question.most_recent
+  end
 end

--- a/test/models/question_test.rb
+++ b/test/models/question_test.rb
@@ -46,7 +46,7 @@ class QuestionTest < ActiveSupport::TestCase
   end
 
   test 'last_published' do
-    q = questions(:two)
+    q = questions(:new_two)
     assert_difference('Question.last_published.count') do
       assert q.publish(users(:admin))
     end

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -305,7 +305,7 @@ export default class SearchResult extends Component {
                 {this.resultStatus(result.status)}
                 <li className={`result-timestamp pull-right ${this.props.programVar && 'list-program-var'}`}>
                   <p>{ format(parse(result.createdAt,''), 'MMMM Do, YYYY') }</p>
-                  <p><text className="sr-only">Item Version Number: </text>version {result.version && result.version} | <text className="sr-only">Item type: </text>{type}</p>
+                  <p><text className="sr-only">Item Version Number: </text>version {this.version(result.version, result.mostRecent)} | <text className="sr-only">Item type: </text>{type}</p>
                   {this.props.programVar && (<p><text className="sr-only">Item program defined Variable: </text>{this.props.programVar}</p>)}
                 </li>
               </ul>
@@ -334,6 +334,16 @@ export default class SearchResult extends Component {
         </li>
       </ul>
     );
+  }
+
+  version(currentVersion, mostRecent) {
+    if (currentVersion) {
+      if (mostRecent && mostRecent > currentVersion) {
+        return `${currentVersion} (version ${mostRecent} available)`;
+      } else {
+        return currentVersion;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
If an old response set is being used on a question or an old question is being used on a form, that will be shown on the respective question and form pages.

This shows as "VERSION 1 (VERSION 3 AVAILABLE)" or something like that.

Passed WAVE

Still need to implement this for survey -> forms to complete SDPV-115

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
