### PR TITLE
[SDPV-65] System use sort

### DIFF
--- a/app/controllers/elasticsearch_controller.rb
+++ b/app/controllers/elasticsearch_controller.rb
@@ -15,11 +15,13 @@ class ElasticsearchController < ApplicationController
     system_filter = params[:systems] ? params[:systems] : []
     current_version_filter = params[:mostrecent] == 'true'
     content_since = params[:contentSince]
+    sort = params[:sort]
     results = if SDP::Elasticsearch.ping
                 SDP::Elasticsearch.search(type, query_string, page, query_size,
                                           current_user_id, publisher_search,
                                           my_stuff_filter, program_filter,
-                                          system_filter, current_version_filter, content_since)
+                                          system_filter, current_version_filter,
+                                          content_since, sort)
               else
                 SDP::SimpleSearch.search(type, query_string, current_user_id,
                                          query_size, page, publisher_search,

--- a/features/advance_search.feature
+++ b/features/advance_search.feature
@@ -29,3 +29,11 @@ Feature: Advanced Search
     Then I should see "Content Since Filter:"
     And I should see "7/29/2017"
     And I should see "Clear Adv. Filters"
+
+  Scenario: Sort by system Usage
+    Given I am on the "/" page
+    When I click on the "Advanced" link
+    And I select the "System Usage" option in the "Sort By:" list
+    And I click on the "Close" button
+    Then I should see "Sorting results by System Usage"
+    And I should see "Clear Adv. Filters"

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -94,6 +94,27 @@ module SDP
                      {}
                    end
 
+      sort_filter = ''
+      sort_body = if sort_filter.empty?
+                    [
+                      '_score',
+                      { '_script': {
+                        'script': "doc['surveillance_systems.id'].values.size()",
+                        type: 'number',
+                        order: 'desc'
+                      } }
+                    ]
+                  else
+                    [
+                      { '_script': {
+                        'script': "doc['surveillance_systems.id'].values.size()",
+                        type: 'number',
+                        order: 'desc'
+                      } },
+                      '_score'
+                    ]
+                  end
+
       from_index = (page - 1) * query_size
       search_body = {
         size: query_size,
@@ -104,6 +125,7 @@ module SDP
             must: must_body
           }
         },
+        sort: sort_body,
         highlight: highlight_body
       }
 

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -1,6 +1,8 @@
 # rubocop:disable Metrics/ModuleLength
 # rubocop:disable Metrics/MethodLength
 # rubocop:disable Metrics/ParameterLists
+# rubocop:disable Metrics/PerceivedComplexity
+
 module SDP
   module Elasticsearch
     MAX_DUPLICATE_QUESTION_SUGGESTIONS = 10
