### PR TITLE
[SDPV-676] Migrate fix 1 13

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -255,7 +255,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     nio4r (2.3.0)
-    nokogiri (1.8.4)
+    nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
     oj (3.5.0)
     olive_branch (2.1.2)

--- a/db/migrate/20180925164840_add_associations_to_versions.rb
+++ b/db/migrate/20180925164840_add_associations_to_versions.rb
@@ -1,6 +1,5 @@
 class AddAssociationsToVersions < ActiveRecord::Migration[5.1]
   def change
-    enable_extension 'hstore'
     add_column :versions, :associations, :hstore, default: {}
   end
 end


### PR DESCRIPTION
Adjusting migration so HStore needs to be manually enabled (since it can't be enabled from vocab container in cluster via migrations)
