### PR TITLE
[SDPV-366] Increase waitTime for OpenShift build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -78,7 +78,7 @@ pipeline {
       steps {
         echo "Triggering new build for development environment..."
         openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
-          waitTime: '10', waitUnit: 'min'
+          waitTime: '20', waitUnit: 'min'
       }
     }
   }


### PR DESCRIPTION
This change just increases the wait time for the openshift SDP-V container build to finish.  It takes longer to complete the build in the CDC environment then in our cluster.

- [N/A] Added unit tests for new functionality
- [N/A] Passed all unit tests using `rails test` with 90%+ coverage
- [N/A] Added cucumber tests for any new functionality
- [N/A] Passed all cucumber tests using `bundle exec cucumber`
- [N/A] Passed overcommit hooks, including running all code through Rubocop
- [N/A] If any database changes were made, run `rake generate_erd` to update the README.md
- [N/A] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [N/A] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
