### PR TITLE
[SDPV-290] Adding documentation of the FHIR API

### DIFF
--- a/webpack/components/FHIRDoc.js
+++ b/webpack/components/FHIRDoc.js
@@ -1,0 +1,52 @@
+import React, { Component } from 'react';
+
+export default class FHIRDoc extends Component {
+  render() {
+    return (
+      <div className="container">
+        <div className="row basic-bg">
+          <div className="col-md-12">
+            <div className="showpage_header_container no-print">
+              <ul className="list-inline">
+                <li className="showpage_button"><span className="fa fa-question-circle fa-2x" aria-hidden="true"></span></li>
+                <li className="showpage_title"><h1>FHIR Documentation</h1></li>
+              </ul>
+            </div>
+            <div className="container col-md-12">
+              <p>The Vocabulary Service provides a <a href="http://hl7.org/fhir">Fast Healthcare Interoperability Resources (FHIR)</a> API.
+              This feature lets software developers create programs that can directly use information from the Vocabulary Service.
+              </p>
+
+              <p>This API is not a full implementation of the FHIR specification, rather it is a subset that is relevant to the
+              features of the Vocabulary Service. The API is currently read-only and supports the JSON representation of FHIR resources.
+              Other resource formats are not currently supported.
+              </p>
+
+              <h2>API Details</h2>
+              <p>The main endpoint for the FHIR API is <strong>/api/fhir</strong></p>
+              <p>The API supports the <a href="http://www.hl7.org/implement/standards/fhir/questionnaire.html">Questionnaire</a> resource.
+              This maps to a Survey in the Vocabulary Service. Sections and questions will be included in the Questionnaire resource.
+              Response Sets are made available via the <a href="http://www.hl7.org/implement/standards/fhir/valueset.html">ValueSet</a> resource.</p>
+              <p>The API supports the <a href="http://www.hl7.org/implement/standards/fhir/http.html#history">history features of FHIR</a>.
+              Accessing a resource via the FHIR API without using the history features will always return the most recent version of the resource.
+              As an example, if there is a Survey with a version independent ID of <strong>S-1</strong>, accessing <strong>/api/fhir/Questionnaire/S-1</strong> will
+              return the most recent version of that Survey. Assuming that the Survey has three versions in the service, the first version of the Survey
+              can be accessed via <strong>/api/fhir/Questionnaire/S-1/_history/1</strong>. The same pattern applies to Reponse Sets.
+              </p>
+
+              <h2>FHIR Extensions</h2>
+              <p>The Vocabulary Service manages information that exceeds the scope of the FHIR specification. In these cases, the specification
+              allows for <a href="http://www.hl7.org/implement/standards/fhir/extensibility.html">extensibility</a>. The API implements two extensions
+              to provide information that is specific to the Vocabulary Service and the needs of its users.</p>
+              <p><strong>Questionnaire.item</strong> may contain two extensions.</p>
+              <p>Extension with the URL <strong>https://sdp-v.services.cdc.gov/fhir/questionnaire-item-program-var</strong> represents the program
+              variable for the question.</p>
+              <p>Extension with the URL <strong>https://sdp-v.services.cdc.gov/fhir/questionnaire-item-meta</strong> represents the tags
+              assciated with the question.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/webpack/containers/App.js
+++ b/webpack/containers/App.js
@@ -106,7 +106,7 @@ class App extends Component {
         </div>
         <footer className="footer">
           <div className="container">
-            2016 Centers for Disease Control and Prevention. All rights reserved.
+            2018 Centers for Disease Control and Prevention. All rights reserved.
             <div className="nav-links">
               <Link to="/privacy">Privacy</Link>
               <Link to="/">Security</Link>

--- a/webpack/containers/Header.js
+++ b/webpack/containers/Header.js
@@ -229,6 +229,7 @@ class Header extends Component {
                     }}>Step-by-Step Walkthrough</a></li>
                   }
                   <li className="nav-dropdown-item"><a href="/api/" tabIndex="2" target="_blank">Swagger API</a></li>
+                  <li className="nav-dropdown-item"><Link to="/fhirDoc">FHIR Documentation</Link></li>
                   <li role="separator" className="divider"></li>
                   <li className="nav-dropdown-item"><span className="version-display">Release: v{this.props.appVersion}</span></li>
                 </ul>

--- a/webpack/landing.js
+++ b/webpack/landing.js
@@ -20,6 +20,7 @@ import SectionEditContainer from './containers/sections/SectionEditContainer';
 import SurveyShowContainer from './containers/surveys/SurveyShowContainer';
 import Privacy from './containers/Privacy';
 import Help from './containers/Help';
+import FHIRDoc from './components/FHIRDoc';
 import AdminPanel from './containers/AdminPanel';
 import App from './containers/App';
 import AuthenticatedRoutes from './containers/AuthenticatedRoutes';
@@ -49,6 +50,7 @@ ReactDOM.render(
         </Route>
         <Route path='/privacy' component={Privacy}/>
         <Route path='/help' component={Help}/>
+        <Route path='/fhirDoc' component={FHIRDoc}/>
         <Route path='/sections/:sectionId' component={SectionShowContainer} />
         <Route path='/responseSets/:rsId' component={ResponseSetShowContainer} />
         <Route path='/questions/:qId' component={QuestionShowContainer} />


### PR DESCRIPTION
No new functionality, just documentation.

Documentation page passed WAVE accessibility check.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
