### PR TITLE
Changed production config to log at info level

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :warn
+  config.log_level = :info
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
This change bumps up the logging level from warn to info so that we get the rails route information in the log files.