### PR TITLE
[SDPV-115] Showing out of date forms on surveys

### DIFF
--- a/app/views/surveys/show.json.jbuilder
+++ b/app/views/surveys/show.json.jbuilder
@@ -11,9 +11,9 @@ json.questions @survey.questions do |q|
                 :other_allowed
 end
 
-json.forms @survey.forms do |form|
+json.forms @survey.forms_with_most_recent do |form|
   json.extract! form, :id, :name, :description, :created_at, :updated_at, \
-                :version_independent_id, :version, :parent, \
+                :version_independent_id, :version, :parent, :most_recent, \
                 :form_questions, :control_number, :status, :created_by_id, :published_by_id
   json.url form_url(form, format: :json)
 end

--- a/test/fixtures/forms.yml
+++ b/test/fixtures/forms.yml
@@ -11,7 +11,7 @@ one:
   published_by: publisher
 
 two:
-  name: MyString
+  name: Form 2
   created_by: admin
   version: 1
   status: published
@@ -49,3 +49,10 @@ search_3:
   version: 1
   status: draft
   version_independent_id: F-6
+
+newtwo:
+  name: New Form 2
+  created_by: admin
+  version: 2
+  status: published
+  version_independent_id: F-2

--- a/test/frontend/components/survey/survey_show_test.js
+++ b/test/frontend/components/survey/survey_show_test.js
@@ -20,13 +20,13 @@ describe('SurveyShow', () => {
       ],
       deleteSurvey: ()=> {}
     };
-    const startState = {}
+    const startState = {};
     component = renderComponent(SurveyShow, props, startState);
   });
 
   it('should create a list of forms', () => {
     // Drop out of JQuery and just use draw javascript selectors
-    expect(component[0].querySelectorAll('.survey-form').length).to.equal(3);
+    expect(component[0].querySelectorAll('.survey-form .panel-heading').length).to.equal(3);
   });
 
   it('should render an empty list of forms', () => {

--- a/test/models/survey_test.rb
+++ b/test/models/survey_test.rb
@@ -68,4 +68,13 @@ class SurveyTest < ActiveSupport::TestCase
     assert_equal f1.id, s.survey_forms[0].form_id
     assert_equal f3.id, s.survey_forms[1].form_id
   end
+
+  test 'Getting forms with most_recent loaded' do
+    s = surveys(:one)
+    fs = s.forms_with_most_recent
+    old_form = fs.find { |f| f.name == 'Form 2' }
+    assert_equal 1, old_form.version
+    assert_equal 2, old_form.max_version
+    assert_equal 2, old_form.most_recent
+  end
 end

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router';
 import parse from 'date-fns/parse';
 import format from 'date-fns/format';
+import { displayVersion } from '../utilities/componentHelpers';
 import currentUserProps from "../prop-types/current_user_props";
 import { responseSetProps } from "../prop-types/response_set_props";
 
@@ -305,7 +306,7 @@ export default class SearchResult extends Component {
                 {this.resultStatus(result.status)}
                 <li className={`result-timestamp pull-right ${this.props.programVar && 'list-program-var'}`}>
                   <p>{ format(parse(result.createdAt,''), 'MMMM Do, YYYY') }</p>
-                  <p><text className="sr-only">Item Version Number: </text>version {this.version(result.version, result.mostRecent)} | <text className="sr-only">Item type: </text>{type}</p>
+                  <p><text className="sr-only">Item Version Number: </text>version {displayVersion(result.version, result.mostRecent)} | <text className="sr-only">Item type: </text>{type}</p>
                   {this.props.programVar && (<p><text className="sr-only">Item program defined Variable: </text>{this.props.programVar}</p>)}
                 </li>
               </ul>
@@ -334,16 +335,6 @@ export default class SearchResult extends Component {
         </li>
       </ul>
     );
-  }
-
-  version(currentVersion, mostRecent) {
-    if (currentVersion) {
-      if (mostRecent && mostRecent > currentVersion) {
-        return `${currentVersion} (version ${mostRecent} available)`;
-      } else {
-        return currentVersion;
-      }
-    }
   }
 }
 

--- a/webpack/components/surveys/SurveyShow.js
+++ b/webpack/components/surveys/SurveyShow.js
@@ -5,6 +5,7 @@ import { hashHistory, Link } from 'react-router';
 import VersionInfo from '../VersionInfo';
 import PublisherLookUp from "../shared_show/PublisherLookUp";
 import CodedSetTable from "../CodedSetTable";
+import { displayVersion } from '../../utilities/componentHelpers';
 
 import { surveyProps } from '../../prop-types/survey_props';
 import { formProps } from '../../prop-types/form_props';
@@ -108,7 +109,7 @@ class SurveyShow extends Component {
             </div>
           </div>
           {this.props.forms.map((f,i) =>
-            <div  key={i} className="basic-c-box panel-default survey-form">
+            <div key={i} className="basic-c-box panel-default survey-form">
               <div className="panel-heading">
                 <h2 className="panel-title"><Link to={`/forms/${f.id}`}>{ f.name }</Link></h2>
               </div>
@@ -118,6 +119,9 @@ class SurveyShow extends Component {
                     <li key={i}><Link to={`/questions/${q.id}`}>{q.content}</Link></li>
                   )}
                 </ul>
+              </div>
+              <div className="panel-footer survey-form">
+                <p>Form version: {displayVersion(f.version, f.mostRecent)}</p>
               </div>
             </div>
           )}

--- a/webpack/styles/master.scss
+++ b/webpack/styles/master.scss
@@ -37,6 +37,7 @@
 @import "widgets/searchresults";
 @import "widgets/pagination";
 @import "widgets/admin_panel";
+@import "widgets/surveyform";
 
 
 //LAYOUTS//

--- a/webpack/styles/widgets/_surveyform.scss
+++ b/webpack/styles/widgets/_surveyform.scss
@@ -1,0 +1,5 @@
+.survey-form {
+  .panel-footer {
+    padding-left: 15px
+  }
+}

--- a/webpack/utilities/componentHelpers.js
+++ b/webpack/utilities/componentHelpers.js
@@ -23,3 +23,13 @@ export function isExtendable(object, currentUser) {
   return currentUser && currentUser.id &&
     object.status === 'published';
 }
+
+export function displayVersion(currentVersion, mostRecent) {
+  if (currentVersion) {
+    if (mostRecent && mostRecent > currentVersion) {
+      return `${currentVersion} (version ${mostRecent} available)`;
+    } else {
+      return currentVersion;
+    }
+  }
+}


### PR DESCRIPTION
Following the same pattern for forms and questions, this change now
shows versions of forms that are in a survey and will show when there is
a newer version of the form available.

Passed WAVE

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
