### PR TITLE
Patch to 1.7 - Various bug fixes and minor improvements

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -127,8 +127,10 @@ class QuestionsController < ApplicationController
   # DELETE /questions/1.json
   def destroy
     if @question.status == 'draft'
+      @question.cascading_action do |element|
+        element.destroy if element.status == 'draft' && element.exclusive_use?
+      end
       @question.destroy
-      SDP::Elasticsearch.delete_item('question', @question.id, true)
       render json: @question
     else
       render json: @question.errors, status: :unprocessable_entity

--- a/app/controllers/response_sets_controller.rb
+++ b/app/controllers/response_sets_controller.rb
@@ -112,7 +112,6 @@ class ResponseSetsController < ApplicationController
   def destroy
     if @response_set.status == 'draft'
       @response_set.destroy
-      SDP::Elasticsearch.delete_item('response_set', @response_set.id, true)
       render json: @response_set
     else
       render json: @response_set.errors, status: :unprocessable_entity

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -64,8 +64,10 @@ class SectionsController < ApplicationController
   # DELETE /sections/1.json
   def destroy
     if @section.status == 'draft'
+      @section.cascading_action do |element|
+        element.destroy if element.status == 'draft' && element.exclusive_use?
+      end
       @section.destroy
-      SDP::Elasticsearch.delete_item('section', @section.id, true)
       render json: @section
     else
       render json: @section.errors, status: :unprocessable_entity

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -44,8 +44,10 @@ class SurveysController < ApplicationController
 
   def destroy
     if @survey.status == 'draft'
+      @survey.cascading_action do |element|
+        element.destroy if element.status == 'draft' && element.exclusive_use?
+      end
       @survey.destroy
-      SDP::Elasticsearch.delete_item('survey', @survey.id, true)
       render json: @survey
     else
       render json: @survey.errors, status: :unprocessable_entity

--- a/app/models/concerns/groupable.rb
+++ b/app/models/concerns/groupable.rb
@@ -23,15 +23,15 @@ module Groupable
 
   def add_to_group(gid)
     cascading_action do |element|
-      element.groups << Group.find(gid)
-      UpdateIndexJob.perform_later(element.class.to_s.downcase, id)
+      element.groups << Group.find(gid) unless element.groups.include?(Group.find(gid))
+      UpdateIndexJob.perform_later(element.class.to_s.underscore, id)
     end
   end
 
   def remove_from_group(gid)
     cascading_action do |element|
       element.groups.delete(Group.find(gid))
-      UpdateIndexJob.perform_later(element.class.to_s.downcase, id)
+      UpdateIndexJob.perform_later(element.class.to_s.underscore, id)
     end
   end
 end

--- a/app/models/concerns/versionable.rb
+++ b/app/models/concerns/versionable.rb
@@ -92,7 +92,7 @@ module Versionable
         if element.version > 1
           prev_version = element.class.find_by(version_independent_id: element.version_independent_id,
                                                version: element.version - 1)
-          UpdateIndexJob.perform_later(element.class.to_s.downcase, prev_version.id)
+          UpdateIndexJob.perform_later(element.class.to_s.underscore, prev_version.id)
         end
       end
     end

--- a/app/models/import_session.rb
+++ b/app/models/import_session.rb
@@ -12,7 +12,8 @@ class ImportSession < ApplicationRecord
       self.import_errors = importer.errors.uniq if importer.errors.present?
       unless importer.sections_exist?
         self.import_errors ||= []
-        self.import_errors << 'Unable to find any data element sheets in this Excel file'
+        self.import_errors << 'Unable to find any data element sheets in this Excel file. Check that your spreadsheet ' \
+                              "sections are separated by 'START: ' and 'END: ' rows (include these phrases with exact spelling before the section name)."
       end
     rescue ArgumentError, Zip::Error
       self.import_errors ||= []
