### PR TITLE
[SDPV-495] Reduce load time of duplicates in the curation page

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -1,4 +1,7 @@
+require './lib/sdp/elastic_search'
+
 class SurveysController < ApplicationController
+  before_action :load_survey_with_children, only: :show
   load_and_authorize_resource
   before_action :set_paper_trail_whodunnit
 
@@ -112,7 +115,7 @@ class SurveysController < ApplicationController
 
   # GET /surveys/1/duplicates
   def duplicates
-    if SDP::Elasticsearch.ping
+    if ::SDP::Elasticsearch.ping
       render json: @survey.potential_duplicates(current_user), status: :ok
     else
       render json: { msg: 'Request cannot be processed as Elasticsearch appears to be down.' }, status: :unprocessable_entity
@@ -143,6 +146,10 @@ class SurveysController < ApplicationController
   end
 
   private
+
+  def load_survey_with_children
+    @survey = Survey.includes(sections: [:groups]).find(params[:id])
+  end
 
   def can_survey_be_created?(survey)
     if survey.all_versions.count >= 1

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -79,6 +79,21 @@ class Question < ApplicationRecord
     end
   end
 
+  def enque_duplicate_finder(batch)
+    if status == 'draft'
+      batch.add_to_batch(self, :questions) do |results|
+        if results && results['hits'] && results['hits']['total'] > 0
+          category_name = category ? category.name : ''
+          rt = response_type ? response_type.name : ''
+          { draft_question: { id: id, content: content, description: description, response_type: rt,
+                              category: category_name }, potential_duplicates: results['hits']['hits'] }
+        else
+          false
+        end
+      end
+    end
+  end
+
   def mark_as_duplicate(replacement)
     section_nested_items.each do |sni|
       sni.question = replacement

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -76,6 +76,20 @@ class ResponseSet < ApplicationRecord
     end
   end
 
+  def enque_duplicate_finder(batch, question)
+    if status == 'draft'
+      batch.add_to_batch(self, :response_sets) do |rs_results|
+        if rs_results && rs_results['hits'] && rs_results['hits']['total'] > 0
+          { draft_response_set: { id: id, linked_question: { id: question.id, content: question.content },
+                                  name: name, description: description, responses: responses },
+            potential_duplicates: rs_results['hits']['hits'] }
+        else
+          false
+        end
+      end
+    end
+  end
+
   def mark_as_duplicate(replacement)
     section_nested_items.each do |sni|
       sni.response_set = replacement

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -51,6 +51,7 @@ class Survey < ApplicationRecord
       q_count = 0
       rs_count = 0
       sect_dupes = s.potential_duplicates(current_user)
+      sect_dupes[:response_sets] ||= []
       q_count = sect_dupes[:questions].length if sect_dupes[:questions]
       rs_count = sect_dupes[:response_sets].length if sect_dupes[:response_sets]
       dupes << { id: s.id, name: s.name, q_count: q_count, rs_count: rs_count, dupes: sect_dupes }

--- a/app/models/survey.rb
+++ b/app/models/survey.rb
@@ -46,15 +46,15 @@ class Survey < ApplicationRecord
   def potential_duplicates(current_user)
     dupes = []
     sections.each do |s|
-      sect_dupe_count = s.q_with_dupes_count(current_user)
-      next unless sect_dupe_count > 0
       q_count = 0
       rs_count = 0
       sect_dupes = s.potential_duplicates(current_user)
       sect_dupes[:response_sets] ||= []
       q_count = sect_dupes[:questions].length if sect_dupes[:questions]
       rs_count = sect_dupes[:response_sets].length if sect_dupes[:response_sets]
-      dupes << { id: s.id, name: s.name, q_count: q_count, rs_count: rs_count, dupes: sect_dupes }
+      if q_count + rs_count > 0
+        dupes << { id: s.id, name: s.name, q_count: q_count, rs_count: rs_count, dupes: sect_dupes }
+      end
     end
     dupes
   end

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -19,12 +19,14 @@ module SDP
       def execute(current_user_id = nil, groups = [])
         batch_results = {}
         result = SDP::Elasticsearch.batch_find_duplicates(@potential_duplicates.map { |pd| pd[:object] }, current_user_id, groups)
