### PR TITLE
[SDPV-743] Publish test results

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require:
+- rubocop/formatter/checkstyle_formatter
 inherit_from: .rubocop_todo.yml
 AllCops:
   TargetRubyVersion: 2.2

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ gem 'axlsx_rails'
 group :development, :test do
   gem 'fakeweb', '~> 1.3'
   gem 'rubocop', '~> 0.49.0', require: false
+  gem 'rubocop-checkstyle_formatter', require: false
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'axe-matchers'
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -385,6 +385,8 @@ GEM
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
+    rubocop-checkstyle_formatter (0.4.0)
+      rubocop (>= 0.35.1)
     ruby-graphviz (1.2.3)
     ruby-ole (1.2.12.1)
     ruby-progressbar (1.9.0)
@@ -513,6 +515,7 @@ DEPENDENCIES
   roo (~> 2.4.0)
   roo-xls (~> 1.0.0)
   rubocop (~> 0.49.0)
+  rubocop-checkstyle_formatter
   scss_lint
   selenium-webdriver
   simplecov

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -109,6 +109,11 @@ pipeline {
       steps {
         publishBrakeman 'reports/brakeman.html'
         cucumber 'reports/cucumber.json'
+        checkstyle canComputeNew: false, defaultEncoding: '', healthy: '',
+          pattern: 'reports/rubocop-checkstyle-result.xml', unHealthy: ''
+        publishHTML([allowMissing: false, alwaysLinkToLastBuild: true, keepAll: false,
+          reportDir: 'reports/rubocop', reportFiles: 'index.html', reportName: 'RuboCop Report',
+          reportTitles: ''])
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -108,6 +108,7 @@ pipeline {
     stage('Publish Results') {
       steps {
         publishBrakeman 'reports/brakeman.html'
+        cucumber 'reports/cucumber.json'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 #!/usr/bin/env groovy
 pipeline {
-  agent none
+  agent { label 'vocab-ruby' }
 
   options {
     timeout(time: 120, unit: 'MINUTES')
@@ -8,8 +8,6 @@ pipeline {
 
   stages {
     stage('Run Tests') {
-      agent { label 'vocab-ruby' }
-
       steps {
         updateSlack('#FFFF00', 'Started tests')
 
@@ -107,9 +105,13 @@ pipeline {
       }
     }
 
-    stage('Build for Dev Env') {
-      agent any
+    stage('Publish Results') {
+      steps {
+        publishBrakeman 'reports/brakeman.html'
+      }
+    }
 
+    stage('Build for Dev Env') {
       when {
         branch 'development'
       }

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,16 @@ Rails.application.load_tasks
 
 if Rails.env != 'production'
   require 'rubocop/rake_task'
-  RuboCop::RakeTask.new
+  RuboCop::RakeTask.new(:rubocop) do |t|
+    t.options = ['--format',
+                 'RuboCop::Formatter::CheckstyleFormatter',
+                 '-o',
+                 'reports/rubocop-checkstyle-result.xml',
+                 '--format',
+                 'html',
+                 '-o',
+                 'reports/rubocop/index.html']
+  end
   task default: [:create_reports_dir, :rubocop, 'brakeman:run', 'bundle_audit:run',
                  'javascript:test', 'javascript:lint', 'erd:test', 'swagger:validate', 'cucumber']
 end

--- a/lib/tasks/cucumber.rake
+++ b/lib/tasks/cucumber.rake
@@ -27,7 +27,7 @@ begin
       t.binary = vendored_cucumber_bin # If nil, the gem's binary is used.
       t.fork = true # You may get faster startup if you set this to false
       t.profile = 'default'
-      t.cucumber_opts = ["--format rerun --out rerun.txt"]
+      t.cucumber_opts = ["--format rerun --out rerun.txt --format json --out reports/cucumber.json"]
     end
 
     Cucumber::Rake::Task.new({:wip => 'test:prepare'}, 'Run features that are being worked on') do |t|


### PR DESCRIPTION
This change will publish the Brakeman, Cucumber, and RuboCop test results back to Jenkins so that they are more easily viewed as part of each build rather than the raw console log output.