@@ -29,7 +30,8 @@ class ImportSession < ApplicationRecord
       self.survey = survey
     else
       self.import_errors ||= []
-      self.import_errors << 'Unable to find any data element sheets in this Excel file'
+      self.import_errors << 'Unable to find any data element sheets in this Excel file. Check that your spreadsheet ' \
+                            "sections are separated by 'START: ' and 'END: ' rows (include these phrases with exact spelling before the section name)."
     end
     save!
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -23,6 +23,16 @@ class Section < ApplicationRecord
   after_destroy :update_nested_sections
 
   after_commit :index, on: [:create, :update]
+  after_commit :es_destroy, on: [:destroy]
+
+  def es_destroy
+    SDP::Elasticsearch.delete_item('section', id, true)
+  end
+
+  def exclusive_use?
+    # Checking if the survey or parent section that was just destroyed was the only link
+    surveys.empty? && parent.nil?
+  end
 
   def update_surveys
     survey_array = surveys.to_a
@@ -139,12 +149,18 @@ class Section < ApplicationRecord
   end
 
   def cascading_action(&block)
-    yield self
+    temp_qs = []
+    temp_nested_sections = []
+    temp_response_sets = []
     section_nested_items.each do |sni|
-      sni.nested_section.cascading_action(&block) if sni.nested_section
-      sni.question.cascading_action(&block) if sni.question
-      sni.response_set.cascading_action(&block) if sni.response_set
+      temp_qs << sni.question if sni.question
+      temp_nested_sections << sni.nested_section if sni.nested_section
+      temp_response_sets << sni.response_set if sni.response_set
     end
+    yield self
+    temp_qs.each { |q| q.cascading_action(&block) }
+    temp_nested_sections.each { |ns| ns.cascading_action(&block) }
+    temp_response_sets.each { |rs| rs.cascading_action(&block) }
   end
 
   # Get the programs that the section is associated with by the surveys that the

--- a/app/models/section_nested_item.rb
+++ b/app/models/section_nested_item.rb
@@ -55,13 +55,15 @@ class SectionNestedItem < ApplicationRecord
   end
 
   def reindex
-    UpdateIndexJob.perform_later('question', question.id) if previous_changes[:question_id]
+    UpdateIndexJob.perform_later('question', question.id) if question && previous_changes[:question_id]
     UpdateIndexJob.perform_later('response_set', response_set.id) if response_set
+    UpdateIndexJob.perform_later('section', nested_section.id) if nested_section && previous_changes[:nested_section_id]
   end
 
   def reindex_on_update
     # While question can't actually change, previous_changes[:question_id] will exist if this section question was just created
-    UpdateIndexJob.perform_later('question', question.id) if previous_changes[:question_id]
+    UpdateIndexJob.perform_later('question', question.id) if question && previous_changes[:question_id]
+    UpdateIndexJob.perform_later('section', nested_section.id) if nested_section && previous_changes[:nested_section_id]
     if response_set && previous_changes[:response_set_id]
       UpdateIndexJob.perform_later('response_set', response_set.id)
     end

--- a/app/views/questions/_question.json.jbuilder
+++ b/app/views/questions/_question.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! question, :id, :content, :created_at, :created_by, :created_by_id, :updated_at, :category_id, :concepts, :description, :status, \
               :category, :version, :version_independent_id, :other_versions, :most_recent, :response_sets, :response_type, \
-              :parent, :other_allowed, :published_by, :most_recent_published, :subcategory, :groups
+              :parent, :other_allowed, :published_by, :most_recent_published, :subcategory, :groups, :linked_response_sets
 json.url question_url(question, format: :json)
 
 json.sections question.sections do |s|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -44,6 +44,7 @@ Category.find_or_create_by name: 'Clinical'
 Category.find_or_create_by name: 'Treatment'
 Category.find_or_create_by name: 'Laboratory'
 Category.find_or_create_by name: 'Vaccine'
