### PR TITLE
[SDPV-346] Don't have MITRE URLs in config files

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -24,4 +24,9 @@ elasticsearch:
 
 app_version: '1.7-alpha'
 disable_user_registration: false
-concept_service_url: 'http://concept-manager.129.83.185.216.xip.io'
+#
+# This URL should use the internal cluster name for the concept-manager service.
+# If you need this to be resolvable in your local environment, then add an
+# alias in your local systems /etc/hosts (or equivalent) file to map this hostname
+# to the proper IP address in your environment.
+concept_service_url: 'http://concept-manager.sdp.svc:8080'


### PR DESCRIPTION
We should not be including MITRE-internal URLs in config files.

- [N/A] Added unit tests for new functionality
- [N/A] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality (tests already existed, but were failing in CDC env)
- [x] Passed all cucumber tests using `bundle exec cucumber` (existing tests now pass)
- [x] Passed overcommit hooks, including running all code through Rubocop
- [N/A] If any database changes were made, run `rake generate_erd` to update the README.md
- [N/A] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [N/A] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
