### PR TITLE
Slack integration

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,11 @@ pipeline {
   }
 
   stages {
+    stage('Contact Slack') {
+      steps {
+        slackSend (color: '#FFFF00', message: "STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+      }
+    }
     stage('Run Tests') {
       agent { label 'vocab-ruby' }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,7 +11,6 @@ pipeline {
       agent { label 'vocab-ruby' }
 
       steps {
-        echo "Notifying Slack that the pipeline has started..."
         updateSlack('#FFFF00', 'STARTED')
 
         script {
@@ -110,5 +109,7 @@ pipeline {
 }
 
 def updateSlack(String colorHex, String messageText) {
-  slackSend (color: colorHex, message: "${messageText}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+  if (env.BRANCH_NAME == 'development' || env.CHANGE_ID) {
+    slackSend (color: colorHex, message: "${messageText}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+  }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
 
       steps {
         echo "Notifying Slack that the pipeline has started..."
-        slackSend (color: '#FFFF00', message: "STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+        updateSlack('#FFFF00', 'STARTED')
 
         script {
           env.svcname = sh returnStdout: true, script: 'echo -n "test-${BUILD_NUMBER}-${BRANCH_NAME}" | tr "_A-Z" "-a-z" | cut -c1-24 | sed -e "s/-$//"'
@@ -72,11 +72,11 @@ pipeline {
         }
 
         success {
-          slackSend (color: '#00FF00', message: "FINISHED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+          updateSlack('#00FF00', 'FINISHED')
         }
 
         failure {
-          slackSend (color: '#FF0000', message: "FAILED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+          updateSlack('#FF0000', 'FAILED')
         }
       }
     }
@@ -89,7 +89,7 @@ pipeline {
       }
 
       steps {
-        slackSend (color: '#FFFF00', message: "Starting build for development environment: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+        updateSlack('#FFFF00', 'Starting build for development environment')
         
         echo "Triggering new build for development environment..."
         openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
@@ -98,13 +98,17 @@ pipeline {
 
       post {
         success {
-          slackSend (color: '#00FF00', message: "Finished building for development environment: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+          updateSlack('#00FF00', 'Finished building for development environment')
         }
 
         failure {
-          slackSend (color: '#FF0000', message: "Failed to build for development environment: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
+          updateSlack('#FF0000', 'Failed to build for development environment')
         }
       }
     }
   }
+}
+
+def updateSlack(String colorHex, String messageText) {
+  slackSend (color: colorHex, message: "${messageText}: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,11 +7,12 @@ pipeline {
   }
 
   stages {
-    stage('Contact Slack') {
+    stage('Slack: start notification') {
       steps {
         slackSend (color: '#FFFF00', message: "STARTED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
       }
     }
+
     stage('Run Tests') {
       agent { label 'vocab-ruby' }
 
@@ -84,6 +85,12 @@ pipeline {
         echo "Triggering new build for development environment..."
         openshiftBuild namespace: 'sdp', bldCfg: 'vocabulary',
           waitTime: '20', waitUnit: 'min'
+      }
+    }
+    
+    stage('Slack: finish notification') {
+      steps {
+        slackSend (color: '#00FF00', message: "FINISHED: Job '${env.JOB_NAME} [${env.BUILD_NUMBER}]' (${env.BUILD_URL})")
       }
     }
   }


### PR DESCRIPTION
Added hooks for updating Slack on new jobs. This currently prints to the platform channel, which we will change to the project channel after testing it with enough jobs.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any database changes were made, run `rake generate_erd` to update the README.md
- [x] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
