### PR TITLE
Fixing tabs on SectionEditSearch and some ES and edit bugs

### DIFF
--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -154,7 +154,8 @@ class SectionsController < ApplicationController
     if params[:section][:linked_items]
       params[:section][:linked_items].each do |sni|
         section_nested_items << SectionNestedItem.new(question_id: sni[:question_id], response_set_id: sni[:response_set_id],\
-                                                      position: sni[:position], program_var: sni[:program_var])
+                                                      position: sni[:position], program_var: sni[:program_var],\
+                                                      nested_section_id: sni[:nested_section_id])
       end
     end
     section_nested_items

--- a/app/models/section_nested_item.rb
+++ b/app/models/section_nested_item.rb
@@ -5,7 +5,7 @@ class SectionNestedItem < ApplicationRecord
   belongs_to :nested_section, class_name: 'Section'
   validates :position, presence: true
   validates_associated :section
-  validate :must_have_nested_section_or_question, :not_nested_section_and_question
+  validate :must_have_nested_section_or_question, :not_nested_section_and_question, :no_nested_self
 
   after_commit :reindex, on: [:create, :destroy]
   after_commit :reindex_on_update, on: [:update]
@@ -19,6 +19,12 @@ class SectionNestedItem < ApplicationRecord
   def not_nested_section_and_question
     if nested_section_id.present? && question_id.present?
       errors.add(:question, 'Cannot be associated with both a question and a nested section')
+    end
+  end
+
+  def no_nested_self
+    if nested_section_id.present? && nested_section_id == section_id
+      errors.add(:section, 'Section cannot contain itself as a nested section')
     end
   end
 

--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -252,16 +252,16 @@
             }
           }
         },
