### PR TITLE
[ECPAAS-152] Headless Testing Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,11 +47,9 @@ group :development, :test do
   gem 'byebug'
   gem 'capybara', '2.11.0'
   gem 'capybara-accessible'
-  gem 'capybara-webkit'
   gem 'chromedriver-helper'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner', git: 'https://github.com/DatabaseCleaner/database_cleaner.git'
-  gem 'headless'
   gem 'json-schema'
   gem 'overcommit'
   gem 'parallel_tests'

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'capybara', '2.11.0'
   gem 'capybara-accessible'
   gem 'capybara-webkit'
+  gem 'chromedriver-helper'
   gem 'cucumber-rails', require: false
   gem 'database_cleaner', git: 'https://github.com/DatabaseCleaner/database_cleaner.git'
   gem 'headless'
@@ -59,7 +60,7 @@ group :development, :test do
   gem 'pry-rescue'
   gem 'pry-stack_explorer'
   gem 'scss_lint', require: false
-  gem 'selenium-webdriver', '2.48.0'
+  gem 'selenium-webdriver'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,6 @@ GEM
       xpath (~> 2.0)
     capybara-accessible (0.2.1)
       capybara (~> 2.0)
-    capybara-webkit (1.14.0)
       capybara (>= 2.3.0, < 2.14.0)
       json
     case_transform (0.2)
@@ -151,7 +150,6 @@ GEM
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     hashie (3.5.6)
-    headless (2.3.1)
     httparty (0.15.6)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
@@ -404,7 +402,6 @@ DEPENDENCIES
   cancancan
   capybara (= 2.11.0)
   capybara-accessible
-  capybara-webkit
   config
   cucumber-rails
   database_cleaner!
@@ -412,7 +409,6 @@ DEPENDENCIES
   elasticsearch
   fakeweb (~> 1.3)
   foreman
-  headless
   httparty
   jbuilder (~> 2.5)
   js-routes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -325,7 +325,7 @@ GEM
       rake (>= 0.9, < 13)
       sass (~> 3.4.20)
     securecompare (1.0.0)
-    selenium-webdriver (2.48.0)
+    selenium-webdriver (3.8.0)
       childprocess (~> 0.5)
       multi_json (~> 1.0)
       rubyzip (~> 1.0)
@@ -442,7 +442,7 @@ DEPENDENCIES
   roo-xls (~> 1.0.0)
   rubocop (~> 0.49.0)
   scss_lint
-  selenium-webdriver (= 2.48.0)
+  selenium-webdriver (~> 3.8.0)
   simplecov
   tzinfo-data
   web-console

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 
       steps {
         script {
-          env.svcname = sh returnStdout: true, script: 'echo -n "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24'
+          env.svcname = sh returnStdout: true, script: 'echo -n "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24 | sed -e "s/-$//"'
           env.tdbname = sh returnStdout: true, script: 'echo -n "${svcname}" | tr "-" "_"'
         }
         echo "svc: ${svcname}, tdbname: ${tdbname}"

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ Rails.application.load_tasks
 if Rails.env != 'production'
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-  task default: [:create_reports_dir, :rubocop, 'brakeman:run', 'bundle_audit:run',
+  task default: [:create_reports_dir, :rubocop, 'cucumber:html', 'brakeman:run', 'bundle_audit:run',
                  'javascript:test', 'javascript:lint', 'erd:test', 'swagger:validate']
 end
 

--- a/features/manage_forms.feature
+++ b/features/manage_forms.feature
@@ -37,8 +37,7 @@ Feature: Manage Sections
     When I go to the list of Sections
     And I click on the menu link for the Section with the name "Test Section"
     And I click on the option to Details the Section with the name "Test Section"
-    When I click on the "Delete" link
-    When I confirm my action
+    When I click on the "Delete" link and confirm my action
     Then I go to the dashboard
     When I go to the list of Sections
     Then I should not see "Test Section"

--- a/features/manage_questions.feature
+++ b/features/manage_questions.feature
@@ -113,8 +113,7 @@ Feature: Manage Questions
     When I go to the list of Questions
     And I click on the menu link for the Question with the content "Test Question"
     And I click on the option to Details the Question with the content "Test Question"
-    When I click on the "Delete" link
-    When I confirm my action
+    When I click on the "Delete" link and confirm my action
     Then I go to the dashboard
     When I go to the list of Questions
     Then I should not see "Test Question"

--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -68,8 +68,7 @@ Feature: Manage Response Sets
     When I go to the list of Response Sets
     And I click on the menu link for the Response Set with the name "Test Response Set"
     And I click on the option to Details the Response Set with the name "Test Response Set"
-    When I click on the "Delete" link
-    When I confirm my action
+    When I click on the "Delete" link and confirm my action
     Then I go to the dashboard
     When I go to the list of Response Sets
     Then I should not see "Test Response Set"

--- a/features/manage_surveys.feature
+++ b/features/manage_surveys.feature
@@ -81,8 +81,7 @@ Feature: Manage Surveys
   When I go to the list of Surveys
   And I click on the menu link for the Survey with the name "Test Survey"
   And I click on the option to Details the Survey with the name "Test Survey"
-  When I click on the "Delete" link
-  When I confirm my action
+  When I click on the "Delete" link and confirm my action
   Then I go to the dashboard
   When I go to the list of Surveys
   Then I should not see "Test Survey"

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -149,7 +149,6 @@ When(/^I click on the "([^"]*)" (button|link) and confirm my action$/) do |butto
       page.driver.browser.switch_to.alert.accept
     end
   end
-
 end
 
 When(/^I click on the create "([^"]*)" dropdown item$/) do |object_type|

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -135,6 +135,23 @@ When(/^I click on the "([^"]*)" (button|link)$/) do |button_name, _button_or_lin
   click_on(button_name)
 end
 