+Category.find_or_create_by name: 'Screening'
 epid = Category.find_or_create_by name: 'Epidemiological'
 ep = Category.find_or_create_by name: 'Emergency Preparedness'
 

--- a/features/edit_questions.feature
+++ b/features/edit_questions.feature
@@ -55,7 +55,7 @@ Feature: Edit Questions
     Then I should see "New Response Set"
     And I click on the "Save" button
     And I should see "What is your favorite color?"
-    When I click on the "Linked Response Sets" link
+    When I click on the "Author Recommended Response Sets" link
     And I should see "New Response Set"
 
   Scenario: Test rs add button doesn't allow you to add multiple of the same causing errors

--- a/features/widget.feature
+++ b/features/widget.feature
@@ -9,7 +9,7 @@ Feature: Widget Display
     Then I should see "What is your gender?"
     And I should see "This is a question"
     And I should see "DRAFT"
-    And I should see "Linked Response Sets: 0"
+    And I should see "Author Recommended Response Sets: 0"
 
   Scenario: View response set widget and test collapsable responses
     Given I have a Response Set with the name "Gender Full" and the description "Response set description" and the response "Original Response"

--- a/test/controllers/sections_controller_test.rb
+++ b/test/controllers/sections_controller_test.rb
@@ -179,6 +179,23 @@ class SectionsControllerTest < ActionDispatch::IntegrationTest
     last_id = Section.last.id
     linked_question = { question_id: Question.last.id, response_set_id: nil, position: 1, program_var: 'test' }
     post sections_url(format: :json), params: { section: { name: 'Create test section', created_by_id: @section.created_by_id, linked_items: [linked_question] } }
+    assert_difference('Question.count', -1) do
+      assert_difference('SectionNestedItem.count', -1) do
+        assert_difference('Section.count', -1) do
+          delete section_url(Section.last, format: :json)
+        end
+      end
+    end
+    assert_response :success
+    assert_not_equal last_id, Section.last
+  end
+
+  test 'shouldnt destroy a question used on multiple sections' do
+    post questions_url(format: :json), params: { question: { status: 'draft', content: 'TBD content' } }
+    last_id = Section.last.id
+    linked_question = { question_id: Question.last.id, response_set_id: nil, position: 1, program_var: 'test' }
+    post sections_url(format: :json), params: { section: { name: 'Non delete test section', created_by_id: @section.created_by_id, linked_items: [linked_question] } }
+    post sections_url(format: :json), params: { section: { name: 'Create test section', created_by_id: @section.created_by_id, linked_items: [linked_question] } }
     assert_difference('Question.count', 0) do
       assert_difference('SectionNestedItem.count', -1) do
         assert_difference('Section.count', -1) do

--- a/test/controllers/survey_controller_test.rb
+++ b/test/controllers/survey_controller_test.rb
@@ -48,12 +48,27 @@ class SurveysControllerTest < ActionDispatch::IntegrationTest
     post surveys_url(format: :json), params: { survey: { name: 'Create test survey', created_by_id: @survey.created_by_id, linked_sections: [{ section_id: Section.last.id, position: 0 }] } }
     assert_difference('Survey.count', -1) do
       assert_difference('SurveySection.count', -1) do
-        assert_difference('Section.count', 0) do
+        assert_difference('Section.count', -1) do
           delete survey_url(Survey.last)
         end
       end
     end
     assert_enqueued_jobs 4
+  end
+
+  test 'shouldnt destroy section if used on another survey' do
+    assert_enqueued_jobs 0
+    post sections_url(format: :json), params: { section: { name: 'Create test section', created_by_id: @survey.created_by_id, linked_questions: [nil], linked_response_sets: [nil] } }
+    post surveys_url(format: :json), params: { survey: { name: 'No delete test survey', created_by_id: @survey.created_by_id, linked_sections: [{ section_id: Section.last.id, position: 0 }] } }
+    post surveys_url(format: :json), params: { survey: { name: 'Create test survey', created_by_id: @survey.created_by_id, linked_sections: [{ section_id: Section.last.id, position: 0 }] } }
+    assert_difference('Survey.count', -1) do
+      assert_difference('SurveySection.count', -1) do
+        assert_difference('Section.count', 0) do
+          delete survey_url(Survey.last)
+        end
+      end
+    end
+    assert_enqueued_jobs 6
   end
 
   test 'should not publish a published survey' do

