### PR TITLE
Increased Twistlock scan and publish timeout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,7 @@ pipeline {
           logLevel: 'true',
           policy: 'critical',
           requirePackageUpdate: true,
-          timeout: 10
+          timeout: 60
 
         echo "Publishing results..."
         twistlockPublish ca: '',
@@ -177,7 +177,7 @@ pipeline {
           image: 'docker-registry.default.svc.cluster.local:5000/sdp/vocabulary:latest',
           key: '',
           logLevel: 'true',
-          timeout: 10
+          timeout: 60
       }
     }
   }


### PR DESCRIPTION
Just increased scan timeout to 60 minutes to prevent timing out in the CDC environment.