### PR TITLE
[SDPV-637] Optimize curation wizard match

### DIFF
--- a/docs/elastic_search_schema.json
+++ b/docs/elastic_search_schema.json
@@ -118,7 +118,8 @@
               "type": "text"
             },
             "name": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -131,7 +132,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystem": {
               "type": "text",
@@ -140,7 +142,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             },
             "displayName": {
               "type": "text",
@@ -149,7 +152,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -227,7 +231,8 @@
         },
         "description": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "groups": {
           "type": "text"
@@ -249,7 +254,8 @@
         },
         "name": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "sectionNestedItems": {
           "properties": {
@@ -281,7 +287,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 },
                 "codeSystem": {
                   "type": "text",
@@ -290,7 +297,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 },
                 "displayName": {
                   "type": "text",
@@ -299,7 +307,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 }
               }
             },
@@ -437,17 +446,20 @@
               "type": "text"
             },
             "name": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
         "codes": {
           "properties": {
             "code": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystem": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystemOid": {
               "type": "text"
@@ -456,7 +468,8 @@
               "type": "date"
             },
             "displayName": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -538,7 +551,8 @@
         },
         "description": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "groups": {
           "type": "text"
@@ -570,7 +584,8 @@
         },
         "name": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "responseSets": {
           "properties": {
@@ -651,7 +666,8 @@
               "type": "text"
             },
             "name": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -783,7 +799,8 @@
               "type": "text"
             },
             "name": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -793,10 +810,12 @@
         "codes": {
           "properties": {
             "code": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystem": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystemOid": {
               "type": "text"
@@ -805,7 +824,8 @@
               "type": "date"
             },
             "displayName": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -883,7 +903,8 @@
         },
         "description": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "groups": {
           "type": "text"
@@ -893,7 +914,8 @@
         },
         "oid": {
           "type": "text",
-          "analyzer": "sdpoid"
+          "analyzer": "sdpoid",
+          "term_vector" : "with_positions_offsets"
         },
         "mostRecent": {
           "type": "boolean"
@@ -909,7 +931,8 @@
         },
         "name": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "questions": {
           "properties": {
@@ -1071,7 +1094,8 @@
               "type": "text"
             },
             "name": {
-              "type": "text"
+              "type": "text",
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -1088,7 +1112,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             },
             "codeSystem": {
               "type": "text",
@@ -1097,7 +1122,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             },
             "displayName": {
               "type": "text",
@@ -1106,7 +1132,8 @@
                   "type": "keyword",
                   "ignore_above": 256
                 }
-              }
+              },
+              "term_vector" : "with_positions_offsets"
             }
           }
         },
@@ -1184,14 +1211,16 @@
         },
         "description": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "ombApprovalDate": {
           "type": "date"
         },
         "controlNumber": {
           "type": "text",
-          "analyzer": "sdpkey"
+          "analyzer": "sdpkey",
+          "term_vector" : "with_positions_offsets"
         },
         "groups": {
           "type": "text"
@@ -1213,7 +1242,8 @@
         },
         "name": {
           "type": "text",
-          "analyzer": "sdpstandard"
+          "analyzer": "sdpstandard",
+          "term_vector" : "with_positions_offsets"
         },
         "questions": {
           "properties": {
@@ -1226,7 +1256,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 },
                 "codeSystem": {
                   "type": "text",
@@ -1235,7 +1266,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 },
                 "displayName": {
                   "type": "text",
@@ -1244,7 +1276,8 @@
                       "type": "keyword",
                       "ignore_above": 256
                     }
-                  }
+                  },
+                  "term_vector" : "with_positions_offsets"
                 }
               }
             },

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -4,6 +4,7 @@
 # rubocop:disable Metrics/PerceivedComplexity
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/CyclomaticComplexity
+# rubocop:disable Metrics/BlockLength
 
 module SDP
   module Elasticsearch

--- a/lib/sdp/elastic_search.rb
+++ b/lib/sdp/elastic_search.rb
@@ -378,7 +378,10 @@ module SDP
 
         mlt_body = {
           more_like_this: {
-            fields: ['name', 'description', 'codes.code', 'codes.codeSystem', 'codes.displayName', 'category.name', 'subcategory.name'],
+            fields: [
+              'name', 'description', 'codes.code', 'codes.codeSystem', 'codes.displayName',
+              'tag_list', 'category', 'subcategory', 'oid', 'controlNumber'
+            ],
             like: [
               {
                 '_type': obj.class.to_s.underscore,
@@ -386,7 +389,7 @@ module SDP
               }
             ],
             min_term_freq: 1,
-            minimum_should_match: '75%'
+            minimum_should_match: '85%'
           }
         }
 
@@ -396,6 +399,13 @@ module SDP
             bool: {
               filter: [filter_body, version_filter],
               must: [mlt_body]
+            }
+          },
+          highlight: {
+            pre_tags: ['<strong>'], post_tags: ['</strong>'],
+            fields: {
+              'name': {}, 'description': {}, 'codes.code': {}, 'codes.codeSystem': {}, 'codes.displayName': {},
+              'tag_list': {}, 'category': {}, 'subcategory': {}, 'oid': {}, 'controlNumber': {}
             }
           },
           sort: sort_body

--- a/webpack/components/surveys/SurveyDedupe.js
+++ b/webpack/components/surveys/SurveyDedupe.js
@@ -347,7 +347,7 @@ class SurveyDedupe extends Component {
                   return (
                     <tr key={i}>
                       <td headers="match-score-column" className="match-score">{dupe.Score}</td>
-                      <td scope="row" headers="name-desc-column"><a href={`/#/questions/${dupe.Source.id}`} target="_blank">{dupe.Source.name}</a><br/><span className="small">{dupe.Source.description}</span></td>
+                      <td scope="row" headers="name-desc-column"><a href={`/#/questions/${dupe.Source.id}`} target="_blank">{dupe.Source.name}</a><br/><span className="small">{dupe.Source.description}<br/>Matched on fields: {dupe.highlight && Object.keys(dupe.highlight).join(', ')}</span></td>
                       <td headers="cdc-pref-column" className={dupe.Source.preferred ? 'cdc-preferred-column' : ''}>{dupe.Source.preferred && <text className='sr-only'>This content is marked as preferred by the CDC</text>}</td>
                       <td headers="response-type-column"><i className='fa $fa-comments' aria-hidden="true"></i> {dupe.Source.responseType && dupe.Source.responseType.name}</td>
                       <td headers="category-column">{dupe.Source.category && dupe.Source.category.name}</td>


### PR DESCRIPTION
Change Include:
- removing irrelevant match attributes for this type of mathcing
- upping the match threshold to require more accurate matches
- using the new tokenizers for fields
- displaying the fields that matched above the threshold at the bottom of each result
- making the result fuzzy again
- some advanced stuff I read up on with having attribute vectors indexed with offsets so it improves accuracy at the cost of minor speed (tested and not a noticable difference) and space. This also will allow highlighting / display of all matched fields and the text they matched on easily if we want to add highlighting all the matched attributes

Make sure you include the related JIRA issue in the title e.g. '[SDP-007] Fixed navbar issue'
Make sure you have checked off the following before you issue your Pull Request:

- [x] Passed all unit tests using `rails test` with 90%+ coverage
- [x] Passed all cucumber tests using `bundle exec cucumber`
- [x] Passed overcommit hooks, including running all code through Rubocop
