### PR TITLE
[SDPV-533,545,586] More 1.10 bugs & Spinner for import

### DIFF
--- a/lib/sdp/importers/spreadsheet.rb
+++ b/lib/sdp/importers/spreadsheet.rb
@@ -156,7 +156,7 @@ module SDP
       attr_accessor :type, :text, :error
 
       def initialize(row_contents)
-        trimmed_contents = row_contents.strip
+        trimmed_contents = row_contents ? row_contents.strip : ''
         { section_start: START_REGEX, section_end: END_REGEX, note: NOTE_REGEX }.each_pair do |k, v|
           match_result = v.match(trimmed_contents)
           next unless match_result

--- a/webpack/components/LoadingSpinner.js
+++ b/webpack/components/LoadingSpinner.js
@@ -1,0 +1,14 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const LoadingSpinner = ({msg="Loading..."}) => (
+  <div>
+    <i className="fa fa-spinner fa-spin" /> {msg}
+  </div>
+);
+
+LoadingSpinner.propTypes = {
+  msg: PropTypes.string
+};
+
+export default LoadingSpinner;

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -288,19 +288,7 @@ export default class SearchResult extends Component {
           <div className="panel-collapse panel-details collapse" id={`collapse-${result.id}-${type}`}>
             <div className="panel-body">
               <text className="sr-only">List of links and names of questions and nested sections linked to this section:</text>
-              {result.sectionNestedItems && result.sectionNestedItems.length > 0 &&
-                result.sectionNestedItems.map((ni, i) => {
-                  if(ni !== undefined) {
-                    return(
-                      <div key={`nested-item-${ni.id}-${i}`} className="result-details-content">
-                        <span className={`fa ${iconMap[ni.type]}`} aria-hidden="true"></span> <Link to={`/${ni.type}s/${ni.id}`}> {ni.name || ni.content}</Link>
-                      </div>
-                    );
-                  } else {
-                    return;
-                  }
-                })
-              }
+              {this.sectionPanel(result)}
             </div>
           </div>
         );
@@ -321,6 +309,26 @@ export default class SearchResult extends Component {
             </div>
           </div>
         );
+    }
+  }
+
+  sectionPanel(result) {
+    if (result.sectionNestedItems && result.sectionNestedItems.length > 0) {
+      if (result.sectionNestedItems[0].type) {
+        return (result.sectionNestedItems.map((ni, i) => {
+          if(ni !== undefined) {
+            return(
+              <div key={`nested-item-${ni.id}-${i}`} className="result-details-content">
+                <span className={`fa ${iconMap[ni.type]}`} aria-hidden="true"></span> <Link to={`/${ni.type}s/${ni.id}`}> {ni.name || ni.content}</Link>
+              </div>
+            );
+          } else {
+            return;
+          }
+        }));
+      } else {
+        return <div className="result-details-content">Click details view in top right for more info and full list of nested items.</div>;
+      }
     }
   }
 

