### PR TITLE
[SDPV-525] Updating docs on the FHIR API

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -22,7 +22,7 @@ oid_prefix:
 elasticsearch:
   log: false
 
-app_version: '1.9'
+app_version: '1.10-alpha'
 disable_user_registration: false
 #
 # This URL should use the internal cluster name for the concept-manager service.

--- a/lib/tasks/elasticsearch.rake
+++ b/lib/tasks/elasticsearch.rake
@@ -8,7 +8,7 @@ namespace :es do
   desc 'Test that elasticsearch is actually working'
   task :test, [:user_email] => :environment do |_t, args|
     u = User.find_by email: args.user_email
-    search_results = SDP::Elasticsearch.search('', '', 1, 10, u.id)
+    search_results = SDP::Elasticsearch.search('', '', 1, 10, {}, u.id)
     if search_results.hits.count > 0
       puts 'Search executed successfully'
     else

--- a/webpack/components/FHIRDoc.js
+++ b/webpack/components/FHIRDoc.js
@@ -43,6 +43,14 @@ export default class FHIRDoc extends Component {
               variable for the question.</p>
               <p>Extension with the URL <strong>https://sdp-v.services.cdc.gov/fhir/questionnaire-item-meta</strong> represents the tags
               assciated with the question.</p>
+
+              <h2>MMG import data in FHIR</h2>
+              <p>If a Questionnaire was imported from an MMG, the Vocabulary Service will attempt to preserve MMG specific information.
+                If a Data Element in the MMG is given a Data Element Identifier, that will be maintained in the Vocabulary Service. The
+                Data Element Identifier as well as the code system, if provided, will are available in the tags extensions of <strong>Question.item</strong>.
+                Additionally, the Data Element Identifier will be used as the <strong>Question.item.linkId</strong>. If there is no Data Element Identifier,
+                then the Vocabulary Service generated id will be used.
+              </p>
             </div>
           </div>
         </div>


### PR DESCRIPTION
Now mentions that we are putting the Data Element Identifier in
Question.item.linkId.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
