### PR TITLE
[SDPV-479] Possible fix for intermittent test failures

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -39,4 +39,7 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'http://localhost:3000' }
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  # Avoid threading issues by running jobs inline
+  config.active_job.queue_adapter = :inline
 end


### PR DESCRIPTION
Theory is that threading issues with ActiveJob are causing the problem.
This change forces the jobs inline, so everything should be single
threaded.

You can find greater detail in my comment here: https://publichealthsurveillance.atlassian.net/secure/RapidBoard.jspa?rapidView=6&projectKey=SDPV&modal=detail&selectedIssue=SDPV-479&quickFilter=11

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
