### PR TITLE
[SDPV-526, 542] Updating fixtures, fixing import response type

### DIFF
--- a/app/models/response_type.rb
+++ b/app/models/response_type.rb
@@ -1,3 +1,5 @@
+# It is expected that all ResponseTypes will be instances of
+# https://www.hl7.org/fhir/DSTU2/valueset-answer-format.html
 class ResponseType < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 end

--- a/lib/sdp/importers/spreadsheet.rb
+++ b/lib/sdp/importers/spreadsheet.rb
@@ -223,12 +223,16 @@ module SDP
           value: 'Tag Value (R)',
           system: 'Code System Identifier (O)'
         },
+        # Note that response_types does not contain all possible values.
+        # It only contains values that can appear in MMG files.
+        # This appears to be the complete set, but with MMGs, it can be hard to tell.
         response_types: {
           'Date' => :date,
           'Coded' => :choice,
           'Numeric' => :decimal,
           'Text' => :text,
-          'Date/time' => :dateTime
+          'Date/time' => :dateTime,
+          'String' => :string
         }
       }.freeze
 

--- a/test/controllers/categories_controller_test.rb
+++ b/test/controllers/categories_controller_test.rb
@@ -4,7 +4,7 @@ class CategoriesControllerTest < ActionDispatch::IntegrationTest
   include Devise::Test::IntegrationHelpers
 
   setup do
-    @category = categories(:one)
+    @category = categories(:clinical)
     sign_in users(:admin)
   end
 

--- a/test/fixtures/categories.yml
+++ b/test/fixtures/categories.yml
@@ -1,13 +1,18 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
-#
-one:
-  name: "One"
-# column: value
-#
-two:
-  name: "Two"
-# column: value
+clinical:
+  name: 'Clinical'
+treatment:
+  name: 'Treatment'
+demographics:
+  name: 'Demographics'
+laboratory:
+  name: 'Laboratory'
+vaccine:
+  name: 'Vaccine'
+screening:
+  name: 'Screening'
+epidemiological:
+  name: 'Epidemiological'
+ep:
+  name: 'Public Health Emergency Preparedness & Response'

--- a/test/fixtures/questions.yml
+++ b/test/fixtures/questions.yml
@@ -2,8 +2,8 @@
 one:
   content: What is your gender?
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   status: published
   version: 1
   version_independent_id: Q-1
@@ -12,40 +12,40 @@ one:
 two:
   content: What is another question example?
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   version: 1
   version_independent_id: Q-2
 
 three:
   content: What is another question example?
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   version: 1
   version_independent_id: Q-3
 
 gfv2:
   content: What is another question example?
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   version: 2
   version_independent_id: Q-3
 
 five:
   content: Who did this?
   created_by: not_admin
-  category: one
-  response_type: four
+  category: demographics
+  response_type: string
   version: 1
   version_independent_id: Q-5
 
 search_1:
   content: Search Question 1
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   status: published
   version: 1
   version_independent_id: Q-6
@@ -53,23 +53,23 @@ search_1:
 search_2:
   content: Search Question 2
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   version: 1
   version_independent_id: Q-7
 
 search_3:
   content: Search question 3
   created_by: not_admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: boolean
   version: 1
   version_independent_id: Q-8
 
 new_two:
   content: What is yet another question example?
   created_by: admin
-  category: one
-  response_type: one
+  category: demographics
+  response_type: string
   version: 2
   version_independent_id: Q-2

--- a/test/fixtures/response_types.yml
+++ b/test/fixtures/response_types.yml
@@ -1,31 +1,63 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
-# This model initially had no columns defined. If you add columns to the
-# model remove the '{}' from the fixture names and add the columns immediately
-# below each fixture, per the syntax in the comments below
 #
-one:
-  name: "Response Set"
-# column: value
-#
-two:
-  name: "Integer"
-# column: value
-three:
-  name: "Date"
-  code: "date"
-four:
-  name: "Choice"
-  code: "choice"
-five:
-  name: "Decimal"
-  code: "decimal"
-six:
-  name: "Text"
-  code: "text"
-seven:
-  name: "Date Time"
-  code: "dateTime"
-eight:
-  name: "Open Choice"
-  code: "openChoice"
+# This is based on the FHIR ValueSet - https://www.hl7.org/fhir/DSTU2/valueset-answer-format.html
+boolean:
+  code: 'boolean'
+  name: 'Boolean'
+  description: 'Answer is a yes/no answer.'
+decimal:
+  code: 'decimal'
+  name: 'Decimal'
+  description: 'Answer is a floating point number.'
+integer:
+  code: 'integer'
+  name: 'Integer'
+  description: 'Answer is an integer.'
+date:
+  code: 'date'
+  name: 'Date'
+  description: 'Answer is a date.'
+date_time:
+  code: 'dateTime'
+  name: 'Date Time'
+  description: 'Answer is a date and time.'
+instant:
+  code: 'instant'
+  name: 'Instant'
+  description: 'Answer is a system timestamp.'
+time:
+  code: 'time'
+  name: 'Time'
+  description: 'Answer is a time (hour/minute/second) independent of date.'
+string:
+  code: 'string'
+  name: 'String'
+  description: 'Answer is a short (few words to short sentence) free-text entry.'
+text:
+  code: 'text'
+  name: 'Text'
+  description: 'Answer is a long (potentially multi-paragraph) free-text entry (still captured as a string).'
+url:
+  code: 'url'
+  name: 'Url'
+  description: 'Answer is a url (website, FTP site, etc.).'
+choice:
+  code: 'choice'
+  name: 'Choice'
+  description: 'Answer is a Coding drawn from a list of options.'
+open_choice:
+  code: 'open-choice'
+  name: 'Open Choice'
+  description: 'Answer is a Coding drawn from a list of options or a free-text entry.'
+attachment:
+  code: 'attachment'
+  name: 'Attachment'
+  description: 'Answer is binary content such as a image, PDF, etc.'
+reference:
+  code: 'reference'
+  name: 'Reference'
+  description: 'Answer is a reference to another resource (practitioner, organization, etc.).'
+quantity:
+  code: 'quantity'
+  name: 'Quantity'
+  description: 'Answer is a combination of a numeric value and unit, potentially with a comparator (<, >, etc.).'

--- a/test/fixtures/subcategories.yml
+++ b/test/fixtures/subcategories.yml
@@ -1,0 +1,28 @@
+mc:
+ name: 'Managing & Commanding'
+ category: ep
+operations:
+  name: 'Operations'
+  category: ep
+planning:
+  name: 'Planning/Intelligence'
+  category: ep
+logistics:
+  name: 'Logistics'
+  category: ep
+financial:
+  name: 'Financial/Administration'
+  category: ep
+
+travel:
+ name: 'Travel'
+ category: epidemiological
+contact:
+  name: 'Contact or Exposure'
+  category: epidemiological
+drug_abuse:
+  name: 'Drug Abuse'
+  category: epidemiological
+sexual_behavior:
+  name: 'Sexual Behavior'
+  category: epidemiological


### PR DESCRIPTION
This commit brings the test fixtures in line with the database seed
file.

It also adds the string response type to the spreadsheet importer. It's
possible to add more types, we just need to figure out what they are
called in the MMG files.

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