@@ -19,7 +21,8 @@ module SDP
     def self.search(type, query_string, page, query_size = 10,
                     current_user_id = nil, publisher_search = false,
                     my_stuff_filter = false, program_filter = [],
-                    system_filter = [], current_version_filter = false, content_since = nil)
+                    system_filter = [], current_version_filter = false,
+                    content_since = nil, sort_filter = '')
       version_filter = if current_version_filter
                          { bool: { filter: {
                            term: { 'most_recent': true }
@@ -94,8 +97,7 @@ module SDP
                      {}
                    end
 
-      sort_filter = ''
-      sort_body = if sort_filter.empty?
+      sort_body = if sort_filter.blank?
                     [
                       '_score',
                       { '_script': {

--- a/webpack/actions/search_results_actions.js
+++ b/webpack/actions/search_results_actions.js
@@ -14,7 +14,7 @@ import {
 } from './types';
 
 const VALID_PARAMETERS = ['searchTerms', 'type', 'programFilter', 'systemFilter',
-  'myStuffFilter', 'mostRecentFilter', 'contentSince', 'page'];
+  'myStuffFilter', 'mostRecentFilter', 'contentSince', 'page', 'sort'];
 
 export class SearchParameters {
   constructor(params) {
@@ -27,7 +27,7 @@ export class SearchParameters {
   }
 
   toSearchParameters() {
-    const simpleMapping = {'searchTerms': 'search', 'type': 'type', 'programFilter': 'programs',
+    const simpleMapping = {'searchTerms': 'search', 'type': 'type', 'programFilter': 'programs', 'sort': 'sort',
       'systemFilter': 'systems', 'myStuffFilter': 'mystuff', 'mostRecentFilter': 'mostrecent', 'page': 'page'};
     const params = {};
     forEach(simpleMapping, (value, key) => {

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -192,7 +192,7 @@ class DashboardSearch extends SearchStateComponent {
                 {this.surveillanceSystemsSelect()}
               </div>
               <div className = "col-md-12">
-                <label className="input-label" htmlFor="sort-By">Sort By:</label>
+                <label className="input-label" htmlFor="sort-by">Sort By:</label>
                 <select className="input-select" name="sort-by" id="sort-by" value={this.state.sort} onChange={(e) => this.toggleSort(e)} >
                   <option value=""></option>
                   <option value="System Usage">System Usage</option>

--- a/webpack/components/DashboardSearch.js
+++ b/webpack/components/DashboardSearch.js
@@ -20,6 +20,7 @@ class DashboardSearch extends SearchStateComponent {
       searchTerms: '',
       programFilter: [],
       systemFilter: [],
+      sort: '',
       showAdvSearchModal: false,
       mostRecentFilter: false,
       surveillancePrograms: {},
@@ -73,7 +74,8 @@ class DashboardSearch extends SearchStateComponent {
       programFilter: [],
       systemFilter: [],
       mostRecentFilter: false,
-      contentSince: null
+      contentSince: null,
+      sort: '',
     };
     let newParams = Object.assign(this.currentSearchParameters(), clearedParams);
     this.props.search(newParams);
@@ -159,6 +161,15 @@ class DashboardSearch extends SearchStateComponent {
     this.props.changeFiltersCallback(newState);
   }
 
+  toggleSort(e) {
+    let newState = {sort: e.target.value};
+    this.setState(newState);
+    let searchParams = this.currentSearchParameters();
+    searchParams.sort = newState.sort;
+    this.props.search(searchParams);
+    this.props.changeFiltersCallback(newState);
+  }
+
   advSearchModal() {
     return (
       <Modal animation={false} show={this.state.showAdvSearchModal} onHide={this.hideAdvSearch} aria-label="Advanced Search Filters">
@@ -179,6 +190,13 @@ class DashboardSearch extends SearchStateComponent {
               </div>
               <div className="col-md-12">
                 {this.surveillanceSystemsSelect()}
+              </div>
+              <div className = "col-md-12">
+                <label className="input-label" htmlFor="sort-By">Sort By:</label>
+                <select className="input-select" name="sort-by" id="sort-by" value={this.state.sort} onChange={(e) => this.toggleSort(e)} >
+                  <option value=""></option>
+                  <option value="System Usage">System Usage</option>
+                </select>
               </div>
               <div className="col-md-12">
                 <h2>Additonal Filters:</h2>
@@ -227,7 +245,7 @@ class DashboardSearch extends SearchStateComponent {
             </span>
           </div>
           <div>
-            {(this.state.programFilter.length > 0 || this.state.systemFilter.length > 0 || this.state.mostRecentFilter || this.state.contentSince) && <a href="#" tabIndex="4" className="adv-search-link pull-right" onClick={(e) => {
+            {(this.state.programFilter.length > 0 || this.state.systemFilter.length > 0 || this.state.mostRecentFilter || this.state.contentSince || this.state.sort !== '') && <a href="#" tabIndex="4" className="adv-search-link pull-right" onClick={(e) => {
               e.preventDefault();
               this.clearAdvSearch();
             }}>Clear Adv. Filters</a>}
@@ -254,6 +272,9 @@ class DashboardSearch extends SearchStateComponent {
               <div className="adv-filter-list">Content Since Filter:
                 <row className="adv-filter-list-item col-md-12">{this.state.contentSince.format('M/D/YYYY')}</row>
               </div>
+            }
+            {this.state.sort !== '' &&
+              <div className="adv-filter-list">Sorting results by {this.state.sort}</div>
             }
           </div><br/>
         </div>

--- a/webpack/styles/widgets/_search.scss
+++ b/webpack/styles/widgets/_search.scss
@@ -121,7 +121,7 @@
 }
 
 .adv-filter-modal-body {
-  min-height: 410px;
+  min-height: 640px;
 }
 
 .adv-filter-instr {


### PR DESCRIPTION
This does two things to the search results:
- by default the search results with the same score returned from elasticsearch will now be ordered (secondarily by default) by their system usage.
- when the sort filter is specified in the drop down, returned results will be sorted by system usage first and score second.

I did it as a drop down since there are other sort types on the backlog

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