--- a/webpack/containers/surveys/SurveyEditContainer.js
+++ b/webpack/containers/surveys/SurveyEditContainer.js
@@ -143,15 +143,34 @@ function mapDispatchToProps(dispatch) {
 
 function mapStateToProps(state, ownProps) {
   const survey = state.surveys[ownProps.params.surveyId||0];
+  let sections = state.sections;
   var selectedSearchResults = {};
   if(survey && survey.surveySections){
     survey.surveySections.map((ss)=>{
       selectedSearchResults[ss.sectionId] = true;
+      const sectionWithNestedItems = Object.assign({}, sections[ss.sectionId]);
+      if (sectionWithNestedItems.sectionNestedItems && sectionWithNestedItems.sectionNestedItems[0]) {
+        sectionWithNestedItems.sectionNestedItems = sectionWithNestedItems.sectionNestedItems.map((sni) => {
+          let fullNestedItem = {};
+          if (sni.questionId && state.questions[sni.questionId]) {
+            fullNestedItem = state.questions[sni.questionId];
+            fullNestedItem.type = 'question';
+            return fullNestedItem;
+          } else if (sni.nestedSectionId && state.sections[sni.nestedSectionId]) {
+            fullNestedItem = state.sections[sni.nestedSectionId];
+            fullNestedItem.type = 'section';
+            return fullNestedItem;
+          } else {
+            return sni;
+          }
+        });
+      }
+      sections[ss.sectionId] = sectionWithNestedItems;
     });
   }
   return {
     survey: survey,
-    sections:  state.sections,
+    sections:  sections,
     questions: state.questions,
     stats: state.stats,
     currentUser: state.currentUser,

--- a/webpack/containers/surveys/SurveyImportContainer.js
+++ b/webpack/containers/surveys/SurveyImportContainer.js
@@ -5,6 +5,7 @@ import { bindActionCreators } from 'redux';
 
 import { setSteps } from '../../actions/tutorial_actions';
 import { createImportSession, updateImportSession, attemptImportFile } from '../../actions/survey_actions';
+import LoadingSpinner from '../../components/LoadingSpinner';
 
 class SurveyImportContainer extends Component {
   constructor(props) {
@@ -47,17 +48,21 @@ class SurveyImportContainer extends Component {
     if (this.state.importSessionId) {
       this.props.updateImportSession(this.state.importSessionId, e.target.files[0], this.state.importType, (successResponse) => {
         this.setState({importErrors: successResponse.data.importErrors, importWarnings: successResponse.data.importWarnings, importSessionId: successResponse.data.id, filePromiseReturned: true});
+      },(error) => {
+        this.setState({importErrors: [error.message],filePromiseReturned: true});
       });
     } else {
       this.props.createImportSession(e.target.files[0], this.state.importType, (successResponse) => {
         this.setState({importErrors: successResponse.data.importErrors, importWarnings: successResponse.data.importWarnings, importSessionId: successResponse.data.id, filePromiseReturned: true});
+      },(error) => {
+        this.setState({importErrors: [error.message],filePromiseReturned: true});
       });
     }
     this.setState({file: e.target.files[0], fileChosen: true});
   }
 
   //takes the onclick event - returns the target value to the state object.
-  changeFormat( e) {
+  changeFormat(e) {
     this.setState({importType : e.target.value});
   }
 
@@ -70,13 +75,18 @@ class SurveyImportContainer extends Component {
         <br/>
         <fieldset>
           <legend>Please select the format of the file you wish to import</legend>
-          <div>
-          <br/>
-          <input type='radio' className='form-radio-input'  value="generic" onClick={this.changeFormat} name='importType' id='import-type-generic'  />
-          <label htmlFor="import-type-generic">Generic Import</label>
-          <br/><input type='radio' className='form-radio-input' value="mmg" onClick={this.changeFormat}  defaultChecked name='importType' id='import-type-mmg' />
-          <label htmlFor="import-type-mmg">MMG Import</label>
-        </div>
+          <div className="radio">
+            <label htmlFor="import-type-generic">
+              <input type='radio' className='form-radio-input'  value="generic" onClick={this.changeFormat} name='importType' id='import-type-generic'  />
+              Generic Import
+            </label>
+          </div>
+          <div className="radio">
+            <label htmlFor="import-type-mmg">
+              <input type='radio' className='form-radio-input' value="mmg" onClick={this.changeFormat}  defaultChecked name='importType' id='import-type-mmg' />
+              MMG Import
+            </label>
+          </div>
         </fieldset>
 
       </div>);
@@ -140,7 +150,7 @@ class SurveyImportContainer extends Component {
           </div>
         </div>
       );
-    }else if (this.state.importWarnings && this.state.importWarnings.length > 0 && !this.state.importAttempted){
+    }else if (this.state.importWarnings && this.state.importWarnings.length > 0 && !this.state.importAttempted && this.state.filePromiseReturned){
       return (
         <div>
           <div className="import-action-message warning" role="alert">
@@ -159,6 +169,15 @@ class SurveyImportContainer extends Component {
           </div>
         </div>
       );
+    }else if (this.state.importWarnings && this.state.importWarnings.length > 0 && !this.state.importAttempted && !this.state.filePromiseReturned){
+      return (
+        <div>
+          <div className="import-action-message warning" role="alert">
+            Checking file format... Please wait.
+            <LoadingSpinner msg="Working..."/>
+          </div>
+        </div>
+      );
     }else if (!this.state.importAttempted && this.state.filePromiseReturned){
       return (
         <div className="import-action-message success" role="alert">
@@ -168,7 +187,12 @@ class SurveyImportContainer extends Component {
         </div>
       );
     } else if (this.state.fileChosen && !this.state.filePromiseReturned) {
-      return <div className="import-action-message warning" role="alert">Checking file format... Please wait.</div>;
+      return (
+        <div className="import-action-message warning" role="alert">
+          Checking file format... Please wait.
+          <LoadingSpinner msg="Working..."/>
+        </div>
+      );
     } else {
       return;
     }
@@ -223,7 +247,10 @@ class SurveyImportContainer extends Component {
         </div>
       );
     } else if (this.state.importAttempted) {
-      return <div className="import-action-message warning" role="alert">Attempting Import... Please wait.</div>;
+      return <div className="import-action-message warning" role="alert">
+        Attempting Import... Please wait.
+        <LoadingSpinner msg="Working..." />
+      </div>;
     } else {
       return;
     }


### PR DESCRIPTION
Fixed bug reported by mike when trying to import an MMG through the UI. (see 586 for spreadsheet to test). 
Fixed issue where on Question Show page Linked Sections expandable was blank (content isn't available on that page so now it directs user to view section for more details), and on the right side of the survey edit page when a survey already had sections on it (now all expandables should work on the survey edit page)
Cherry-picked the spinner code

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
