### PR TITLE
[SDPV-427] Moving data element id to linkId

### DIFF
--- a/app/helpers/api/fhir/questionaires_helper.rb
+++ b/app/helpers/api/fhir/questionaires_helper.rb
@@ -1,0 +1,14 @@
+module Api
+  module Fhir
+    module QuestionairesHelper
+      def link_id(question)
+        de_id = question.concepts.find { |c| c.display_name == 'Data Element Identifier' } if question.concepts.present?
+        if de_id
+          de_id.value
+        else
+          question.id.to_s
+        end
+      end
+    end
+  end
+end

--- a/app/views/api/fhir/questionaires/_question.json.jbuilder
+++ b/app/views/api/fhir/questionaires/_question.json.jbuilder
@@ -1,4 +1,4 @@
-json.linkId sni.id.to_s
+json.linkId link_id(sni.question)
 json.text sni.question.content if sni.question
 type = sni.question.response_type.code if sni.question
 type ||= sni.response_set ? 'choice' : 'text'

--- a/test/controllers/api/fhir/questionaires_controller_test.rb
+++ b/test/controllers/api/fhir/questionaires_controller_test.rb
@@ -48,6 +48,16 @@ module Api
         assert_equal 'MyString', program_var['valueString']
       end
 
+      test 'api should use the data element identifier as the link id' do
+        get api_fhir_questionaire_url(@survey.version_independent_id)
+        assert_response :success
+        assert_json_schema_response('fhir/Questionnaire.json')
+        res = JSON.parse response.body
+        link_id = res['item'][0]['item'][0]['linkId']
+        assert link_id
+        assert_equal '1234-5', link_id
+      end
+
       test 'api should show survey of specific version' do
         get api_fhir_questionaire_url(@survey.version_independent_id, version: 1)
         assert_response :success

--- a/test/fixtures/concepts.yml
+++ b/test/fixtures/concepts.yml
@@ -49,3 +49,9 @@ ten:
   value: Generic
   taggable: one (Survey)
   code_system: MMG
+
+eleven:
+  value: 1234-5
+  taggable: one (Question)
+  code_system: LOINC
+  display_name: Data Element Identifier


### PR DESCRIPTION
Perviously, we were using the question id as the linkId. Now, if the
question is tagged with a Data Element Identifier, that will now be used
as the linkId.

Some minor issues with this change:
* The linkId does not have a place for a code system. Some data element identifiers, but not all, have a code system. In this case it is just dropped.
* The data element identifier is still put in the extensions. I can filter it out if we think it is the right thing to do, but I left it, in case someone wanted to look for the code system.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
