### PR TITLE
[SDPV-850, 863] - Addition of Curation History Tab, GA Analytics tag and removal of hamburger stacks

### DIFF
--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -107,6 +107,10 @@ class Question < ApplicationRecord
 
   def link_to_duplicate(replacement)
     self.duplicate_of = replacement
+    q_replacement = Question.find(replacement)
+    q_replacement.suggested_replacement_of == '' if q_replacement.suggested_replacement_of == nil?
+    q_replacement.suggested_replacement_of << "#{id} "
+    q_replacement.save!
     self.content_stage = 'Duplicate'
     self.duplicates_replaced_count += 1
   end

--- a/app/models/response_set.rb
+++ b/app/models/response_set.rb
@@ -103,6 +103,10 @@ class ResponseSet < ApplicationRecord
 
   def link_to_duplicate(replacement)
     self.duplicate_of = replacement
+    q_replacement = ResponseSet.find(replacement)
+    q_replacement.suggested_replacement_of == '' if q_replacement.suggested_replacement_of == nil?
+    q_replacement.suggested_replacement_of << "#{id} "
+    q_replacement.save!
     self.content_stage = 'Duplicate'
     self.duplicates_replaced_count += 1
   end

--- a/app/views/layouts/landing.html.erb
+++ b/app/views/layouts/landing.html.erb
@@ -14,6 +14,18 @@
 
     <%= javascript_pack_tag 'babel-polyfill.js' %>
     <%= stylesheet_pack_tag 'landing' %>
+
+    <!-- Google Analytics -->
+    <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', 'UA-130404032-1', 'auto');
+    ga('send', 'pageview', '/localhost/cs');
+    </script>
+    <!-- End Google Analytics -->
   </head>
 
   <body class="body">

--- a/app/views/questions/_question.json.jbuilder
+++ b/app/views/questions/_question.json.jbuilder
@@ -1,7 +1,7 @@
 json.extract! question, :id, :content, :created_at, :created_by, :created_by_id, :updated_at, :category_id, :concepts, :description, :status, \
               :category, :version, :version_independent_id, :other_versions, :most_recent, :response_sets, :response_type, :data_collection_methods, \
               :parent, :other_allowed, :published_by, :most_recent_published, :subcategory, :groups, :linked_response_sets, :preferred, :content_stage, \
-              :duplicate_of, :tag_list
+              :duplicate_of, :suggested_replacement_of, :tag_list
 json.url question_url(question, format: :json)
 
 json.sections question.sections do |s|

--- a/app/views/response_sets/_response_set.json.jbuilder
+++ b/app/views/response_sets/_response_set.json.jbuilder
@@ -1,6 +1,6 @@
 json.extract! response_set, :id, :name, :description, :oid, :created_by, :created_by_id, :tag_list, \
               :status, :version, :most_recent, :most_recent_published, :version_independent_id, :content_stage, \
-              :questions, :created_at, :updated_at, :parent, :published_by, :source, :groups, :preferred, :duplicate_of
+              :questions, :created_at, :updated_at, :parent, :published_by, :source, :groups, :preferred, :duplicate_of, :suggested_replacement_of
 json.url response_set_url(response_set, format: :json)
 
 json.all_versions response_set.all_versions do |rs|

--- a/db/migrate/20190304154748_add_suggested_replacement_of_to_response_sets.rb
+++ b/db/migrate/20190304154748_add_suggested_replacement_of_to_response_sets.rb
@@ -1,0 +1,5 @@
+class AddSuggestedReplacementOfToResponseSets < ActiveRecord::Migration[5.1]
+  def change
+    add_column :response_sets, :suggested_replacement_of, :string
+  end
+end

--- a/db/migrate/20190304155018_add_suggested_replacement_of_to_questions.rb
+++ b/db/migrate/20190304155018_add_suggested_replacement_of_to_questions.rb
@@ -1,0 +1,5 @@
+class AddSuggestedReplacementOfToQuestions < ActiveRecord::Migration[5.1]
+  def change
+    add_column :questions, :suggested_replacement_of, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181022163639) do
+ActiveRecord::Schema.define(version: 20190304155018) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 20181022163639) do
     t.string "content_stage", default: "Draft"
     t.integer "duplicate_of"
     t.integer "minor_change_count", default: 0
+    t.string "suggested_replacement_of"
     t.index ["category_id"], name: "index_questions_on_category_id"
     t.index ["created_by_id"], name: "index_questions_on_created_by_id"
     t.index ["response_type_id"], name: "index_questions_on_response_type_id"