-        "questions": {
+        "sectionNestedItems": {
           "type": "object",
           "properties": {
+            "id": {
+              "type": "string"
+            },
             "name": {
               "type": "string"
             },
             "responseSet": {
-              "type": "string"
-            },
-            "id": {
               "type": "string"
             },
             "responseSetID": {

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -186,7 +186,7 @@ export default class SearchResult extends Component {
       case 'survey_section':
         return (
           <ul className="list-inline result-linked-number result-linked-item associated__question" aria-label="Additional Section details.">
-            {result.questions && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-${type}`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about linked </text>Questions and Nested Sections: {result.questions && result.questions.length}</a></li>}
+            {result.sectionNestedItems && <li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-${type}`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about linked </text>Questions and Nested Sections: {result.sectionNestedItems && result.sectionNestedItems.length}</a></li>}
           </ul>
         );
       case 'section_nested_item':
@@ -263,11 +263,11 @@ export default class SearchResult extends Component {
         return (
           <div className="panel-collapse panel-details collapse panel-body" id={`collapse-${result.id}-${type}`}>
             <text className="sr-only">List of links and names of questions and nested sections linked to this section:</text>
-            {result.questions && result.questions.length > 0 &&
-              result.questions.map((q, i) => {
+            {result.sectionNestedItems && result.sectionNestedItems.length > 0 &&
+              result.sectionNestedItems.map((ni, i) => {
                 return(
-                  <div key={`question-${q.id}-${i}`} className="result-details-content">
-                    <Link to={`/questions/${q.id}`}> {q.name || q.content}</Link>
+                  <div key={`nested-item-${ni.id}-${i}`} className="result-details-content">
+                    <Link to={`/${ni.type}s/${ni.id}`}> {ni.name || ni.content}</Link>
                   </div>
                 );
               })

--- a/webpack/containers/sections/SectionEditSearchContainer.js
+++ b/webpack/containers/sections/SectionEditSearchContainer.js
@@ -61,6 +61,14 @@ class SectionEditSearchContainer extends SearchManagerComponent {
     const searchResults = this.props.searchResults;
     return (
       <div>
+        <ul className="nav nav-tabs" role="tablist">
+          <li id="question-search-tab" className={`nav-item ${this.state.searchType === 'question' ? 'active' : ''}`} role="tab" onClick={() => this.selectType('question')} aria-selected={this.state.searchType === 'question'} aria-controls="question-search">
+            <a className="nav-link" data-toggle="tab" href="#" role="tab"><i className="fa fa-tasks" aria-hidden="true"><text className='sr-only'>Click to filter search by</text></i> Questions</a>
+          </li>
+          <li id="section-search-tab" className={`nav-item ${this.state.searchType === 'section' ? 'active' : ''}`} role="tab" onClick={() => this.selectType('section')} aria-selected={this.state.searchType === 'section'} aria-controls="section-search">
+            <a className="nav-link" data-toggle="tab" href="#" role="tab"><i className="fa fa-list-alt" aria-hidden="true"><text className='sr-only'>Click to filter search by</text></i> Sections</a>
+          </li>
+        </ul>
         <DashboardSearch search={this.search}
                          surveillanceSystems={this.props.surveillanceSystems}
                          surveillancePrograms={this.props.surveillancePrograms}
@@ -69,12 +77,7 @@ class SectionEditSearchContainer extends SearchManagerComponent {
                          suggestions={this.props.suggestions}
                          fetchSuggestions={this.props.fetchSuggestions}
                          placeholder="Search Questions..." />
-        <button id="questions-filter-button" className={"section-edit-search-filter btn" + (this.state.searchType === 'question' ? " section-edit-search-filter-active-item" : "")} onClick={() => this.selectType('question')}>
-          <h2 className="item-title" id="question-analytics-item-title"><i className="fa fa-tasks" aria-hidden="true"></i> Questions</h2>
-        </button>
-        <button id="sections-filter-button" className={"section-edit-search-filter btn" + (this.state.searchType === 'section' ? " section-edit-search-filter-active-item" : "")} onClick={() => this.selectType('section')}>
-          <h2 className="item-title" id="sections-analytics-item-title"><i className="fa fa-list-alt" aria-hidden="true"></i> Sections</h2>
-        </button><br/><br/>
+        <br/>
         <div className="load-more-search">
           {searchResults.hits && searchResults.hits.hits.map((sr, i) => {
             let isSelected = this.state.searchType === 'section' ? this.props.selectedSections[sr.Id] : this.props.selectedQuestions[sr.Id];

--- a/webpack/containers/surveys/SurveyShowContainer.js
+++ b/webpack/containers/surveys/SurveyShowContainer.js
@@ -85,7 +85,18 @@ function mapStateToProps(state, ownProps) {
     props.sections = props.sections.map((sect) => {
       const sectionWithNestedItems = Object.assign({}, sect);
       if (sectionWithNestedItems.sectionNestedItems) {
-        sectionWithNestedItems.questions = sectionWithNestedItems.sectionNestedItems.map((sni) => state.questions[sni.questionId]);
+        sectionWithNestedItems.sectionNestedItems = sectionWithNestedItems.sectionNestedItems.map((sni) => {
+          let fullNestedItem = {};
+          if (sni.questionId) {
+            fullNestedItem = state.questions[sni.questionId];
+            fullNestedItem.type = 'question';
+            return fullNestedItem;
+          } else if (sni.sectionId) {
+            fullNestedItem = state.sections[sni.sectionId];
+            fullNestedItem.type = 'section';
+            return fullNestedItem;
+          }
+        });
       }
       return sectionWithNestedItems;
     });

--- a/webpack/schema.js
+++ b/webpack/schema.js
@@ -67,7 +67,5 @@ questionSearchSchema.define({
 });
 
 sectionSearchSchema.define({
-  parent: sectionSearchSchema,
-  questions: [ questionSchema ],
-  responseSets: [ responseSetSchema ]
+  parent: sectionSearchSchema
 });


### PR DESCRIPTION
Fixes for tabs, making tabs look like mockups, made it so section can't nest itself, fixing nested_sections in ES, updates search result so it works with nestedsection links,  fixed issue with "undefined" status on SectionEdit when you switch search.