### PR TITLE
[SDPV-278] Spreadsheet importer now links to most recent RS

### DIFF
--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -24,6 +24,10 @@ class ResponseSet < ApplicationRecord
 
   after_commit :index, on: [:create, :update]
 
+  def self.most_recent_for_oid(oid)
+    where(oid: oid).order(version: :desc).first
+  end
+
   def index
     UpdateIndexJob.perform_later('response_set', id)
   end

--- a/lib/sdp/importers/spreadsheet.rb
+++ b/lib/sdp/importers/spreadsheet.rb
@@ -187,7 +187,7 @@ module SDP
       end
 
       def response_set_for_vads(element)
-        rs = ResponseSet.where(oid: element[:value_set_oid]).first
+        rs = ResponseSet.most_recent_for_oid(element[:value_set_oid])
         if rs.nil?
           rs = ResponseSet.new(
             created_by: @user, status: 'draft',

--- a/test/fixtures/response_sets.yml
+++ b/test/fixtures/response_sets.yml
@@ -16,6 +16,7 @@ two:
   version: 1
   version_independent_id: RS-2
   created_by: admin
+  oid: 5.6.7.8
 
 three:
   name: Gender Full
@@ -30,6 +31,7 @@ gfv2:
   version: 2
   version_independent_id: RS-2
   created_by: admin
+  oid: 5.6.7.8
 
 search_1:
   name: Search Response Set 1

--- a/test/models/response_set_test.rb
+++ b/test/models/response_set_test.rb
@@ -93,4 +93,13 @@ class ResponseSetTest < ActiveSupport::TestCase
     assert_equal 1, sp.length
     assert_includes sp.map(&:name), 'Generic Surveillance Program'
   end
+
+  test 'most_recent_for_oid' do
+    rs = ResponseSet.most_recent_for_oid('5.6.7.8')
+    assert rs
+    assert_equal 2, rs.version
+
+    rs = ResponseSet.most_recent_for_oid('6.7.8.9')
+    assert_nil rs
+  end
 end


### PR DESCRIPTION
Will now select the most recent version of a response set when searching
by OID.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
