### PR TITLE
Changing style of Jenkins Pipeline for CI/CD process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,7 +71,7 @@ pipeline {
       when {
         branch 'development'
       }
-      steps {}
+      steps {
         echo "Triggering new build for development environment..."
         openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
           checkForTriggeredDeployments: 'true',

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
       steps {
         script {
           env.svcname = sh returnStdout: true, script: 'set +x; echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
-          nv.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
+          env.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
         }
         echo "svc: ${svcname}, tdbname: ${tdbname}"
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,12 +58,12 @@ pipeline {
         }
       }
 
-#      post {
-#        always {
-#          echo "Destroying test database..."
-#          sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
-#        }
-#      }
+/*      post {
+        always {
+          echo "Destroying test database..."
+          sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
+        }
+      } */
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,12 +58,12 @@ pipeline {
         }
       }
 
-      post {
-        always {
-          echo "Destroying test database..."
-          sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
-        }
-      }
+#      post {
+#        always {
+#          echo "Destroying test database..."
+#          sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
+#        }
+#      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
           sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
           waitUntil {
             script {
-              sleep time: '500', unit: 'MILLISECONDS'
+              sleep time: 500, unit: 'MILLISECONDS'
               def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
               return (r == "true")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -8,11 +8,11 @@ pipeline {
 
   stages {
     stage('Run Tests') {
-      agent { label 'ruby' }
+      agent { label 'vocab-ruby' }
 
       steps {
         script {
-          env.svcname = sh returnStdout: true, script: 'echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
+          env.svcname = sh returnStdout: true, script: 'set +x; echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
           nv.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
         }
         echo "svc: ${svcname}, tdbname: ${tdbname}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -30,12 +30,12 @@ pipeline {
         sh 'foreman start webpack &'
 
         echo "Starting test database..."
-        timeout(time: 2, unit: 'MINUTES') {
+        timeout(time: 5, unit: 'MINUTES') {
           sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
           waitUntil {
             script {
-              def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
               sleep time: '500', unit: 'MILLISECONDS'
+              def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
               return (r == "true")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,7 +34,7 @@ pipeline {
           sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
           waitUntil {
             script {
-              sleep time: 500, unit: 'MILLISECONDS'
+              sleep time: 5, unit: 'SECONDS'
               def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
               return (r == "true")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,10 +71,12 @@ pipeline {
       when {
         branch 'development'
       }
-      echo "Triggering new build for development environment..."
-      openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
-        checkForTriggeredDeployments: 'true',
-        waitTime: '10', waitUnit: 'MINUTES'
+      steps {}
+        echo "Triggering new build for development environment..."
+        openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
+          checkForTriggeredDeployments: 'true',
+          waitTime: '10', waitUnit: 'MINUTES'
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   agent none
 
   options {
-    timeout(time: 1, unit: 'HOUR')
+    timeout(time: 1, unit: 'HOURS')
   }
 
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
   agent none
 
   options {
-    timeout(time: 5, unit: 'MINUTES')
+    timeout(time: 1, unit: 'HOUR')
   }
 
   stages {
@@ -58,12 +58,12 @@ pipeline {
         }
       }
 
-/*      post {
+      post {
         always {
           echo "Destroying test database..."
           sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
         }
-      } */
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,56 +1,67 @@
-node('ruby') {
-  env.svcname = sh returnStdout: true, script: 'echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
-  env.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
+#!/usr/bin/env groovy
+pipeline {
+  agent none
 
-  stage('Checkout') {
-    // Checkout code from repository
-    checkout scm
+  options {
+    timeout(time: 5, unit: 'MINUTES')
   }
 
-  stage('Install Deps') {
-    sh 'yarn install'
-    sh 'bundle install'
-  }
-
-  stage('Precompile Assets') {
-    sh 'NODE_ENV=production bundle exec rails assets:precompile'
-  }
-
-  stage('Start Foreman') {
-    sh 'foreman start webpack &'
-  }
-
-  try {
-    stage('Start Test DB') {
-      timeout(time: 120, unit: 'SECONDS') {
-        sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
-        waitUntil {
-          def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
-          return (r == "true")
-        }
-        env.dbhost = sh returnStdout: true, script: 'oc get service -l testdb=${svcname} -o jsonpath="{.items[*].spec.clusterIP}"'
-        env.podName = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{.items[*].metadata.name}"'
-        env.namespace = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{.items[*].metadata.namespace}"'
-        openshiftExec namespace: "${namespace}", pod: "${podName}", container: 'postgresql', command: [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -q -c 'ALTER ROLE railstest WITH SUPERUSER'" ]
-      }
-    }
-
-    stage('Create Schema') {
-      withEnv(["OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432', 'RAILS_ENV=test']) {
-        sh 'bundle exec rake db:create'
-        sh 'bundle exec rake db:schema:load'
-      }
-    }
-
+  stages {
     stage('Run Tests') {
-      withEnv(['NO_PROXY=localhost,127.0.0.1', "OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432']) {
-        sh 'bundle exec rake'
+      agent { label 'ruby' }
+
+      steps {
+        script {
+          env.svcname = sh returnStdout: true, script: 'echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
+          nv.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
+        }
+        echo "svc: ${svcname}, tdbname: ${tdbname}"
+
+        checkout scm
+
+        echo "Installing dependencies..."
+        sh 'yarn install'
+        sh 'bundle install'
+
+        echo "Precompiling assets..."
+        sh 'NODE_ENV=production bundle exec rails assets:precompile'
+
+        echo "Starting Foreman..."
+        sh 'foreman start webpack &'
+
+        echo "Starting test database..."
+        timeout(time: 2, unit: 'MINUTES') {
+          sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
+          waitUntil {
+            def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
+            return (r == "true")
+          }
+          script {
+            env.dbhost = sh returnStdout: true, script: 'oc get service -l testdb=${svcname} -o jsonpath="{.items[*].spec.clusterIP}"'
+            env.podName = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{.items[*].metadata.name}"'
+            env.namespace = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{.items[*].metadata.namespace}"'
+          }
+          openshiftExec namespace: "${namespace}", pod: "${podName}", container: 'postgresql', command: [ "/bin/sh", "-i", "-c", "psql -h 127.0.0.1 -q -c 'ALTER ROLE railstest WITH SUPERUSER'" ]
+        }
+
+        echo "Creating schema..."
+        withEnv(["OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432', 'RAILS_ENV=test']) {
+          sh 'bundle exec rake db:create'
+          sh 'bundle exec rake db:schema:load'
+        }
+
+        echo "Running tests..."
+        withEnv(['NO_PROXY=localhost,127.0.0.1', "OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432']) {
+          sh 'bundle exec rake'
+        }
       }
-    }
-  }
-  finally {
-    stage('Destroy Test DB') {
-      sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
+
+      post {
+        always {
+          echo "Destroying test database..."
+          sh 'oc delete pods,dc,rc,services,secrets -l testdb=${svcname}'
+        }
+      }
     }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,8 +12,8 @@ pipeline {
 
       steps {
         script {
-          env.svcname = sh returnStdout: true, script: 'echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
-          env.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
+          env.svcname = sh returnStdout: true, script: 'echo -n "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
+          env.tdbname = sh returnStdout: true, script: 'echo -n "${svcname}" | tr "-" "_"'
         }
         echo "svc: ${svcname}, tdbname: ${tdbname}"
 
@@ -34,7 +34,7 @@ pipeline {
           sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
           waitUntil {
             script {
-              sleep time: 5, unit: 'SECONDS'
+              sleep time: 15, unit: 'SECONDS'
               def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
               return (r == "true")
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -65,5 +65,16 @@ pipeline {
         }
       }
     }
+
+    stage('Build for Dev Env') {
+      agent any
+      when {
+        branch 'development'
+      }
+      echo "Triggering new build for development environment..."
+      openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
+        checkForTriggeredDeployments: 'true',
+        waitTime: '10', waitUnit: 'MINUTES'
+    }
   }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -35,6 +35,7 @@ pipeline {
           waitUntil {
             script {
               def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
+              sleep time: '500', unit: 'MILLISECONDS'
               return (r == "true")
             }
           }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 
       steps {
         script {
-          env.svcname = sh returnStdout: true, script: 'set +x; echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
+          env.svcname = sh returnStdout: true, script: 'echo "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
           env.tdbname = sh returnStdout: true, script: 'echo "${svcname}" | tr "-" "_"'
         }
         echo "svc: ${svcname}, tdbname: ${tdbname}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,6 @@ pipeline {
       steps {
         echo "Triggering new build for development environment..."
         openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
-          checkForTriggeredDeployments: 'true',
           waitTime: '10', waitUnit: 'MINUTES'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,8 +33,10 @@ pipeline {
         timeout(time: 2, unit: 'MINUTES') {
           sh 'oc process openshift//postgresql-ephemeral -l testdb=${svcname} DATABASE_SERVICE_NAME=${svcname} POSTGRESQL_USER=railstest POSTGRESQL_PASSWORD=railstest POSTGRESQL_DATABASE=${tdbname} | oc create -f -'
           waitUntil {
-            def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
-            return (r == "true")
+            script {
+              def r = sh returnStdout: true, script: 'oc get pod -l name=${svcname} -o jsonpath="{range .items[*]}{.status.containerStatuses[*].ready}{end}"'
+              return (r == "true")
+            }
           }
           script {
             env.dbhost = sh returnStdout: true, script: 'oc get service -l testdb=${svcname} -o jsonpath="{.items[*].spec.clusterIP}"'


### PR DESCRIPTION
This reflects a move to the new CI/CD pipeline process we are putting in place.

- [ NA ] Added unit tests for new functionality
- [ NA ] Passed all unit tests using `rails test` with 90%+ coverage
- [ NA ] Added cucumber tests for any new functionality
- [ x ] Passed all cucumber tests using `bundle exec cucumber`
- [ x ] Passed overcommit hooks, including running all code through Rubocop
- [ NA ] If any database changes were made, run `rake generate_erd` to update the README.md
- [ NA ] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [ NA ] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