-        result['responses'].each_with_index do |resp, i|
-          pd = @potential_duplicates[i]
-          filter_result = pd[:filter].call(resp)
-          if filter_result
-            batch_results[pd[:category]] ||= []
-            batch_results[pd[:category]] << filter_result
+        if result['responses']
+          result['responses'].each_with_index do |resp, i|
+            pd = @potential_duplicates[i]
+            filter_result = pd[:filter].call(resp)
+            if filter_result
+              batch_results[pd[:category]] ||= []
+              batch_results[pd[:category]] << filter_result
+            end
           end
         end
         batch_results

--- a/test/elastic_helpers.rb
+++ b/test/elastic_helpers.rb
@@ -32,6 +32,9 @@ module Elastictest
     fake_body += ']}}'
     FakeWeb.clean_registry
     FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
+    FakeWeb.register_uri(:get, %r{http://example\.com:9200/_msearch}, body: fake_body + "\n" + fake_body + "\n", content_type: 'application/x-ndjson')
+    # FakeWeb.register_uri(:get, %r{http://example\.com:9200/vocabulary}, body: fake_body, content_type: 'application/json')
+    # FakeWeb.register_uri(:get, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
   end
 
   def self.fake_results(result_type, results)

--- a/test/elastic_helpers.rb
+++ b/test/elastic_helpers.rb
@@ -30,9 +30,10 @@ module Elastictest
     fake_body += fake_results('survey', surveys)
 
     fake_body += ']}}'
+    msearch_body = '{"responses":[' + [fake_body, fake_body, fake_body].join(',') + ']}'
     FakeWeb.clean_registry
     FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
-    FakeWeb.register_uri(:get, %r{http://example\.com:9200/_msearch}, body: fake_body + "\n" + fake_body + "\n", content_type: 'application/x-ndjson')
+    FakeWeb.register_uri(:get, %r{http://example\.com:9200/_msearch}, body: msearch_body, content_type: 'application/json')
     # FakeWeb.register_uri(:get, %r{http://example\.com:9200/vocabulary}, body: fake_body, content_type: 'application/json')
     # FakeWeb.register_uri(:get, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
   end

--- a/test/unit/lib/elastic_search_test.rb
+++ b/test/unit/lib/elastic_search_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 
 require 'sdp/elastic_search'
+require 'elastic_helpers'
 
 class ElasticSearchTest < ActiveSupport::TestCase
   def test_ensure_index
@@ -43,5 +44,31 @@ class ElasticSearchTest < ActiveSupport::TestCase
     req = FakeWeb.last_request
     assert_equal 'GET', req.method
     assert_equal '/vocabulary/question/_search', req.path
+  end
+
+  def test_batch_find_duplicates
+    SDP::Elasticsearch.batch_find_duplicates([questions(:one), questions(:two)], users(:admin).id)
+    req = FakeWeb.last_request
+    assert_equal 'GET', req.method
+    assert_equal '/_msearch', req.path
+  end
+
+  def test_batch_duplicate_finder
+    old_impl = SDP::Elasticsearch.singleton_method(:batch_find_duplicates)
+    begin
+      SDP::Elasticsearch.define_singleton_method(:batch_find_duplicates) do |objs, _user_id, _groups|
+        { 'responses' => objs }
+      end
+      bdf = SDP::Elasticsearch::BatchDuplicateFinder.new
+      bdf.add_to_batch('foo', :test_category) do |result|
+        assert_equal 'foo', result
+        'dupe question'
+      end
+      batch_result = bdf.execute(users(:admin).id)
+      assert batch_result
+      assert_equal 'dupe question', batch_result[:test_category].first
+    ensure
+      SDP::Elasticsearch.define_singleton_method(:batch_find_duplicates, old_impl)
+    end
   end
 end


### PR DESCRIPTION
This change cut the response time of the duplicates endpoint on surveys from 13 seconds on my laptop for the Hepatitis MMG to about 5 seconds.

It eliminates the use of `q_with_dupes_count` which is where most of the savings comes from. It also uses batching to send all elastic search queries for a section at once.

Finally, it fixes an unrelated bug. The surveys controller would crash if you went to it directly upon server start in development mode. This is because the SDP::Elasticsearch library wasn't loaded yet, but it typically is somewhere in the flow of the dashboard controller, which is why this probably went unnoticed.

- [x] Added unit tests for new functionality
- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