--- a/test/models/import_session_test.rb
+++ b/test/models/import_session_test.rb
@@ -30,7 +30,7 @@ class ImportSessionTest < ActiveSupport::TestCase
       import_session = ImportSession.new(spreadsheet: File.read('./test/fixtures/files/TestGenericTemplate.xlsx', mode: 'rb'),
                                          created_by: @user, original_filename: 'TestGenericTemplate.xlsx')
       import_session.check!
-      assert_equal 'Unable to find any data element sheets in this Excel file', import_session.import_errors.first
+      assert_equal "Unable to find any data element sheets in this Excel file. Check that your spreadsheet sections are separated by 'START: ' and 'END: ' rows (include these phrases with exact spelling before the section name).", import_session.import_errors.first
     end
   end
 

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -181,7 +181,7 @@ export default class SearchResult extends Component {
     } else if (result.responseSets == undefined) {
       return (<li>Click question name to view additional question information.</li>);
     } else {
-      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about </text>Linked Response Sets: {result.responseSets && result.responseSets.length}</a></li>);
+      return (<li><a className="panel-toggle" data-toggle="collapse" href={`#collapse-${result.id}-question`}><i className="fa fa-bars" aria-hidden="true"></i><text className="sr-only">Click link to expand information about </text>Author Recommended Response Sets: {result.responseSets && result.responseSets.length}</a></li>);
     }
   }
 

--- a/webpack/components/questions/QuestionShow.js
+++ b/webpack/components/questions/QuestionShow.js
@@ -182,11 +182,24 @@ export default class QuestionShow extends Component {
               <div className="panel-heading">
                 <h2 className="panel-title">
                   <a className="panel-toggle" data-toggle="collapse" href="#collapse-rs"><i className="fa fa-bars" aria-hidden="true"></i>
-                  <text className="sr-only">Click link to expand information about linked </text>Linked Response Sets: {question.responseSets && question.responseSets.length}</a>
+                  <text className="sr-only">Click link to expand information about linked </text>Author Recommended Response Sets: {question.responseSets && question.responseSets.length}</a>
                 </h2>
               </div>
               <div className="box-content panel-collapse panel-details collapse panel-body" id="collapse-rs">
                 <ResponseSetList responseSets={question.responseSets} />
+              </div>
+            </div>
+          }
+          {question.linkedResponseSets && question.linkedResponseSets.length > 0 &&
+            <div className="basic-c-box panel-default">
+              <div className="panel-heading">
+                <h2 className="panel-title">
+                  <a className="panel-toggle" data-toggle="collapse" href="#collapse-lrs"><i className="fa fa-bars" aria-hidden="true"></i>
+                  <text className="sr-only">Click link to expand information about </text>Response Sets Linked on Sections: {question.linkedResponseSets && question.linkedResponseSets.length}</a>
+                </h2>
+              </div>
+              <div className="box-content panel-collapse panel-details collapse panel-body" id="collapse-lrs">
+                <ResponseSetList responseSets={question.linkedResponseSets} />
               </div>
             </div>
           }

