### PR TITLE
Response Set source

### DIFF
--- a/features/manage_response_sets.feature
+++ b/features/manage_response_sets.feature
@@ -228,3 +228,37 @@ Feature: Manage Response Sets
     Then I should see "Unsaved Changes"
     Then I press the key escape
     Then I should not see "Unsaved Changes"
+
+  Scenario: Create New Response Set PHIN VADS Source
+    Given I am logged in as test_author@gmail.com
+    Given I have a Response Set with the name "Birth Outcome (Rubella)" and the description "Response set description" with oid "2.16.840.1.114222.4.11.3323"
+    When I go to the list of Response Sets
+    When I click on the menu link for the Response Set with the name "Birth Outcome (Rubella)"
+    And I click on the option to Details the Response Set with the name "Birth Outcome (Rubella)"
+    Then I should see "Name: Birth Outcome (Rubella)"
+    And I should see "Source: PHIN VADS"
+    Then I go to the dashboard
+    When I go to the list of Response Sets
+    Then I should see "Birth Outcome (Rubella)"
+    When I go to the dashboard
+    And I fill in the "search" field with "Birth Outcome"
+    And I click on the "search-btn" button
+    Then I should see "Birth Outcome (Rubella)"
+    And I should see the "PHIN VADS" link
+    
+  Scenario: Create New Response Set Local Source
+    Given I am logged in as test_author@gmail.com
+    Given I have a Response Set with the name "Body Type" and the description "Body Type description"
+    When I go to the list of Response Sets
+    When I click on the menu link for the Response Set with the name "Body Type"
+    And I click on the option to Details the Response Set with the name "Body Type"
+    Then I should see "Name: Body Type"
+    And I should see "Source: Local"
+    Then I go to the dashboard
+    When I go to the list of Response Sets
+    Then I should see "Body Type"
+    When I go to the dashboard
+    And I fill in the "search" field with "Body Type"
+    And I click on the "search-btn" button
+    Then I should see "Body Type"
+    And I should not see a "PHIN VADS" link

--- a/features/step_definitions/response_set_steps.rb
+++ b/features/step_definitions/response_set_steps.rb
@@ -36,6 +36,11 @@ Given(/^I have a Response Set with the name "([^"]*)" and the description "([^"]
   ResponseSet.create!(name: set_name, description: desc, version: 1, created_by: user)
 end
 
+Given(/^I have a Response Set with the name "([^"]*)" and the description "([^"]*)" with oid "([^"]*)"$/) do |set_name, desc, oid|
+  user = get_user 'test_author@gmail.com'
+  ResponseSet.create!(name: set_name, description: desc, version: 1, created_by: user, source: 'PHIN_VADS', oid: oid)
+end
+
 When(/^I go to the list of Response Sets$/) do
   Elastictest.fake_rs_search_results
   visit '/'

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -154,7 +154,25 @@ export default class SearchResult extends Component {
       </li>
     );
   }
+  
+  resultSetSourceInfo(result) {
+    return (
+      <li className="result-analytics-item">
+        <span><text className="sr-only">Result set source: </text>{this.responseSetSourceLink(result)}</span>
+        <p className="item-description" aria-hidden="true">Source</p>
+      </li>
+    );
+  }
 
+  responseSetSourceLink(responseSet) {
+    if(responseSet.source === 'PHIN_VADS' && responseSet.oid && responseSet.version === responseSet.mostRecent) {
+      return <a href={`https://phinvads.cdc.gov/vads/ViewValueSet.action?oid=${responseSet.oid}`} target="_blank">PHIN VADS</a>;
+    } else if (responseSet.source === 'PHIN_VADS') {
+      return <a href="https://phinvads.cdc.gov">PHIN VADS</a>;
+    } else {
+      return <text>{responseSet.source[0].toUpperCase() + responseSet.source.slice(1)}</text>;
+    }
+  }
   selectResultButton(result, isSelected, handleSelectSearchResult, type) {
     if(isSelected){
       return (
@@ -453,6 +471,7 @@ export default class SearchResult extends Component {
                     </p>
                   )}
                 </li>
+               { result.source && this.resultSetSourceInfo(result)}
               </ul>
             </div>
           </div>

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -154,7 +154,7 @@ export default class SearchResult extends Component {
       </li>
     );
   }
-  
+
   resultSetSourceInfo(result) {
     return (
       <li className="result-analytics-item">

--- a/webpack/components/SearchResult.js
+++ b/webpack/components/SearchResult.js
@@ -158,7 +158,7 @@ export default class SearchResult extends Component {
   resultSetSourceInfo(result) {
     return (
       <li className="result-analytics-item">
-        <span><text className="sr-only">Result set source: </text>{this.responseSetSourceLink(result)}</span>
+        <span className="small"><text className="sr-only">Result set source: </text>{this.responseSetSourceLink(result)}</span>
         <p className="item-description" aria-hidden="true">Source</p>
       </li>
     );
@@ -447,6 +447,7 @@ export default class SearchResult extends Component {
                 {result.surveillancePrograms && this.programsInfo(result)}
                 {result.surveillanceSystems && this.systemsInfo(result)}
                 {this.resultStatus(result.status)}
+                {result.source && this.resultSetSourceInfo(result)}
                 <li className={`result-timestamp pull-right ${(this.props.programVar || isSimpleEditable(result, this.props.currentUser)) && 'list-program-var'}`}>
                   <p>{ format(parse(result.createdAt,''), 'MMMM Do, YYYY') }</p>
                   <p><text className="sr-only">Item Version Number: </text>version {displayVersion(result.version, result.mostRecentPublished)} | <text className="sr-only">Item type: </text>{type.replace('_s','S').replace('section_','').replace('survey_','').replace('nested_','').replace('_dropped','').replace('nested','').replace('item','question')}</p>
@@ -471,7 +472,6 @@ export default class SearchResult extends Component {
                     </p>
                   )}
                 </li>
-               { result.source && this.resultSetSourceInfo(result)}
               </ul>
             </div>
           </div>

--- a/webpack/styles/layouts/_panels.scss
+++ b/webpack/styles/layouts/_panels.scss
@@ -17,10 +17,6 @@
 
 .basic-bg {
   margin-bottom: 20px;
-  margin-right: 20px;
-  margin-left: 20px;
-  padding-left: 20px;
-  padding-right: 20px;
   padding-top: 10px;
   padding-bottom: 10px;
   background-color: white;


### PR DESCRIPTION
Fix for SDPV-318 : UI: Display "Source" on Response Set Summary
Search widget result source should show "Local" for locally created response set, or have the same link to PHIN VADS if the imported response set includes a PHIN VADS oid.

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [ ] Added unit tests for new functionality
- [ ] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Added cucumber tests for any new functionality
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [ ] Passed overcommit hooks, including running all code through Rubocop
- [ ] If any database changes were made, run `rake generate_erd` to update the README.md
- [ ] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [x] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
