### PR TITLE
added release link to v1-21

### DIFF
--- a/db/schema.rb
+++ b/db/schema.rb
@@ -145,8 +145,8 @@ ActiveRecord::Schema.define(version: 20190626183858) do
     t.string "content_stage", default: "Draft"
     t.integer "duplicate_of"
     t.integer "minor_change_count", default: 0
-    t.datetime "curated_at"
     t.string "suggested_replacement_of"
+    t.datetime "curated_at"
     t.index ["category_id"], name: "index_questions_on_category_id"
     t.index ["created_by_id"], name: "index_questions_on_created_by_id"
     t.index ["response_type_id"], name: "index_questions_on_response_type_id"
@@ -173,8 +173,8 @@ ActiveRecord::Schema.define(version: 20190626183858) do
     t.string "content_stage", default: "Draft"
     t.integer "duplicate_of"
     t.integer "minor_change_count", default: 0
-    t.datetime "curated_at"
     t.string "suggested_replacement_of"
+    t.datetime "curated_at"
     t.index ["created_by_id"], name: "index_response_sets_on_created_by_id"
     t.index ["updated_by_id"], name: "index_response_sets_on_updated_by_id"
   end

--- a/webpack/containers/Help.js
+++ b/webpack/containers/Help.js
@@ -1202,7 +1202,7 @@ class Help extends Component {
           <br/>
           <h4 id="releasenotes"><strong>Release Notes</strong></h4>
             <ul>
-            <li id="1.21"><strong>Release <a href='' target='_blank'>1.21</a></strong> <small>(June 28, 2019)</small></li>
+            <li id="1.21"><strong>Release <a href='https://publichealthsurveillance.atlassian.net/wiki/spaces/SVS/pages/579338249/SDP+Vocabulary+Service+Release+1.21' target='_blank'>1.21</a></strong> <small>(June 28, 2019)</small></li>
               <ol>
               <li>Users can now preview response sets linked to questions on the dashboard by clicking the 'preview' button on the right side of the search result expansion.</li>
               <li>The metrics API and admin dashboard now report a count of the number of collaborative authoring groups.</li>


### PR DESCRIPTION
- [X] Passed all unit tests using `rails test` with 90%+ coverage
- [X] Passed overcommit hooks, including running all code through Rubocop
- [X] If any database changes were made, run `rake generate_erd` to update the README.md