--- a/webpack/components/shared_show/ProgramsAndSystems.js
+++ b/webpack/components/shared_show/ProgramsAndSystems.js
@@ -20,7 +20,7 @@ class ProgramsAndSystems extends Component {
   surveillancePrograms(item) {
     if (item.surveillancePrograms) {
       return <span>{item.surveillancePrograms.length}
-       {item.surveillancePrograms.length > 0 ? ` - ${join(item.surveillancePrograms)}` : ''}</span>;
+       {item.surveillancePrograms.length > 0 ? ` - ${join(item.surveillancePrograms, ', ')}` : ''}</span>;
     } else {
       return 'Loading';
     }
@@ -29,7 +29,7 @@ class ProgramsAndSystems extends Component {
   surveillanceSystems(item) {
     if (item.surveillanceSystems) {
       return <span>{item.surveillanceSystems.length}
-       {item.surveillanceSystems.length > 0 ? ` - ${join(item.surveillanceSystems)}` : ''}</span>;
+       {item.surveillanceSystems.length > 0 ? ` - ${join(item.surveillanceSystems, ', ')}` : ''}</span>;
     } else {
       return 'Loading';
     }

--- a/webpack/containers/surveys/SurveyImportContainer.js
+++ b/webpack/containers/surveys/SurveyImportContainer.js
@@ -84,6 +84,7 @@ class SurveyImportContainer extends Component {
   attemptImport() {
     this.props.attemptImportFile(this.state.importSessionId, (successResponse)=>{
       this.setState({importWarnings: successResponse.data.importErrors,
+        importErrors: successResponse.data.importErrors,
         importSessionId: successResponse.data.id,
         survey: successResponse.data.survey});
     });
@@ -91,7 +92,7 @@ class SurveyImportContainer extends Component {
   }
 
   cancelImport() {
-    this.setState({file: null, importAttempted: false, importErrors: [], fileChosen: false, filePromiseReturned: false});
+    this.setState({file: null, importAttempted: false, importErrors: [], fileChosen: false, filePromiseReturned: false, survey: {}});
   }
 
   fileActions() {
@@ -130,12 +131,12 @@ class SurveyImportContainer extends Component {
   }
 
   importStatus() {
-    if (this.state.importAttempted && this.state.importErrors && this.state.importErrors.length > 0 && !this.state.survey.id) {
+    if (this.state.importAttempted && this.state.importErrors && this.state.importErrors.length > 0 && this.state.survey === null) {
       return (
         <div>
           <div className="import-action-message error" role="alert">
             <button className="btn btn-default" onClick={this.cancelImport}><span className="fa fa-trash"></span> Remove</button>
-            File could not be imported
+            File could not be imported. Try to fix as many of the following errors as possible.
           </div>
           <div className="import-notes">
             {this.state.importErrors.map((msg, i) => {
@@ -148,7 +149,7 @@ class SurveyImportContainer extends Component {
           </div>
         </div>
       );
-    } else if (this.state.importAttempted && this.state.importWarnings && this.state.importWarnings.length > 0 && this.state.survey.id) {
+    } else if (this.state.importAttempted && this.state.importWarnings && this.state.importWarnings.length > 0 && this.state.survey && this.state.survey.id) {
       return (
         <div>
           <div className="import-action-message warning" role="alert">
@@ -167,7 +168,7 @@ class SurveyImportContainer extends Component {
           {this.importResults()}
         </div>
       );
-    } else if (this.state.importAttempted && this.state.survey.id) {
+    } else if (this.state.importAttempted && this.state.survey && this.state.survey.id) {
       return (
         <div>
           <div className="import-action-message success" role="alert">


### PR DESCRIPTION
For the solution to adding a category one was added to seeds file and I will be running the same command in Prod and Demo (as soon as I get my badge).

Fixes include:
  - Cascading delete for draft content that is only used on the survey / section / question being deleted
  - Workin ES updates for response_sets (was dropping underscore in places)
  - Properly cascading delete and group additions
  - No more hanging import when mmg is problematic and can't be imported
  - Improved error messaging
  - ES updates on delete now cascade instead of just parent object updating
  - Improved language clarifying association of linked response sets on question show page

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any database changes were made, run `rake generate_erd` to update the README.md
- [x] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