@@ -171,6 +172,7 @@ ActiveRecord::Schema.define(version: 20181022163639) do
     t.string "content_stage", default: "Draft"
     t.integer "duplicate_of"
     t.integer "minor_change_count", default: 0
+    t.string "suggested_replacement_of"
     t.index ["created_by_id"], name: "index_response_sets_on_created_by_id"
     t.index ["updated_by_id"], name: "index_response_sets_on_updated_by_id"
   end

--- a/webpack/components/questions/QuestionShow.js
+++ b/webpack/components/questions/QuestionShow.js
@@ -278,7 +278,7 @@ export default class QuestionShow extends Component {
           <div className="tab-content">
           <div className={`tab-pane ${this.state.selectedTab === 'curation' && 'active'}`} id="curation" role="tabpanel" aria-hidden={this.state.selectedTab !== 'curation'} aria-labelledby="curation-history-tab">
             {isSimpleEditable(question, this.props.currentUser) ? (
-              <CurationHistoryTab duplicateOf={question.duplicateOf} contentStage={question.contentStage} objSetName={'Question'} type='response_set'/>
+              <CurationHistoryTab suggestedRepOf={question.suggestedRepOf} duplicateOf={question.duplicateOf} contentStage={question.contentStage} objSetName={'Question'} type='response_set'/>
             ) : (
               <div className='basic-c-box panel-default question-type'>
                 <div className="panel-heading">

--- a/webpack/components/questions/QuestionShow.js
+++ b/webpack/components/questions/QuestionShow.js
@@ -13,6 +13,7 @@ import TagModal from "../TagModal";
 import ProgramsAndSystems from "../shared_show/ProgramsAndSystems";
 import PublisherLookUp from "../shared_show/PublisherLookUp";
 import ChangeHistoryTab from "../shared_show/ChangeHistoryTab";
+import CurationHistoryTab from "../shared_show/CurationHistoryTab";
 import GroupLookUp from "../shared_show/GroupLookUp";
 import Breadcrumb from "../Breadcrumb";
 import BasicAlert from '../../components/BasicAlert';
@@ -270,8 +271,25 @@ export default class QuestionShow extends Component {
             <li id="change-history-tab" className="nav-item" role="tab" onClick={() => this.setState({selectedTab: 'changes'})} aria-selected={this.state.selectedTab === 'changes'} aria-controls="changes">
               <a className="nav-link" data-toggle="tab" href="#change-history" role="tab">Change History</a>
             </li>
+            <li id="curation-history-tab" className="nav-item" role="tab" onClick={() => this.setState({selectedTab: 'curation'})} aria-selected={this.state.selectedTab === 'curation'} aria-controls="curation">
+              <a className="nav-link" data-toggle="tab" href="#curation-history" role="tab">Curation History</a>
+            </li>
           </ul>
           <div className="tab-content">
+          <div className={`tab-pane ${this.state.selectedTab === 'curation' && 'active'}`} id="curation" role="tabpanel" aria-hidden={this.state.selectedTab !== 'curation'} aria-labelledby="curation-history-tab">
+            {isSimpleEditable(question, this.props.currentUser) ? (
+              <CurationHistoryTab duplicateOf={question.duplicateOf} contentStage={question.contentStage} objSetName={'Question'} type='response_set'/>
+            ) : (
+              <div className='basic-c-box panel-default question-type'>
+                <div className="panel-heading">
+                  <h2 className="panel-title">Curation</h2>
+                </div>
+                <div className="box-content">
+                  You do not have permissions to see curation history on this item (you must be the owner or in the proper collaborative authoring group).
+                </div>
+              </div>
+            )}
+          </div>
             <div className={`tab-pane ${this.state.selectedTab === 'changes' && 'active'}`} id="changes" role="tabpanel" aria-hidden={this.state.selectedTab !== 'changes'} aria-labelledby="change-history-tab">
               {isSimpleEditable(question, this.props.currentUser) ? (
                 <ChangeHistoryTab versions={question.versions} type='question' majorVersion={question.version} />
@@ -281,7 +299,7 @@ export default class QuestionShow extends Component {
                     <h2 className="panel-title">Changes</h2>
                   </div>
                   <div className="box-content">
-                    You do not have permissions to see change history on this item (you must be a collaborating author / in the proper group).
+                    You do not have permissions to see change history on this item (you must be the owner or in the proper collaborative authoring group).
                   </div>
                 </div>
               )}
@@ -306,11 +324,6 @@ export default class QuestionShow extends Component {
                   <strong>Content Stage: </strong>
                   {question.contentStage}
                 </div>}
-                {question.duplicateOf && question.contentStage && question.contentStage === 'Duplicate' &&
-                <div className="box-content">
-                  <strong>Duplicate of: </strong><Link to={`/questions/${question.duplicateOf}`}>Question #{question.duplicateOf}</Link>
-                </div>
-                }
                 { this.props.currentUser && question.status && question.status === 'published' &&
                 <div className="box-content">
                   <strong>Visibility: </strong>Published (publicly available)

--- a/webpack/components/response_sets/ResponseSetShow.js
+++ b/webpack/components/response_sets/ResponseSetShow.js
@@ -265,7 +265,7 @@ export default class ResponseSetShow extends Component {
           <div className="tab-content">
           <div className={`tab-pane ${this.state.selectedTab === 'curation' && 'active'}`} id="curation" role="tabpanel" aria-hidden={this.state.selectedTab !== 'curation'} aria-labelledby="curation-history-tab">
             {isSimpleEditable(responseSet, this.props.currentUser) ? (
-              <CurationHistoryTab duplicateOf={responseSet.duplicateOf} contentStage={responseSet.contentStage} objSetName={'Response Set'} type='response_set'/>
+              <CurationHistoryTab suggestedReplacementOf={responseSet.suggestedReplacementOf} duplicateOf={responseSet.duplicateOf} contentStage={responseSet.contentStage} objSetName={'Response Set'} type='response_set'/>
             ) : (
               <div className='basic-c-box panel-default response_set-type'>
                 <div className="panel-heading">

--- a/webpack/components/response_sets/ResponseSetShow.js
+++ b/webpack/components/response_sets/ResponseSetShow.js
@@ -19,6 +19,7 @@ import ProgramsAndSystems from "../shared_show/ProgramsAndSystems";
 import PublisherLookUp from "../shared_show/PublisherLookUp";
 import GroupLookUp from "../shared_show/GroupLookUp";
 import ChangeHistoryTab from "../shared_show/ChangeHistoryTab";
+import CurationHistoryTab from "../shared_show/CurationHistoryTab";
 import currentUserProps from "../../prop-types/current_user_props";
 import { publishersProps } from "../../prop-types/publisher_props";
 import { isEditable, isRevisable, isPublishable, isRetirable, isExtendable, isSimpleEditable, isGroupable } from '../../utilities/componentHelpers';
@@ -122,7 +123,7 @@ export default class ResponseSetShow extends Component {
           </Modal.Body>
           <Modal.Footer>
             <Button onClick={() => this.props.publishResponseSet(this.props.responseSet.id)} bsStyle="primary">Confirm Publish</Button>
-            <Button onClick={()=>this.setState({showPublishModal: false})} bsStyle="default">Cancel</Button>
+            <Button onClick={() => this.setState({showPublishModal: false})} bsStyle="default">Cancel</Button>
           </Modal.Footer>
         </Modal>
       </div>
@@ -257,8 +258,25 @@ export default class ResponseSetShow extends Component {
             <li id="change-history-tab" className="nav-item" role="tab" onClick={() => this.setState({selectedTab: 'changes'})} aria-selected={this.state.selectedTab === 'changes'} aria-controls="changes">
               <a className="nav-link" data-toggle="tab" href="#change-history" role="tab">Change History</a>
             </li>
+            <li id="curation-history-tab" className="nav-item" role="tab" onClick={() => this.setState({selectedTab: 'curation'})} aria-selected={this.state.selectedTab === 'changes'} aria-controls="curation">
+              <a className="nav-link" data-toggle="tab" href="#curation-history" role="tab">Curation History</a>
+            </li>
           </ul>
           <div className="tab-content">
+          <div className={`tab-pane ${this.state.selectedTab === 'curation' && 'active'}`} id="curation" role="tabpanel" aria-hidden={this.state.selectedTab !== 'curation'} aria-labelledby="curation-history-tab">
+            {isSimpleEditable(responseSet, this.props.currentUser) ? (
+              <CurationHistoryTab duplicateOf={responseSet.duplicateOf} contentStage={responseSet.contentStage} objSetName={'Response Set'} type='response_set'/>
+            ) : (
+              <div className='basic-c-box panel-default response_set-type'>
+                <div className="panel-heading">
+                  <h2 className="panel-title">Curation</h2>
+                </div>
+                <div className="box-content">
+                  You do not have permissions to see curation history on this item ((you must be the owner or in the proper collaborative authoring group).
+                </div>
+              </div>
+            )}
+          </div>
             <div className={`tab-pane ${this.state.selectedTab === 'changes' && 'active'}`} id="changes" role="tabpanel" aria-hidden={this.state.selectedTab !== 'changes'} aria-labelledby="change-history-tab">
               {isSimpleEditable(responseSet, this.props.currentUser) ? (
                 <ChangeHistoryTab versions={responseSet.versions} type='response_set' majorVersion={responseSet.version} />
@@ -268,7 +286,7 @@ export default class ResponseSetShow extends Component {
                     <h2 className="panel-title">Changes</h2>
                   </div>
                   <div className="box-content">
-                    You do not have permissions to see change history on this item (you must be a collaborating author / in the proper group).
+                    You do not have permissions to see change history on this item (you must be the owner or in the proper collaborative authoring group).
                   </div>
                 </div>
               )}
@@ -305,11 +323,6 @@ export default class ResponseSetShow extends Component {
                   <div className="box-content">
                     <strong>Content Stage: </strong>
                     {responseSet.contentStage}
-                  </div>
-                }
-                {responseSet.duplicateOf && responseSet.contentStage && responseSet.contentStage === 'Duplicate' &&
-                  <div className="box-content">
-                    <strong>Duplicate of: </strong><Link to={`/responseSets/${responseSet.duplicateOf}`}>Response Set #{responseSet.duplicateOf}</Link>
                   </div>
                 }
                 { this.props.currentUser && responseSet.status && responseSet.status === 'published' &&

--- a/webpack/components/sections/SectionEdit.js
+++ b/webpack/components/sections/SectionEdit.js
@@ -376,11 +376,11 @@ class SectionEdit extends Component {
         <form onSubmit={this.handleSubmit}>
           <Errors errors={this.state.errors} />
             <div className="form-inline">
-              <button tabIndex="3" className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
               <input tabIndex="3" className='btn btn-default pull-right' name="Save Section" type="submit" value={`Save`}/>
               <button tabIndex="3" className="btn btn-default pull-right" disabled>Export</button>
               {this.cancelButton()}
             </div>
+            <br/>
             <hr />
             <div className="section-group">
               <label htmlFor="section-name" hidden>Name</label>

--- a/webpack/components/shared_show/CurationHistoryTab.js
+++ b/webpack/components/shared_show/CurationHistoryTab.js
@@ -33,6 +33,18 @@ function GetDuplicateLink(sEvent, nDuplicateOf) {
   }
 }
 
+function GetSuggestedRepOf(sEvent, sSuggestedReplacementOf) {
+  switch(sEvent)
+  {
+    case 'Response Set':
+      return sSuggestedReplacementOf.trim().split(" ").map((replace_id)=>{return(<u>{<Link to={`/responseSets/${replace_id}`}>Response Set #{replace_id}</Link>}<br/></u>);})
+    case 'Question':
+      return sSuggestedReplacementOf.trim().split(" ").map((replace_id)=>{return(<u>{<Link to={`/questions/${replace_id}`}>Question #{replace_id}</Link>}<br/></u>);})
+    default:
+      return 'Suggested Replacement not found.';
+  }
+}
+
     return (
             <div className={`basic-c-box panel-default ${this.props.type}-type`}>
               <div className="panel-heading">
@@ -47,15 +59,13 @@ function GetDuplicateLink(sEvent, nDuplicateOf) {
                     {this.props.duplicateOf && this.props.contentStage && this.props.contentStage === 'Duplicate' &&
                       <div className="box-content">
                         {GetDuplicateLink(this.props.objSetName, this.props.duplicateOf)}
-                        <br/>
-                      </div>
-                    }
+                      </div>}
                 </div>
                 <div className="box-content">
-                  This {this.props.objSetName} has been selected by authors as a replacement for the following {this.props.objSetName}s:
+                    This {this.props.objSetName} has been selected by authors as a replacement for the following {this.props.objSetName}s:
                   <br/>
                   <br/>
-                  <u>PlaceHolder for Link.</u>
+                  {this.props.suggestedReplacementOf && this.props.objSetName && GetSuggestedRepOf(this.props.objSetName, this.props.suggestedReplacementOf)}
                 </div>
             </div>
         );
@@ -64,6 +74,7 @@ function GetDuplicateLink(sEvent, nDuplicateOf) {
 
 CurationHistoryTab.propTypes = {
   duplicateOf: PropTypes.number,
+  suggestedreplacementOf: PropTypes.number,
   contentStage: PropTypes.string,
   type: PropTypes.string
 };

--- a/webpack/components/shared_show/CurationHistoryTab.js
+++ b/webpack/components/shared_show/CurationHistoryTab.js
@@ -1,0 +1,71 @@
+import React, {Component } from 'react';
+import PropTypes from 'prop-types';
+import parse from 'date-fns/parse';
+import format from 'date-fns/format';
+import { Link } from 'react-router';
+import Linkify from 'react-linkify';
+import CodedSetTable from "../CodedSetTable";
+
+class CurationHistoryTab extends Component {
+  render() {
+    if(this.props.contentStage !== 'Duplicate'){
+      return (
+        <div className={`basic-c-box panel-default ${this.props.type}-type`}>
+          <div className="panel-heading">
+            <h2 className="panel-title">Curation</h2>
+          </div>
+          <div className="box-content">
+            No curation history available.
+          </div>
+        </div>
+      );
+    }
+
+function GetDuplicateLink(sEvent, nDuplicateOf) {
+  switch(sEvent)
+  {
+    case 'Response Set':
+      return <Link to={`/responseSets/${nDuplicateOf}`}>Response Set #{nDuplicateOf}</Link>
+    case 'Question':
+      return <Link to={`/questions/${nDuplicateOf}`}>Question #{nDuplicateOf}</Link>
+    default:
+      return 'Duplicate not found.';
+  }
+}
+
+    return (
+            <div className={`basic-c-box panel-default ${this.props.type}-type`}>
+              <div className="panel-heading">
+                <h2 className="panel-title">Curation</h2>
+                <br/>
+                  The Curation Wizard promotes harmonization in data collection by identifying similar questions and response sets in SDP-V and suggesting them to the author of SDP-V surveys to consider for reuse. The author may decide to replace one or more questions and/or response sets on their survey with the suggested content if it is found to meet the author’s data collection needs. The following summarizes decisions by authors who have used the Curation Wizard to catalog their public SDP-V surveys.
+                </div>
+      <div className="box-content">
+                  Authors have selected the following {this.props.objSetName}s as replacements for this {this.props.objSetName}:
+                  <br/>
+                  <br/>
+                    {this.props.duplicateOf && this.props.contentStage && this.props.contentStage === 'Duplicate' &&
+                      <div className="box-content">
+                        {GetDuplicateLink(this.props.objSetName, this.props.duplicateOf)}
+                        <br/>
+                      </div>
+                    }
+                </div>
+                <div className="box-content">
+                  This {this.props.objSetName} has been selected by authors as a replacement for the following {this.props.objSetName}s:
+                  <br/>
+                  <br/>
+                  <u>PlaceHolder for Link.</u>
+                </div>
+            </div>
+        );
+      }
+    }
+
+CurationHistoryTab.propTypes = {
+  duplicateOf: PropTypes.number,
+  contentStage: PropTypes.string,
+  type: PropTypes.string
+};
+
+export default CurationHistoryTab;

--- a/webpack/components/surveys/SurveyEdit.js
+++ b/webpack/components/surveys/SurveyEdit.js
@@ -245,10 +245,10 @@ class SurveyEdit extends Component {
         <form onSubmit={(e) => this.handleSubmit(e)}>
           <Errors errors={this.state.errors} />
             <div className="survey-inline">
-              <button tabIndex="3" className="btn btn-default btn-sm" disabled><span className="fa fa-navicon"></span><span className="sr-only">Edit Action Menu</span></button>
               <input tabIndex="3" className='btn btn-default pull-right' name="Save Survey" type="submit" value={`Save`}/>
               {this.cancelButton()}
             </div>
+            <br/>
           <hr />
           <div className="survey-group">
             <label htmlFor="survey-name" hidden>Name</label>


### PR DESCRIPTION
- [IP] Added unit tests for new functionality
- [X ] Passed all unit tests using `rails test` with 90%+ coverage
- [IP] Added cucumber tests for any new functionality
- [IP] Passed all cucumber tests using `bundle exec cucumber`
- [X] Passed overcommit hooks, including running all code through Rubocop
- [X] If any database changes were made, run `rake generate_erd` to update the README.md
I ran the rake task.  This is the first db change I've made.  No update to README.md
- [ ] If any changes were made to config/routes.rb run `rake jsroutes:generate`
- [ ] If any HTML was added or modified check to make sure it was still 508 compliant with WAVE tool / carried over any attributes from similar sections
- [X] Ensure all code has been appropriately commented inline per standard convention
