### PR TITLE
[SDPV-767] Fixing issues with tests in the CDC Dev/Test env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,6 @@ pipeline {
 
         echo "Creating schema..."
         withEnv(["OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432', 'RAILS_ENV=test']) {
-          sh 'bundle exec rake db:create'
           sh 'bundle exec rake db:schema:load'
         }
 
@@ -72,7 +71,7 @@ pipeline {
         }
 
         echo "Running tests..."
-        withEnv(['NO_PROXY=localhost,127.0.0.1', "OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432']) {
+        withEnv(['NO_PROXY=localhost,127.0.0.1,.sdp.svc', "OPENSHIFT_POSTGRESQL_DB_NAME=${tdbname}", 'OPENSHIFT_POSTGRESQL_DB_USERNAME=railstest', 'OPENSHIFT_POSTGRESQL_DB_PASSWORD=railstest', "OPENSHIFT_POSTGRESQL_DB_HOST=${dbhost}", 'OPENSHIFT_POSTGRESQL_DB_PORT=5432']) {
           sh 'bundle exec rake'
         }
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -14,7 +14,7 @@ require 'axe/cucumber/step_definitions'
 require_relative '../../test/elastic_helpers'
 FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: '{}', content_type: 'application/json')
 
-FakeWeb.register_uri(:any, %r{http://concept-manager\..*}, body: '{}')
+FakeWeb.register_uri(:any, %r{http://concept-manager\.sdp\.svc:8080/}, body: '{}')
 
 Capybara.register_driver :chrome do |app|
   driver =  Capybara::Selenium::Driver.new(app, browser: :chrome)

--- a/test/elastic_helpers.rb
+++ b/test/elastic_helpers.rb
@@ -31,7 +31,6 @@ module Elastictest
 
     fake_body += ']}}'
     msearch_body = '{"responses":[' + [fake_body, fake_body, fake_body].join(',') + ']}'
-    FakeWeb.clean_registry
     FakeWeb.register_uri(:any, %r{http://example\.com:9200/}, body: fake_body, content_type: 'application/json')
     FakeWeb.register_uri(:get, %r{http://example\.com:9200/_msearch}, body: msearch_body, content_type: 'application/json')
     # FakeWeb.register_uri(:get, %r{http://example\.com:9200/vocabulary}, body: fake_body, content_type: 'application/json')


### PR DESCRIPTION
1) We don't need to create the test database.  The database is already
created as part of the container initialization.
2) Added .sdp.svc to NO_PROXY env var to run tests.  This isn't
necessary in the CDC environment, but in the MITRE env, this prevents
requests for the concept-manager service from being sent to the MITRE
proxy server, which responds with a 503 error.
3) Corrected uri registered with FakeWeb for concept-manager svc
4 ) Removed call to FakeWeb.clean_registry