+When(/^I click on the "([^"]*)" (button|link) and confirm my action$/) do |button_name, _button_or_link|
+  # This step is meant to supplement the standard "click" step above and replace the combination
+  # of it and the previous "I confirm my action" step, which did not work in a headless test.
+
+  if !ENV['HEADLESS']
+    click_on(button_name)
+    page.driver.browser.switch_to.alert.accept
+  else
+    begin
+      click_on(button_name)
+    rescue Selenium::WebDriver::Error::UnhandledAlertError
+      page.driver.browser.switch_to.alert.accept
+    end
+  end
+
+end
+
 When(/^I click on the create "([^"]*)" dropdown item$/) do |object_type|
   page.find('#create-menu').click
   page.find('.nav-dropdown-item', text: object_type).click
@@ -142,14 +159,6 @@ end
 
 When(/^I select the "([^"]*)" option in the "([^"]*)" list$/) do |option, list|
   select(option, from: list)
-end
-
-When(/^I confirm my action$/) do
-  # So, apparently the poltergeist driver automatically accept/confirm/okays all alerts
-  # Additionally, it doesn't support the code below, which is required when using selenium.
-  # I'm torn on removing the step entirely, so I'm leaving it and this explanation for posterity.
-
-  page.driver.browser.switch_to.alert.accept unless ENV['HEADLESS']
 end
 
 # Then clauses

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -50,9 +50,7 @@ Capybara.javascript_driver = :chrome
 if ENV['HEADLESS']
   require 'selenium/webdriver'
 
-  # TODO - We already have code in our Rakefile which appears to be an attempt at solving this same problem.
-  #        We should either fix or remove that code, and (either way) this code may be better off in the Jenkinsfile or elsewhere.
-  #        In addition, the delay may be too long, too short, or ultimately a bad solution to this race condition.
+  # TODO:  We already have code in our Rakefile which appears to be an attempt at solving this same problem. We should either fix or remove that code, and (either way) this code may be better off in the Jenkinsfile or elsewhere. In addition, the delay may be too long, too short, or ultimately a bad solution to this race condition.
   puts 'Alternate dir creation location...'
   `mkdir reports`
   `touch reports/cucumber.html`

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -50,7 +50,9 @@ Capybara.javascript_driver = :chrome
 if ENV['HEADLESS']
   require 'selenium/webdriver'
 
-  # TODO:  We already have code in our Rakefile which appears to be an attempt at solving this same problem. We should either fix or remove that code, and (either way) this code may be better off in the Jenkinsfile or elsewhere. In addition, the delay may be too long, too short, or ultimately a bad solution to this race condition.
+  # We already have code in our Rakefile which appears to be an attempt at solving this same problem
+  # TODO: Either fix or remove that code, and (either way) maybe move this code to Jenkinsfile or elsewhere
+  # TODO: This delay may be too long, too short, or ultimately a bad solution to this race condition
   puts 'Alternate dir creation location...'
   `mkdir reports`
   `touch reports/cucumber.html`

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -50,16 +50,14 @@ Capybara.javascript_driver = :chrome
 if ENV['HEADLESS']
   require 'selenium/webdriver'
 
-  # We already have code in our Rakefile which appears to be an attempt at solving this same problem
-  # TODO: Either fix or remove that code, and (either way) maybe move this code to Jenkinsfile or elsewhere
-  # TODO: This delay may be too long, too short, or ultimately a bad solution to this race condition
-  puts 'Alternate dir creation location...'
-  `mkdir reports`
+  # A task exists in the Rakefile to create this directory, but it fails to do so in headless mode
+  puts 'Creating reports directory...'
+  `mkdir -p reports`
   `touch reports/cucumber.html`
-  puts
-  puts 'Sleeping for 10 seconds...'
-  sleep(10)
-  puts
+
+  # Sleep to avoid a race condition as the directory and file are created
+  puts 'Sleeping for 15 seconds...'
+  sleep(15)
 
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new(app, browser: :chrome)

--- a/features/support/test_helper.rb
+++ b/features/support/test_helper.rb
@@ -1,3 +1,0 @@
-Capybara::Webkit.configure do |config|
-  config.allow_url('fonts.googleapis.com')
-end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -53,7 +53,7 @@ begin
   desc 'Alias for cucumber:ok'
   task :cucumber => 'cucumber:ok'
 
-  #task :default => :cucumber
+  task :default => :cucumber
 
   task :features => :cucumber do
     STDERR.puts "*** The 'features' task is deprecated. See rake -T cucumber ***"


### PR DESCRIPTION
Updates to allow headless cucumber testing.

Please note: The Nokogiri gem needs to be updated to >= 1.8.2, and this is causing an error due to advisory CVE-2017-15412. This is true in both my branch and development, and I am choosing to let the devs test this change (rather than making it myself in this branch) to avoid side effects and keep my branch focused only on headless testing.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
